### PR TITLE
Document kernel-level response buffering in Windows HttpListener

### DIFF
--- a/docs/fundamentals/runtime-libraries/system-net-httplistener.md
+++ b/docs/fundamentals/runtime-libraries/system-net-httplistener.md
@@ -44,3 +44,9 @@ An <xref:System.Net.HttpListener> can require client authentication. You can eit
 The <xref:System.Net.HttpListener> class is built on top of `HTTP.sys`, which is the kernel mode listener that handles all HTTP traffic for Windows.
 `HTTP.sys` provides connection management, bandwidth throttling, and web server logging.
 Use the [HttpCfg.exe](/windows/win32/http/httpcfg-exe) tool to add SSL certificates.
+
+Starting in .NET 11, the Windows `HTTP.sys` implementation of <xref:System.Net.HttpListener> supports enabling kernel-level response buffering. When enabled, response data is buffered by `HTTP.sys` before being sent to the client, which can improve throughput for high-latency connections. This can be enabled by calling the <xref:System.AppContext.SetSwitch%2A?displayProperty=nameWithType> method as follows:
+
+   ```csharp
+   AppContext.SetSwitch("System.Net.HttpListener.EnableKernelResponseBuffering", true);
+   ```


### PR DESCRIPTION

## Summary

Added information about kernel-level response buffering support in Windows HttpListener starting from .NET 11.

Documenting [fix](https://github.com/dotnet/runtime/pull/124720) for [issue 123425](https://github.com/dotnet/runtime/issues/123425).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/runtime-libraries/system-net-httplistener.md](https://github.com/dotnet/docs/blob/2eea1424f13c6de196cdc1c563c792a2d93a94ca/docs/fundamentals/runtime-libraries/system-net-httplistener.md) | [System.Net.HttpListener class](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-net-httplistener?branch=pr-en-us-52304) |

<!-- PREVIEW-TABLE-END -->