### PR TITLE
Clarify MarshalMode naming convention and return value coverage

### DIFF
--- a/docs/standard/native-interop/custom-marshalling-source-generation.md
+++ b/docs/standard/native-interop/custom-marshalling-source-generation.md
@@ -38,7 +38,7 @@ The <xref:System.Runtime.InteropServices.Marshalling.MarshalMode> specified in a
 > The member names follow the pattern `{CallDirection}{DataFlow}`:
 >
 > - **Call direction** (`ManagedToUnmanaged` or `UnmanagedToManaged`) indicates which side initiates the call. `ManagedToUnmanaged` means managed code calling unmanaged code (P/Invoke). `UnmanagedToManaged` means unmanaged code calling managed code (Reverse P/Invoke, COM).
-> - **Data flow** (`In`, `Out`, or `Ref`) indicates how data moves relative to the call. `In` means data flows from the caller to the callee. `Out` means data flows from the callee back to the caller — this includes both `out` parameters and return values. `Ref` means data flows in both directions.
+> - **Data flow** (`In`, `Out`, or `Ref`) indicates how data moves relative to the call. `In` means data flows from the caller to the callee. `Out` means data flows from the callee back to the caller&mdash;this includes both `out` parameters and return values. `Ref` means data flows in both directions.
 >
 > For example, `ManagedToUnmanagedOut` is used for `out` parameters and return values when managed code calls unmanaged code. Even though the name starts with "ManagedToUnmanaged", the marshaller for this mode converts *from* the unmanaged representation *to* the managed representation, because the data flows back to the managed caller.
 

--- a/docs/standard/native-interop/custom-marshalling-source-generation.md
+++ b/docs/standard/native-interop/custom-marshalling-source-generation.md
@@ -22,17 +22,25 @@ The set of methods that the marshalling generator expects from a custom marshall
 
 The <xref:System.Runtime.InteropServices.Marshalling.MarshalMode> specified in a <xref:System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute> determines the expected marshalling support and shape for the marshaller implementation. All modes support stateless marshaller implementations. Element marshalling modes do not support stateful marshaller implementations.
 
-| `MarshalMode` | Expected support | Can be stateful |
-| --- | --- | --- |
-| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedIn> | Managed to unmanaged | Yes |
-| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedRef> | Managed to unmanaged and unmanaged to managed | Yes |
-| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedOut> | Unmanaged to managed | Yes |
-| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.UnmanagedToManagedIn> | Unmanaged to managed | Yes |
-| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.UnmanagedToManagedRef> | Managed to unmanaged and unmanaged to managed | Yes |
-| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.UnmanagedToManagedOut> | Managed to unmanaged | Yes |
-| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.ElementIn> | Managed to unmanaged | No |
-| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.ElementRef> | Managed to unmanaged and unmanaged to managed | No |
-| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.ElementOut> | Unmanaged to managed | No |
+| `MarshalMode` | Expected support | Applies to | Can be stateful |
+| --- | --- | --- | --- |
+| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedIn> | Managed to unmanaged | By-value and `in` parameters in P/Invoke | Yes |
+| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedRef> | Managed to unmanaged and unmanaged to managed | `ref` parameters in P/Invoke | Yes |
+| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedOut> | Unmanaged to managed | `out` parameters and **return values** in P/Invoke | Yes |
+| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.UnmanagedToManagedIn> | Unmanaged to managed | By-value and `in` parameters in Reverse P/Invoke | Yes |
+| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.UnmanagedToManagedRef> | Managed to unmanaged and unmanaged to managed | `ref` parameters in Reverse P/Invoke | Yes |
+| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.UnmanagedToManagedOut> | Managed to unmanaged | `out` parameters and **return values** in Reverse P/Invoke | Yes |
+| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.ElementIn> | Managed to unmanaged | Elements of collections passed with `in` or by-value | No |
+| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.ElementRef> | Managed to unmanaged and unmanaged to managed | Elements of collections passed with `ref` | No |
+| <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.ElementOut> | Unmanaged to managed | Elements of collections passed with `out` | No |
+
+> [!NOTE]
+> The member names follow the pattern `{CallDirection}{DataFlow}`:
+>
+> - **Call direction** (`ManagedToUnmanaged` or `UnmanagedToManaged`) indicates which side initiates the call. `ManagedToUnmanaged` means managed code calling unmanaged code (P/Invoke). `UnmanagedToManaged` means unmanaged code calling managed code (Reverse P/Invoke, COM).
+> - **Data flow** (`In`, `Out`, or `Ref`) indicates how data moves relative to the call. `In` means data flows from the caller to the callee. `Out` means data flows from the callee back to the caller — this includes both `out` parameters and return values. `Ref` means data flows in both directions.
+>
+> For example, `ManagedToUnmanagedOut` is used for `out` parameters and return values when managed code calls unmanaged code. Even though the name starts with "ManagedToUnmanaged", the marshaller for this mode converts *from* the unmanaged representation *to* the managed representation, because the data flows back to the managed caller.
 
 Use <xref:System.Runtime.InteropServices.Marshalling.MarshalMode.Default?displayProperty=nameWithType> to indicate that the marshaller implementation applies to any supported mode, based on the methods it implements. If you specify a marshaller for a more specific `MarshalMode`, that marshaller takes precedence over one marked as `Default`.
 


### PR DESCRIPTION
## Summary

Add an `Applies to` column to the `MarshalMode` table and a NOTE block explaining the `{CallDirection}{DataFlow}` naming convention. Explicitly call out that `Out` modes cover **return values**, not just `out` parameters.

## Motivation

Addresses [dotnet/runtime#124726](https://github.com/dotnet/runtime/issues/124726) — a community user was confused about which `MarshalMode` to use for a custom marshaller that only handles return values from P/Invoke calls. The naming convention (`ManagedToUnmanagedOut` means data flowing *out* of a managed-to-unmanaged call) is non-obvious and was not explained anywhere in the docs.

## Changes to `custom-marshalling-source-generation.md`

- **New `Applies to` column** in the `MarshalMode` table showing the specific parameter/return contexts for each mode
- **Return values bolded** in `ManagedToUnmanagedOut` and `UnmanagedToManagedOut` rows
- **New NOTE block** after the table explaining:
  - The `{CallDirection}{DataFlow}` naming convention
  - Why `ManagedToUnmanagedOut` converts *from* unmanaged *to* managed (data flows back to the managed caller)

Companion PR: https://github.com/dotnet/dotnet-api-docs/pull/12382

/cc @jkoritzinsky

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/native-interop/custom-marshalling-source-generation.md](https://github.com/dotnet/docs/blob/02372f20e5c61d5631234034a5fcc9d6f6bad1d0/docs/standard/native-interop/custom-marshalling-source-generation.md) | [Source generation for custom marshalling](https://review.learn.microsoft.com/en-us/dotnet/standard/native-interop/custom-marshalling-source-generation?branch=pr-en-us-52128) |


<!-- PREVIEW-TABLE-END -->