### PR TITLE
Document RequestContext access in placement and placement filtering

### DIFF
--- a/docs/orleans/grains/request-context.md
+++ b/docs/orleans/grains/request-context.md
@@ -114,3 +114,28 @@ Console.WriteLine(message);
 ```
 
 In this example, the client sets the trace ID to "example-id-set-by-client" before calling the `SayHello` method on the `HelloGrain`. The grain retrieves the trace ID from the request context and logs it.
+
+## Example placement access code
+
+The <xref:Orleans.Runtime.RequestContext> data can be accessed during Placement or Placement Filtering through the <xref:Orleans.Runtime.Placement.PlacementTarget> `RequestContextData`. The static <xref:Orleans.Runtime.RequestContext> is not populated at this time as there is not yet an activation of the grain.  The following placement filter code demonstrates how to get <xref:Orleans.Runtime.RequestContext> data while handling placement:
+
+```csharp
+internal sealed class ExamplePlacementFilterDirector(ILogger<ExamplePlacementFilterDirector> logger)
+    : IPlacementFilterDirector
+{
+    public IEnumerable<SiloAddress> Filter(
+        PlacementFilterStrategy filterStrategy,
+        PlacementTarget target,
+        IEnumerable<SiloAddress> silos)
+    {
+        if (target.RequestContextData.TryGetValue("somekey", out var somevalue) 
+            && somevalue is string somestring)
+        {
+            logger.LogInformation("Read {Value} for {Key} from the RequestContext", somestring, "somekey");
+            // somestring is available for the filtering logic
+        }
+        return silos;
+    }
+}
+```
+In this example, the "somekey" value is read from the <xref:Orleans.Runtime.Placement.PlacementTarget> `RequestContextData` during the placement filtering.

--- a/docs/orleans/grains/request-context.md
+++ b/docs/orleans/grains/request-context.md
@@ -117,7 +117,7 @@ In this example, the client sets the trace ID to "example-id-set-by-client" befo
 
 ## Example placement access code
 
-The <xref:Orleans.Runtime.RequestContext> data can be accessed during Placement or Placement Filtering through the <xref:Orleans.Runtime.Placement.PlacementTarget> `RequestContextData`. The static <xref:Orleans.Runtime.RequestContext> is not populated at this time as there is not yet an activation of the grain.  The following placement filter code demonstrates how to get <xref:Orleans.Runtime.RequestContext> data while handling placement:
+The <xref:Orleans.Runtime.RequestContext> data can be accessed during placement or placement filtering through the <xref:Orleans.Runtime.Placement.PlacementTarget> `RequestContextData`. The static <xref:Orleans.Runtime.RequestContext> is not populated at this time as there is not yet an activation of the grain. The following placement filter code demonstrates how to get <xref:Orleans.Runtime.RequestContext> data while handling placement:
 
 ```csharp
 internal sealed class ExamplePlacementFilterDirector(ILogger<ExamplePlacementFilterDirector> logger)

--- a/docs/orleans/grains/request-context.md
+++ b/docs/orleans/grains/request-context.md
@@ -138,4 +138,5 @@ internal sealed class ExamplePlacementFilterDirector(ILogger<ExamplePlacementFil
     }
 }
 ```
+
 In this example, the "somekey" value is read from the <xref:Orleans.Runtime.Placement.PlacementTarget> `RequestContextData` during the placement filtering.


### PR DESCRIPTION
Added example code for accessing RequestContext data during placement filtering.

## Summary

Example of accessing RequestContext from outside of a grain activation during placement or placement filtering.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/request-context.md](https://github.com/dotnet/docs/blob/05898b460327fd5815bca39686a2b7aef04de381/docs/orleans/grains/request-context.md) | [Request context](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/request-context?branch=pr-en-us-52473) |


<!-- PREVIEW-TABLE-END -->