### PR TITLE
Fix incorrect use of "affect" -> "effect" in changing-namespace-declarations-in-an-xml-document.md

### DIFF
--- a/docs/standard/data/xml/changing-namespace-declarations-in-an-xml-document.md
+++ b/docs/standard/data/xml/changing-namespace-declarations-in-an-xml-document.md
@@ -9,7 +9,7 @@ ms.assetid: a2758f40-e497-4964-8d8d-1bb68af14dcd
 ---
 # Changing Namespace Declarations in an XML Document
 
-The **XmlDocument** exposes namespace declarations and **xmlns** attributes as part of the document object model. These are stored in the **XmlDocument**, so when you save the document, it can preserve the location of those attributes. Changing these attributes has no affect on the **Name**, **NamespaceURI**, and **Prefix** properties of other nodes already in the tree. For example, if you load the following document, then the `test` element has **NamespaceURI** `123.`  
+The **XmlDocument** exposes namespace declarations and **xmlns** attributes as part of the document object model. These are stored in the **XmlDocument**, so when you save the document, it can preserve the location of those attributes. Changing these attributes has no effect on the **Name**, **NamespaceURI**, and **Prefix** properties of other nodes already in the tree. For example, if you load the following document, then the `test` element has **NamespaceURI** `123.`  
   
 ```xml  
 <test xmlns="123"/>  
@@ -35,7 +35,7 @@ doc.documentElement.SetAttribute("xmlns","456")
 doc.documentElement.SetAttribute("xmlns","456");  
 ```  
   
- Therefore, changing `xmlns` attributes will have no affect until you save and reload the **XmlDocument** object.  
+ Therefore, changing `xmlns` attributes will have no effect until you save and reload the **XmlDocument** object.  
   
 ## See also
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/standard/data/xml/changing-namespace-declarations-in-an-xml-document

## Summary

The word "affect" (verb) was used where "effect" (noun) is correct.

(The noun form of "affect" is also incorrect here)

Fixed both occurrences in this document.

No other changes made.

CLA previously signed.

Ready to go.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/data/xml/changing-namespace-declarations-in-an-xml-document.md](https://github.com/dotnet/docs/blob/f5a0c743cbb5c3972b73ca94b9c5f934591539fb/docs/standard/data/xml/changing-namespace-declarations-in-an-xml-document.md) | [Changing Namespace Declarations in an XML Document](https://review.learn.microsoft.com/en-us/dotnet/standard/data/xml/changing-namespace-declarations-in-an-xml-document?branch=pr-en-us-52312) |

<!-- PREVIEW-TABLE-END -->