### PR TITLE
Add static virtual method example to static interface members tutorial

### DIFF
--- a/docs/csharp/advanced-topics/interface-implementation/snippets/staticinterfaces/Describable.cs
+++ b/docs/csharp/advanced-topics/interface-implementation/snippets/staticinterfaces/Describable.cs
@@ -1,0 +1,7 @@
+// <Describable>
+public interface IDescribable<T> where T : IDescribable<T>
+{
+    static abstract string TypeName { get; }
+    static virtual string Describe() => T.TypeName;
+}
+// </Describable>

--- a/docs/csharp/advanced-topics/interface-implementation/snippets/staticinterfaces/Gadget.cs
+++ b/docs/csharp/advanced-topics/interface-implementation/snippets/staticinterfaces/Gadget.cs
@@ -1,0 +1,9 @@
+// <Gadget>
+public struct Gadget : IDescribable<Gadget>
+{
+    public static string TypeName => "Gadget";
+
+    // Overrides the default Describe() with a custom message
+    public static string Describe() => $"{TypeName} (version 2.0)";
+}
+// </Gadget>

--- a/docs/csharp/advanced-topics/interface-implementation/snippets/staticinterfaces/Program.cs
+++ b/docs/csharp/advanced-topics/interface-implementation/snippets/staticinterfaces/Program.cs
@@ -7,6 +7,16 @@ for (int i = 0; i < 10; i++)
     Console.WriteLine(str++);
 // </TestRepeat>
 
+// <TestDescribe>
+static void PrintDescription<T>() where T : IDescribable<T>
+{
+    Console.WriteLine(T.Describe());
+}
+
+PrintDescription<Widget>();
+PrintDescription<Gadget>();
+// </TestDescribe>
+
 // <TestAddition>
 var pt = new Point<int>(3, 4);
 

--- a/docs/csharp/advanced-topics/interface-implementation/snippets/staticinterfaces/Widget.cs
+++ b/docs/csharp/advanced-topics/interface-implementation/snippets/staticinterfaces/Widget.cs
@@ -1,0 +1,8 @@
+// <Widget>
+public struct Widget : IDescribable<Widget>
+{
+    public static string TypeName => "Widget";
+
+    // Uses the default Describe(): returns "Widget"
+}
+// </Widget>

--- a/docs/csharp/advanced-topics/interface-implementation/static-virtual-interface-members.md
+++ b/docs/csharp/advanced-topics/interface-implementation/static-virtual-interface-members.md
@@ -12,8 +12,9 @@ In this tutorial, you learn how to:
 
 > [!div class="checklist"]
 >
-> * Define interfaces with static members.
+> * Define interfaces with static abstract and static virtual members.
 > * Use interfaces to define classes that implement interfaces with operators defined.
+> * Provide default implementations with static virtual methods.
 > * Create generic algorithms that rely on static interface methods.
 
 ## Prerequisites
