### PR TITLE
Update System.Reflection.Metadata and System.Reflection.PortableExecutable.PEReader references

### DIFF
--- a/docs/core/diagnostics/symbols.md
+++ b/docs/core/diagnostics/symbols.md
@@ -1,7 +1,8 @@
 ---
 title: Symbols in .NET
 description: An introduction to symbols and portable PDBs in .NET
-ms.date: 02/08/2021
+ms.date: 03/12/2026
+ai-usage: ai-assisted
 ---
 
 # Symbols
@@ -19,6 +20,9 @@ The [Windows documentation on symbols](/windows/win32/dxtecharts/debugging-with-
 A PDB file is an auxiliary file produced by a compiler to provide other tools, especially debuggers, information about what is in the main executable file and how it was produced. For example, a debugger reads a PDB to map foo.cs line 12 to the right executable location so that it can set a breakpoint. The Windows PDB format has been around a long time, and it evolved from other native debugging symbol formats which were even older. It started out its life as a format for native (C/C++) programs. For the first release of the .NET Framework, the Windows PDB format was extended to support .NET.
 
 The Portable PDB format was introduced in .NET Core, and it's used by default when targeting .NET. When targeting .NET Framework, you can enable portable PDB symbols by specifying `<DebugType>portable</DebugType>` in your project file. The portable PDB format is based on ECMA-335 metadata format. For more information, see [Portable PDB v1.0: Format Specification](https://github.com/dotnet/runtime/blob/main/docs/design/specs/PortablePdb-Metadata.md). Diagnostic tools can use the <xref:System.Reflection.Metadata> library to read portable PDB files (for an example, see <xref:System.Reflection.Metadata.Document?displayProperty=nameWithType>).
+
+> [!CAUTION]
+> The <xref:System.Reflection.Metadata> library is not designed to handle untrusted input. Malformed or malicious PDB files can cause unexpected behavior, including out-of-bounds memory access, crashes, or hangs. Only use this API with trusted files.
 
 ## Use the correct PDB format for your scenario
 

--- a/docs/standard/assembly/file-format.md
+++ b/docs/standard/assembly/file-format.md
@@ -2,7 +2,8 @@
 title: .NET assembly file format
 description: Learn about the .NET assembly file format, which is used to describe and contain .NET apps and libraries.
 author: richlander
-ms.date: 08/20/2019
+ms.date: 03/12/2026
+ai-usage: ai-assisted
 ms.assetid: 6520323e-ff28-4c8a-ba80-e64a413199e6
 ---
 
@@ -29,3 +30,6 @@ Assembly Headers from ECMA 335 II.25.1, Structure of the runtime file format.
 ## Process the assemblies
 
 It is possible to write tools or APIs to process assemblies. Assembly information enables making programmatic decisions at runtime, rewriting assemblies, providing API IntelliSense in an editor, and generating documentation. <xref:System.Reflection?displayProperty=nameWithType>, <xref:System.Reflection.MetadataLoadContext?displayProperty=nameWithType>, and [Mono.Cecil](https://www.mono-project.com/docs/tools+libraries/libraries/Mono.Cecil/) are good examples of tools that are frequently used for this purpose.
+
+> [!CAUTION]
+> The <xref:System.Reflection.Metadata> library and <xref:System.Reflection.PortableExecutable.PEReader> are not designed to handle untrusted input. Malformed or malicious PE files can cause unexpected behavior, including out-of-bounds memory access, crashes, or hangs. Only use these APIs with trusted assemblies.

--- a/docs/standard/assembly/identify.md
+++ b/docs/standard/assembly/identify.md
@@ -1,8 +1,9 @@
 ---
 title: "How to: Determine if a file is an assembly"
 description: This article shows you how determine whether a file is a .NET assembly, both manually and programmatically.
-ms.date: 07/24/2021
+ms.date: 03/12/2026
 ms.topic: how-to
+ai-usage: ai-assisted
 dev_langs:
   - "csharp"
   - "vb"
@@ -35,6 +36,9 @@ This example tests a DLL to see if it is an assembly.
 The <xref:System.Reflection.AssemblyName.GetAssemblyName%2A> method loads the test file, and then releases it once the information is read.
 
 ### Using the PEReader class
+
+> [!CAUTION]
+> <xref:System.Reflection.PortableExecutable.PEReader> and the <xref:System.Reflection.Metadata> library are not designed to handle untrusted input. Malformed or malicious PE files can cause unexpected behavior, including out-of-bounds memory access, crashes, or hangs. Only use these APIs with trusted assemblies.
 
 1. If you're targeting .NET Standard or .NET Framework, install the [System.Reflection.Metadata](https://www.nuget.org/packages/System.Reflection.Metadata/) NuGet package. (When targeting .NET Core or .NET 5+, this step isn't required because this library is included in the shared framework.)
 


### PR DESCRIPTION
Adds a note stating that System.Reflection.Metadata and System.Reflection.PortableExecutable.PEReader do not support untrusted input

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/symbols.md](https://github.com/dotnet/docs/blob/2819e99b74ba4a9b4a6c4adfac03b9f833369053/docs/core/diagnostics/symbols.md) | [Symbols](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/symbols?branch=pr-en-us-52329) |
| [docs/standard/assembly/file-format.md](https://github.com/dotnet/docs/blob/2819e99b74ba4a9b4a6c4adfac03b9f833369053/docs/standard/assembly/file-format.md) | [.NET assembly file format](https://review.learn.microsoft.com/en-us/dotnet/standard/assembly/file-format?branch=pr-en-us-52329) |
| [docs/standard/assembly/identify.md](https://github.com/dotnet/docs/blob/2819e99b74ba4a9b4a6c4adfac03b9f833369053/docs/standard/assembly/identify.md) | ["How to: Determine if a file is an assembly"](https://review.learn.microsoft.com/en-us/dotnet/standard/assembly/identify?branch=pr-en-us-52329) |

<!-- PREVIEW-TABLE-END -->