### PR TITLE
Update copilot instructions for new pages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,6 @@ When assigned an issue or directly given a task in GitHub:
 
 ### New pages
 
-Include any newly created pages in the relevant toc.yml file. The exact location of this file might not be obvious, so you might need to search in which toc.yml file are files from the same directory referenced.
+Include any newly created pages in the relevant toc.yml file. The exact location of this file might not be obvious, so search for the toc.yml that already references pages from the same directory, then add the new page there.
 
-If the new page used to be a redirect (this most often happens when a previously undocumented error is documented), remove it from the .openpublishing.redirection.fundamentals.json file.
+If the new page used to be a redirect (this most often happens when a previously undocumented error is documented), remove its entry from the appropriate `.openpublishing.redirection.*.json` file (that is, from whichever redirection file currently contains that redirect).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,3 +95,9 @@ When assigned an issue or directly given a task in GitHub:
 4. If warnings exist:
    - Click "View Details" to open the build report
    - Resolve any build warnings you introduced
+
+### New pages
+
+Include any newly created pages in the relevant toc.yml file. The exact location of this file might not be obvious, so you might need to search in which toc.yml file are files from the same directory referenced.
+
+If the new page used to be a redirect (this most often happens when a previously undocumented error is documented), remove it from the .openpublishing.redirection.fundamentals.json file.


### PR DESCRIPTION
Added instructions for including new pages in toc.yml and handling redirects.

Copilot didn't make these changes in https://github.com/dotnet/docs/pull/51839, so I'm trying to prevent this from happening going forward. Though I don't have any experience writing copilot instructions, so I'm hoping this is the right way to do it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/copilot-instructions.md](https://github.com/dotnet/docs/blob/8e2c485e5ded15cc2c401d9f3f9a44e5d94bee7c/.github/copilot-instructions.md) | [.NET Documentation Guidelines](https://review.learn.microsoft.com/en-us/dotnet/.github/copilot-instructions?branch=pr-en-us-52006) |


<!-- PREVIEW-TABLE-END -->