### PR TITLE
Fix incorrect URL (#50689)

### DIFF
--- a/docs/azure/sdk/authentication/index.md
+++ b/docs/azure/sdk/authentication/index.md
@@ -88,4 +88,4 @@ A service principal is created in a Microsoft Entra tenant to represent an app a
 For apps hosted on-premises, you can use a service principal to authenticate to Azure resources. This involves creating a service principal in Microsoft Entra ID, assigning it the necessary permissions, and configuring your app to use its credentials. This method allows your on-premises app to securely access Azure services.
 
 > [!div class="nextstepaction"]
-> [Authenticate your on-prem app using a service principal](local-development-service-principal.md)
+> [Authenticate your on-prem app using a service principal](on-premises-apps.md)


### PR DESCRIPTION
## Summary

Link for "Authenticate your on-prem app using a service principal" was pointing to incorrect file. It was replaced with the correct file.

Fixes #Issue_50689 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/azure/sdk/authentication/index.md](https://github.com/dotnet/docs/blob/4e1b6cdce577ce498c58b2bf9db1495abe14555f/docs/azure/sdk/authentication/index.md) | [Authenticate .NET apps to Azure services using the Azure Identity library](https://review.learn.microsoft.com/en-us/dotnet/azure/sdk/authentication/index?branch=pr-en-us-52310) |

<!-- PREVIEW-TABLE-END -->