@@ -65,6 +66,37 @@ AAAAAAAAAA
 ```
 
 This small example demonstrates the motivation for this feature. You can use natural syntax for operators, constant values, and other static operations. You can explore these techniques when you create multiple types that rely on static members, including overloaded operators. Define the interfaces that match your types' capabilities and then declare those types' support for the new interface.
+
+## Static virtual interface methods
+
+The previous example used `static abstract` to declare the `++` operator: every implementing type *must* provide its own implementation. You can also declare `static virtual` members that provide a default implementation. Implementing types can use the default or override it. This distinction is useful when there's a reasonable default that works for most types, but some types need specialized behavior.
+
+The following example defines an `IDescribable<T>` interface with a `static abstract` property, `TypeName`, and a `static virtual` method, `Describe()`. The `TypeName` property is abstract because each type must supply its own name. The `Describe()` method is virtual because the default—returning the type name—is sensible for most types:
+
+:::code language="csharp" source="./snippets/staticinterfaces/Describable.cs" id="Describable":::
+
+A type that implements `IDescribable<T>` must provide `TypeName`. It can choose whether to override `Describe()`. The `Widget` type relies on the default:
+
+:::code language="csharp" source="./snippets/staticinterfaces/Widget.cs" id="Widget":::
+
+The `Gadget` type overrides `Describe()` to include additional detail:
+
+:::code language="csharp" source="./snippets/staticinterfaces/Gadget.cs" id="Gadget":::
+
+You call `static virtual` members through the type parameter in a generic method, just like `static abstract` members:
+
+:::code language="csharp" source="./snippets/staticinterfaces/Program.cs" id="TestDescribe":::
+
+The preceding example produces the following output:
+
+```powershell
+Widget
+Gadget (version 2.0)
+```
+
+`Widget` uses the default implementation of `Describe()`, which returns `TypeName`. `Gadget` overrides `Describe()` with its own version. The compiler resolves the correct implementation at compile time based on the type argument.
+
+In summary, use `static abstract` when every implementing type must provide its own implementation. Use `static virtual` when you can provide a useful default that most types will accept.
 
 ## Generic math
 

--- a/docs/csharp/advanced-topics/interface-implementation/static-virtual-interface-members.md
+++ b/docs/csharp/advanced-topics/interface-implementation/static-virtual-interface-members.md
@@ -71,7 +71,7 @@ This small example demonstrates the motivation for this feature. You can use nat
 
 The previous example used `static abstract` to declare the `++` operator: every implementing type *must* provide its own implementation. You can also declare `static virtual` members that provide a default implementation. Implementing types can use the default or override it. This distinction is useful when there's a reasonable default that works for most types, but some types need specialized behavior.
 
-The following example defines an `IDescribable<T>` interface with a `static abstract` property, `TypeName`, and a `static virtual` method, `Describe()`. The `TypeName` property is abstract because each type must supply its own name. The `Describe()` method is virtual because the default—returning the type name—is sensible for most types:
+The following example defines an `IDescribable<T>` interface with a `static abstract` property, `TypeName`, and a `static virtual` method, `Describe()`. The `TypeName` property is abstract because each type must supply its own name. The `Describe()` method is virtual because returning the type name is a sensisble default for most types:
 
 :::code language="csharp" source="./snippets/staticinterfaces/Describable.cs" id="Describable":::
 
@@ -94,9 +94,7 @@ Widget
 Gadget (version 2.0)
 ```
 
-`Widget` uses the default implementation of `Describe()`, which returns `TypeName`. `Gadget` overrides `Describe()` with its own version. The compiler resolves the correct implementation at compile time based on the type argument.
-
-In summary, use `static abstract` when every implementing type must provide its own implementation. Use `static virtual` when you can provide a useful default that most types will accept.
+`Widget` uses the default implementation of `Describe()`, which returns `TypeName`. `Gadget` overrides `Describe()` with its own version. The compiler resolves the correct implementation at compile time based on the type argument. In summary, use `static abstract` when every implementing type must provide its own implementation. Use `static virtual` when you can provide a useful default that most types will accept.
 
 ## Generic math
 


### PR DESCRIPTION
## Summary

- Adds a "Static virtual interface methods" section to the [static virtual members tutorial](https://learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/interface-implementation/static-virtual-interface-members), between the existing `static abstract` section and the Generic math section
- Introduces `IDescribable<T>` with `static abstract TypeName` and `static virtual Describe()` to directly contrast the two modifiers
- `Widget` uses the default `Describe()`; `Gadget` overrides it — showing when and why you'd choose `virtual` over `abstract`
- All code compiles and runs on .NET 10 with no preview features required
- Updates the tutorial's learning objectives checklist

The previous attempt at this (PR #43130) went stale after review feedback about the `field` keyword and interface access patterns. This PR uses a simpler example that avoids preview features entirely.

Fixes #41668

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/advanced-topics/interface-implementation/static-virtual-interface-members.md](https://github.com/dotnet/docs/blob/92e93958bd975077e34379e11742b62d698c63ed/docs/csharp/advanced-topics/interface-implementation/static-virtual-interface-members.md) | [Tutorial: Explore static virtual members in interfaces](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/interface-implementation/static-virtual-interface-members?branch=pr-en-us-52293) |


<!-- PREVIEW-TABLE-END -->