### PR TITLE
Add a note on repeated copies

### DIFF
--- a/docs/csharp/programming-guide/delegates/how-to-combine-delegates-multicast-delegates.md
+++ b/docs/csharp/programming-guide/delegates/how-to-combine-delegates-multicast-delegates.md
@@ -15,7 +15,7 @@ This example demonstrates how to create multicast delegates. A useful property o
 
 > [!NOTE]
 >
-> You can add the same delegate to a multicast delegate multiple times. When you call the multicast delegate, it invokes all the delegates in the list, including duplicates.
+> You can add the same delegate to a multicast delegate multiple times. When you call the multicast delegate, it invokes all the delegates in the list, including duplicates. When you remove a delegate from a multicast delegate, it removes the rightmost matching entry, so only one instance is removed if there are multiple copies.
 
 ## See also
 

--- a/docs/csharp/programming-guide/delegates/how-to-combine-delegates-multicast-delegates.md
+++ b/docs/csharp/programming-guide/delegates/how-to-combine-delegates-multicast-delegates.md
@@ -2,16 +2,20 @@
 title: "How to combine delegates (Multicast Delegates)"
 description: Learn how to combine delegates to create multicast delegates. See a code example and view more available resources.
 ms.topic: how-to
-ms.date: 12/20/2024
+ms.date: 03/05/2026
 helpviewer_keywords: 
   - "delegates [C#], combining"
   - "multicast delegates [C#]"
 ---
 # How to combine delegates (Multicast Delegates) (C# Programming Guide)
 
-This example demonstrates how to create multicast delegates. A useful property of [delegate](../../language-reference/builtin-types/reference-types.md) objects is that multiple objects can be assigned to one delegate instance by using the `+` operator. The multicast delegate contains a list of the assigned delegates. When the multicast delegate is called, it invokes the delegates in the list, in order. Only delegates of the same type can be combined. The `-` operator can be used to remove a component delegate from a multicast delegate.
+This example demonstrates how to create multicast delegates. A useful property of [delegate](../../language-reference/builtin-types/reference-types.md) objects is that you can assign multiple methods to one delegate instance by using the `+` operator. The multicast delegate contains a list of the assigned delegates. When you call the multicast delegate, it invokes the delegates in the list, in order. You can only combine delegates of the same type. You can use the `-` operator to remove a component delegate from a multicast delegate.
 
 :::code language="csharp" source="./snippets/MulticastExample.cs":::
+
+> [!NOTE]
+>
+> You can add the same delegate to a multicast delegate multiple times. When you call the multicast delegate, it invokes all the delegates in the list, including duplicates.
 
 ## See also
 


### PR DESCRIPTION
Fixes #51930

Add a note that a multicast delegate can include multiple copies of the same delegate.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/delegates/how-to-combine-delegates-multicast-delegates.md](https://github.com/dotnet/docs/blob/ab5396f32f756a2317fafe79cc651612ea627be7/docs/csharp/programming-guide/delegates/how-to-combine-delegates-multicast-delegates.md) | [How to combine delegates (Multicast Delegates) (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/delegates/how-to-combine-delegates-multicast-delegates?branch=pr-en-us-52099) |


<!-- PREVIEW-TABLE-END -->