### PR TITLE
Improve P/Invoke documentation: type warnings, sample fix, troubleshooting

### DIFF
--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -438,11 +438,11 @@ internal unsafe struct SYSTEM_PROCESS_INFORMATION
 
 However, there are some gotchas with fixed buffers. Fixed buffers of non-blittable types won't be correctly marshalled, so the in-place array needs to be expanded out to multiple individual fields. Additionally, in .NET Framework and .NET Core before 3.0, if a struct containing a fixed buffer field is nested within a non-blittable struct, the fixed buffer field won't be correctly marshalled to native code.
 
-## Troubleshooting P/Invoke failures
+## Troubleshoot P/Invoke failures
 
 The following table maps common symptoms to their likely cause and recommended fix.
 
-| Symptom | Likely Cause | Fix |
+| Symptom | Likely cause | Fix |
 |---------|-------------|-----|
 | <xref:System.DllNotFoundException> | Library not found at runtime | Check library name, path, and platform. Use <xref:System.Runtime.InteropServices.NativeLibrary.TryLoad%2A> to test loading. On Linux, verify `LD_LIBRARY_PATH` or `rpath`. |
 | <xref:System.EntryPointNotFoundException> | Export name mismatch | Inspect native exports (`dumpbin /exports` on Windows, `nm -D` on Linux). Check for C++ name mangling (missing `extern "C"`). Set `EntryPoint` explicitly. |
@@ -451,7 +451,7 @@ The following table maps common symptoms to their likely cause and recommended f
 | Intermittent crashes | GC moved an unpinned object or collected a delegate | Root callback delegates for their full lifetime. Use `GCHandle` or `fixed` for pointers held across calls. |
 | Heap corruption on free | Wrong allocator | Match the allocator: never mix `malloc`/`free` with `CoTaskMemAlloc`/`CoTaskMemFree` or `Marshal.FreeHGlobal`. Use the library's own free function. |
 
-## Preventing delegate collection with `GC.KeepAlive`
+## Prevent delegate collection with `GC.KeepAlive`
 
 When you use <xref:System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate%2A> to convert a delegate to a function pointer, the garbage collector does **not** track the relationship between the returned pointer and the source delegate. If the delegate is eligible for collection before the native code finishes using the pointer, the application will crash.
 
@@ -471,6 +471,6 @@ GC.KeepAlive(callback); // Prevent collection — fnPtr does not root the delega
 
 If native code stores the function pointer beyond the call (for example, as a persistent callback), the delegate must be rooted for its entire lifetime — typically by storing it in a `static` field.
 
-## Resolving conflicts between documentation and native headers
+## Resolve conflicts between documentation and native headers
 
 When writing P/Invoke signatures, it's possible to encounter discrepancies between online API documentation and the actual native header files. Header files are the authoritative source for function signatures, struct layouts, type sizes, and calling conventions. When in doubt, verify your P/Invoke signatures against the header rather than relying solely on documentation.

--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -446,7 +446,7 @@ The following table maps common symptoms to their likely cause and recommended f
 |---------|-------------|-----|
 | <xref:System.DllNotFoundException> | Library not found at runtime | Check library name, path, and platform. Use <xref:System.Runtime.InteropServices.NativeLibrary.TryLoad%2A> to test loading. On Linux, verify `LD_LIBRARY_PATH` or `rpath`. |
 | <xref:System.EntryPointNotFoundException> | Export name mismatch | Inspect native exports (`dumpbin /exports` on Windows, `nm -D` on Linux). Check for C++ name mangling (missing `extern "C"`). Set `EntryPoint` explicitly. |
-| <xref:System.AccessViolationException> | Signature mismatch, use-after-free, or missing pinning | Compare managed and native signatures. Check struct sizes with `Marshal.SizeOf<T>()` vs native `sizeof`. Verify memory lifetime. |
+| <xref:System.AccessViolationException> | Signature mismatch, use-after-free, or missing pinning | Compare managed and native signatures. Check struct sizes with `Marshal.SizeOf<T>()` vs native `sizeof`. Verify memory lifetime. Use a blittable signature to troubleshoot marshalling issue  |
 | Silent data corruption | Wrong type size or encoding | Add boundary logging. Compare `Marshal.SizeOf<T>()` to native `sizeof`. Test with known input/output pairs. |
 | Intermittent crashes | GC moved an unpinned object or collected a delegate | Root callback delegates for their full lifetime. Use `GCHandle` or `fixed` for pointers held across calls. |
 | Heap corruption on free | Wrong allocator | Match the allocator: never mix `malloc`/`free` with `CoTaskMemAlloc`/`CoTaskMemFree` or `Marshal.FreeHGlobal`. Use the library's own free function. |

