### PR TITLE
Update archived DataCollector link

### DIFF
--- a/docs/core/testing/unit-testing-code-coverage.md
+++ b/docs/core/testing/unit-testing-code-coverage.md
@@ -1,7 +1,7 @@
 ---
 title: Use code coverage for unit testing
 description: Learn how to use the code coverage capabilities for .NET unit tests.
-ms.date: 10/22/2025
+ms.date: 03/04/2026
 ai-usage: ai-assisted
 ---
 
@@ -158,7 +158,7 @@ If the build is successful, you've created the three projects, appropriately ref
 
 There are two types of code coverage tools:
 
-- **DataCollectors:** DataCollectors monitor test execution and collect information about test runs. They report the collected information in various output formats, such as XML and JSON. For more information, see [your first DataCollector](https://github.com/Microsoft/vstest-docs/blob/main/docs/extensions/datacollector.md).
+- **DataCollectors:** DataCollectors monitor test execution and collect information about test runs. They report the collected information in various output formats, such as XML and JSON. For more information, see [your first DataCollector](https://github.com/microsoft/vstest/blob/main/docs/extensions/datacollector.md).
 - **Report generators:** Use data collected from test runs to generate reports, often as styled HTML.
 
 In this section, the focus is on data collector tools.

--- a/docs/core/testing/unit-testing-code-coverage.md
+++ b/docs/core/testing/unit-testing-code-coverage.md
@@ -1,7 +1,7 @@
 ---
 title: Use code coverage for unit testing
 description: Learn how to use the code coverage capabilities for .NET unit tests.
-ms.date: 03/04/2026
+ms.date: 10/22/2025
 ai-usage: ai-assisted
 ---
 
@@ -158,7 +158,7 @@ If the build is successful, you've created the three projects, appropriately ref
 
 There are two types of code coverage tools:
 
-- **DataCollectors:** DataCollectors monitor test execution and collect information about test runs. They report the collected information in various output formats, such as XML and JSON. For more information, see [your first DataCollector](https://github.com/microsoft/vstest/blob/main/docs/extensions/datacollector.md).
+- **DataCollectors:** DataCollectors monitor test execution and collect information about test runs. They report the collected information in various output formats, such as XML and JSON. For more information, see [your first DataCollector](https://github.com/Microsoft/vstest-docs/blob/main/docs/extensions/datacollector.md).
 - **Report generators:** Use data collected from test runs to generate reports, often as styled HTML.
 
 In this section, the focus is on data collector tools.


### PR DESCRIPTION
## Summary

The "Your first DataCollector" link in the code coverage article pointed to `Microsoft/vstest-docs`, a repository archived in 2022. Content was moved to the active `microsoft/vstest` repository.

## Change

- Updated link in `docs/core/testing/unit-testing-code-coverage.md` from:
  `https://github.com/Microsoft/vstest-docs/blob/main/docs/extensions/datacollector.md`
  to:
  `https://github.com/microsoft/vstest/blob/main/docs/extensions/datacollector.md`

Fixes #50715


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-code-coverage.md](https://github.com/dotnet/docs/blob/d2fff82ab7149f5897ac1bf3694c0e968c086d0c/docs/core/testing/unit-testing-code-coverage.md) | [Use code coverage for unit testing](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-code-coverage?branch=pr-en-us-52079) |

<!-- PREVIEW-TABLE-END -->