### PR TITLE
Fix DefaultAzureCredential snippet and tip placement

### DIFF
--- a/docs/azure/sdk/authentication/credential-chains.md
+++ b/docs/azure/sdk/authentication/credential-chains.md
@@ -68,10 +68,7 @@ The order in which `DefaultAzureCredential` attempts credentials follows.
 
 In its simplest form, you can use the parameterless version of `DefaultAzureCredential` as follows:
 
-:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_Dac" highlight="8":::
-
-> [!TIP]
-> The `UseCredential` method in the preceding code snippet is recommended for use in ASP.NET Core apps. For more information, see [Use the Azure SDK for .NET in ASP.NET Core apps](../aspnetcore-guidance.md#authenticate-using-microsoft-entra-id).
+:::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_Dac" highlight="1":::
 
 ### How to customize DefaultAzureCredential
 
@@ -82,6 +79,9 @@ The following sections describe strategies for controlling which credentials are
 To exclude an individual credential from `DefaultAzureCredential`, use the corresponding `Exclude`-prefixed property in [DefaultAzureCredentialOptions](/dotnet/api/azure.identity.defaultazurecredentialoptions?view=azure-dotnet&preserve-view=true#properties). For example:
 
 :::code language="csharp" source="../snippets/authentication/credential-chains/Program.cs" id="snippet_DacExcludes" highlight="11-13":::
+
+> [!TIP]
+> The `UseCredential` method in the preceding code snippet is recommended for use in ASP.NET Core apps. For more information, see [Use the Azure SDK for .NET in ASP.NET Core apps](../aspnetcore-guidance.md#authenticate-using-microsoft-entra-id).
 
 In the preceding code sample, `EnvironmentCredential`, `ManagedIdentityCredential`, and `WorkloadIdentityCredential` are removed from the credential chain. As a result, the first credential to be attempted is `VisualStudioCredential`. The modified chain contains only development-time credentials and looks like this:
 

--- a/docs/azure/sdk/snippets/authentication/credential-chains/Program.cs
+++ b/docs/azure/sdk/snippets/authentication/credential-chains/Program.cs
@@ -2,6 +2,7 @@
 using Azure.Core;
 using Azure.Core.Diagnostics;
 using Azure.Identity;
+using Azure.Storage.Blobs;
 using Microsoft.Extensions.Azure;
 
 string userAssignedClientId = "<user-assigned-client-id>";
@@ -19,12 +20,15 @@ using AzureEventSourceListener listener = new((args, message) =>
 }, EventLevel.LogAlways);
 #endregion snippet_FilteredLogging
 
+void UseDac()
+{
 #region snippet_Dac
 DefaultAzureCredential credential = new();
 BlobServiceClient client = new(
     new Uri($"https://{storageAccountName}.blob.core.windows.net"),
     credential);
 #endregion snippet_Dac
+}
 
 #region snippet_DacExcludes
 builder.Services.AddAzureClients(clientBuilder =>

--- a/docs/azure/sdk/snippets/authentication/credential-chains/Program.cs
+++ b/docs/azure/sdk/snippets/authentication/credential-chains/Program.cs
@@ -20,13 +20,10 @@ using AzureEventSourceListener listener = new((args, message) =>
 #endregion snippet_FilteredLogging
 
 #region snippet_Dac
-builder.Services.AddAzureClients(clientBuilder =>
-{
-    clientBuilder.AddSecretClient(
-        new Uri($"https://{keyVaultName}.vault.azure.net"));
-    clientBuilder.AddBlobServiceClient(
-        new Uri($"https://{storageAccountName}.blob.core.windows.net"));
-});
+DefaultAzureCredential credential = new();
+BlobServiceClient client = new(
+    new Uri($"https://{storageAccountName}.blob.core.windows.net"),
+    credential);
 #endregion snippet_Dac
 
 #region snippet_DacExcludes


### PR DESCRIPTION
- Replace ASP.NET Core-specific UseCredential snippet with a simpler DefaultAzureCredential example using BlobServiceClient
- Move the UseCredential tip to follow the DacExcludes snippet where it's more contextually appropriate
- Update highlight line number accordingly


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/sdk/authentication/credential-chains.md](https://github.com/dotnet/docs/blob/e6c37b56904ec741a68e42f6faf48ffbb2e77162/docs/azure/sdk/authentication/credential-chains.md) | [docs/azure/sdk/authentication/credential-chains](https://review.learn.microsoft.com/en-us/dotnet/azure/sdk/authentication/credential-chains?branch=pr-en-us-52266) |


<!-- PREVIEW-TABLE-END -->