--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -437,3 +437,40 @@ internal unsafe struct SYSTEM_PROCESS_INFORMATION
 ```
 
 However, there are some gotchas with fixed buffers. Fixed buffers of non-blittable types won't be correctly marshalled, so the in-place array needs to be expanded out to multiple individual fields. Additionally, in .NET Framework and .NET Core before 3.0, if a struct containing a fixed buffer field is nested within a non-blittable struct, the fixed buffer field won't be correctly marshalled to native code.
+
+## Troubleshooting P/Invoke failures
+
+The following table maps common symptoms to their likely cause and recommended fix.
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| <xref:System.DllNotFoundException> | Library not found at runtime | Check library name, path, and platform. Use <xref:System.Runtime.InteropServices.NativeLibrary.TryLoad%2A> to test loading. On Linux, verify `LD_LIBRARY_PATH` or `rpath`. |
+| <xref:System.EntryPointNotFoundException> | Export name mismatch | Inspect native exports (`dumpbin /exports` on Windows, `nm -D` on Linux). Check for C++ name mangling (missing `extern "C"`). Set `EntryPoint` explicitly. |
+| <xref:System.AccessViolationException> | Signature mismatch, use-after-free, or missing pinning | Compare managed and native signatures. Check struct sizes with `Marshal.SizeOf<T>()` vs native `sizeof`. Verify memory lifetime. |
+| Silent data corruption | Wrong type size or encoding | Add boundary logging. Compare `Marshal.SizeOf<T>()` to native `sizeof`. Test with known input/output pairs. |
+| Intermittent crashes | GC moved an unpinned object or collected a delegate | Root callback delegates for their full lifetime. Use `GCHandle` or `fixed` for pointers held across calls. |
+| Heap corruption on free | Wrong allocator | Match the allocator: never mix `malloc`/`free` with `CoTaskMemAlloc`/`CoTaskMemFree` or `Marshal.FreeHGlobal`. Use the library's own free function. |
+
+## Preventing delegate collection with `GC.KeepAlive`
+
+When you use <xref:System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate%2A> to convert a delegate to a function pointer, the garbage collector does **not** track the relationship between the returned pointer and the source delegate. If the delegate is eligible for collection before the native code finishes using the pointer, the application will crash.
+
+Use <xref:System.GC.KeepAlive%2A> to prevent collection:
+
+```csharp
+var callback = new MyDelegate((level, msgPtr) =>
+{
+    string msg = Marshal.PtrToStringUTF8(msgPtr) ?? string.Empty;
+    Console.WriteLine($"[{level}] {msg}");
+});
+
+IntPtr fnPtr = Marshal.GetFunctionPointerForDelegate(callback);
+NativeUsesCallback(fnPtr);
+GC.KeepAlive(callback); // Prevent collection — fnPtr does not root the delegate
+```
+
+If native code stores the function pointer beyond the call (for example, as a persistent callback), the delegate must be rooted for its entire lifetime — typically by storing it in a `static` field.
+
+## Resolving conflicts between documentation and native headers
+
+When writing P/Invoke signatures, it's possible to encounter discrepancies between online API documentation and the actual native header files. Header files are the authoritative source for function signatures, struct layouts, type sizes, and calling conventions. When in doubt, verify your P/Invoke signatures against the header rather than relying solely on documentation.

--- a/docs/standard/native-interop/calling-conventions.md
+++ b/docs/standard/native-interop/calling-conventions.md
@@ -25,6 +25,13 @@ convention in P/Invoke declarations for interop with these libraries.
 
 For non-x86 architectures, both `Stdcall` and `Cdecl` calling conventions are treated as the canonical platform default calling convention.
 
+### When you can omit the calling convention
+
+On x64, ARM, and ARM64 architectures, there is only one calling convention, so specifying one explicitly is unnecessary. You only need to specify a calling convention when targeting **Windows x86 (32-bit)**, where `Stdcall` and `Cdecl` differ.
+
+- ✔️ DO specify the calling convention explicitly when targeting Windows x86.
+- ✔️ DO omit the calling convention on x64, ARM, and ARM64 — the attribute has no effect on these architectures.
+
 ## Specifying calling conventions in managed P/Invoke declarations
 
 The calling conventions are specified by types in the `System.Runtime.CompilerServices` namespace or their combinations:

--- a/docs/standard/native-interop/type-marshalling.md
+++ b/docs/standard/native-interop/type-marshalling.md
@@ -28,6 +28,12 @@ Generally, the runtime tries to do the "right thing" when marshalling to require
 
 This first table describes the mappings for types for which the marshalling is the same for both P/Invoke and field marshalling.
 
+> [!IMPORTANT]
+> C# `long` maps to `int64_t`, but C/C++ `long` is **not** `int64_t` on all platforms. C `long` is 32-bit on Windows and 64-bit on 64-bit Unix. When calling a C function that uses `long`, use <xref:System.Runtime.InteropServices.CLong> or <xref:System.Runtime.InteropServices.CULong> (.NET 6+) instead of C# `long`. See [Cross-platform data type considerations](best-practices.md#cross-platform-data-type-considerations) for details and workarounds for earlier .NET versions.
+
+> [!NOTE]
+> The `wchar_t` type is UTF-16 (2 bytes) on Windows but is compiler-defined on other platforms — typically UTF-32 (4 bytes) on Linux and macOS. When calling cross-platform C functions that use `char*`, use <xref:System.Runtime.InteropServices.StringMarshalling.Utf8?displayProperty=nameWithType> rather than <xref:System.Runtime.InteropServices.StringMarshalling.Utf16?displayProperty=nameWithType>.
+
 | C# keyword  | .NET Type        | Native Type             |
 |-------------|------------------|-------------------------|
 | `byte`      | `System.Byte`    | `uint8_t`               |

--- a/docs/standard/native-interop/type-marshalling.md
+++ b/docs/standard/native-interop/type-marshalling.md
@@ -29,7 +29,7 @@ Generally, the runtime tries to do the "right thing" when marshalling to require
 This first table describes the mappings for types for which the marshalling is the same for both P/Invoke and field marshalling.
 
 > [!IMPORTANT]
-> C# `long` maps to `int64_t`, but C/C++ `long` is **not** `int64_t` on all platforms. C `long` is 32-bit on Windows and 64-bit on 64-bit Unix. When calling a C function that uses `long`, use <xref:System.Runtime.InteropServices.CLong> or <xref:System.Runtime.InteropServices.CULong> (.NET 6+) instead of C# `long`. For details and workarounds for earlier .NET versions, see [Cross-platform data type considerations](best-practices.md#cross-platform-data-type-considerations).
+> When calling a C function that uses `long`, use <xref:System.Runtime.InteropServices.CLong> or <xref:System.Runtime.InteropServices.CULong> (.NET 6+) instead of C# `long`. For details and workarounds for earlier .NET versions, see [Cross-platform data type considerations](best-practices.md#cross-platform-data-type-considerations).
 
 > [!NOTE]
 > The `wchar_t` type is UTF-16 (2 bytes) on Windows but is compiler-defined on other platforms—typically UTF-32 (4 bytes) on Linux and macOS. Because of this, `wchar_t*` is hard to use as a single cross-platform ABI. When you design a cross-platform native API, prefer `char*` with a clearly defined encoding contract (for example, UTF-8) instead of `wchar_t*`.

--- a/docs/standard/native-interop/type-marshalling.md
+++ b/docs/standard/native-interop/type-marshalling.md
@@ -29,10 +29,13 @@ Generally, the runtime tries to do the "right thing" when marshalling to require
 This first table describes the mappings for types for which the marshalling is the same for both P/Invoke and field marshalling.
 
 > [!IMPORTANT]
-> C# `long` maps to `int64_t`, but C/C++ `long` is **not** `int64_t` on all platforms. C `long` is 32-bit on Windows and 64-bit on 64-bit Unix. When calling a C function that uses `long`, use <xref:System.Runtime.InteropServices.CLong> or <xref:System.Runtime.InteropServices.CULong> (.NET 6+) instead of C# `long`. See [Cross-platform data type considerations](best-practices.md#cross-platform-data-type-considerations) for details and workarounds for earlier .NET versions.
+> C# `long` maps to `int64_t`, but C/C++ `long` is **not** `int64_t` on all platforms. C `long` is 32-bit on Windows and 64-bit on 64-bit Unix. When calling a C function that uses `long`, use <xref:System.Runtime.InteropServices.CLong> or <xref:System.Runtime.InteropServices.CULong> (.NET 6+) instead of C# `long`. For details and workarounds for earlier .NET versions, see [Cross-platform data type considerations](best-practices.md#cross-platform-data-type-considerations).
 
 > [!NOTE]
-> The `wchar_t` type is UTF-16 (2 bytes) on Windows but is compiler-defined on other platforms — typically UTF-32 (4 bytes) on Linux and macOS. When calling cross-platform C functions that use `char*`, use <xref:System.Runtime.InteropServices.StringMarshalling.Utf8?displayProperty=nameWithType> rather than <xref:System.Runtime.InteropServices.StringMarshalling.Utf16?displayProperty=nameWithType>.
+> The `wchar_t` type is UTF-16 (2 bytes) on Windows but is compiler-defined on other platforms—typically UTF-32 (4 bytes) on Linux and macOS. Because of this, `wchar_t*` is hard to use as a single cross-platform ABI. When you design a cross-platform native API, prefer `char*` with a clearly defined encoding contract (for example, UTF-8) instead of `wchar_t*`.
+>
+> [!NOTE]
+> Native `char*` strings use the encoding that the library or platform defines. When you call a C function that takes `char*`, match that expected encoding by choosing the correct string marshalling option, such as <xref:System.Runtime.InteropServices.StringMarshalling.Utf8?displayProperty=nameWithType> for UTF-8, <xref:System.Runtime.InteropServices.StringMarshalling.Utf16?displayProperty=nameWithType> for UTF-16, or <xref:System.Runtime.InteropServices.StringMarshalling.Custom?displayProperty=nameWithType> for other encodings.
 
 | C# keyword  | .NET Type        | Native Type             |
 |-------------|------------------|-------------------------|

--- a/samples/snippets/standard/interop/pinvoke/ftw-linux.cs
+++ b/samples/snippets/standard/interop/pinvoke/ftw-linux.cs
@@ -9,7 +9,7 @@ namespace PInvokeSamples
         private delegate int DirClbk(string fName, ref Stat stat, int typeFlag);
 
         // Import the libc and define the method to represent the native function.
-        [LibraryImport("libc.so.6", StringMarshalling = StringMarshalling.Utf16)]
+        [LibraryImport("libc.so.6", StringMarshalling = StringMarshalling.Utf8)]
         private static partial int ftw(string dirpath, DirClbk cl, int descriptors);
 
         // Implement the above DirClbk delegate;

--- a/samples/snippets/standard/interop/pinvoke/ftw-macos.cs
+++ b/samples/snippets/standard/interop/pinvoke/ftw-macos.cs
@@ -9,7 +9,7 @@ namespace PInvokeSamples
         private delegate int DirClbk(string fName, ref Stat stat, int typeFlag);
 
         // Import the libc and define the method to represent the native function.
-        [LibraryImport("libSystem.dylib", StringMarshalling = StringMarshalling.Utf16)]
+        [LibraryImport("libSystem.dylib", StringMarshalling = StringMarshalling.Utf8)]
         private static partial int ftw(string dirpath, DirClbk cl, int descriptors);
 
         // Implement the above DirClbk delegate;


### PR DESCRIPTION
This PR makes several improvements to the native interop documentation:

**Type marshalling warnings** (`type-marshalling.md`)
- Added an Important note that C `long` is not the same as C# `long` (32-bit on Windows, 64-bit on Unix), cross-referencing the existing `CLong` guidance in best-practices.md. The type table maps C# `long` to `int64_t` which is correct, but developers working with C `long` can easily pick the wrong .NET type.
- Added a note that `wchar_t` is UTF-32 on non-Windows platforms, affecting string marshalling choices.

**Fix ftw samples** (`ftw-linux.cs`, `ftw-macos.cs`)
- Changed `StringMarshalling.Utf16` to `StringMarshalling.Utf8`. The C `ftw()` function takes `char*` parameters, which are UTF-8 on Linux/macOS. UTF-16 is incorrect here.

**Calling convention guidance** (`calling-conventions.md`)
- Added a "When you can omit the calling convention" subsection. The existing text explains that non-x86 architectures treat Stdcall and Cdecl identically, but doesn't give the actionable recommendation that developers can (and should) skip specifying a calling convention on x64/ARM/ARM64.

**Best practices additions** (`best-practices.md`)
- **Troubleshooting table:** Maps common symptoms (DllNotFoundException, AccessViolationException, intermittent crashes, etc.) to likely causes and fixes. No equivalent existed.
- **GC.KeepAlive for delegate-to-function-pointer:** `GetFunctionPointerForDelegate` does not root the source delegate. Added a concrete code example showing proper `GC.KeepAlive` usage.
- **Header trust note:** Advises that when documentation and native headers conflict, the header is the authoritative source for signatures.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/native-interop/best-practices.md](https://github.com/dotnet/docs/blob/e1fb668c97c454479ecd9b304a0822821b05260f/docs/standard/native-interop/best-practices.md) | [Native interoperability best practices](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/best-practices?branch=pr-en-us-51987) |
| [docs/standard/native-interop/calling-conventions.md](https://github.com/dotnet/docs/blob/e1fb668c97c454479ecd9b304a0822821b05260f/docs/standard/native-interop/calling-conventions.md) | [Unmanaged calling conventions](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/calling-conventions?branch=pr-en-us-51987) |
| [docs/standard/native-interop/type-marshalling.md](https://github.com/dotnet/docs/blob/e1fb668c97c454479ecd9b304a0822821b05260f/docs/standard/native-interop/type-marshalling.md) | [Type marshalling](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/type-marshalling?branch=pr-en-us-51987) |


<!-- PREVIEW-TABLE-END -->