### PR TITLE
Assign breaking-change issues to gewarren

### DIFF
--- a/.github/policies/label-issues.yml
+++ b/.github/policies/label-issues.yml
@@ -24,6 +24,22 @@ configuration:
                         label: okr-quality
 
         eventResponderTasks:
+
+            - description: >-
+                Assign issues labeled breaking-change to gewarren
+              if:
+                - payloadType: Issues
+                - or:                
+                  - and:
+                    - isAction: 
+                        action: Opened
+                    - hasLabel: 
+                        label: 'breaking-change'                      
+                  - labelAdded:
+                      label: 'breaking-change'
+              then:
+                - assignTo: 'gewarren'
+        
             - description: >-
                 Add "not triaged" label when:
                 * Issue is opened

--- a/.github/policies/label-issues.yml
+++ b/.github/policies/label-issues.yml
@@ -38,7 +38,7 @@ configuration:
                   - labelAdded:
                       label: 'breaking-change'
               then:
-                - assignTo: 'gewarren'
+                - assignTo: gewarren
         
             - description: >-
                 Add "not triaged" label when:

--- a/.github/policies/label-issues.yml
+++ b/.github/policies/label-issues.yml
@@ -29,16 +29,17 @@ configuration:
                 Assign issues labeled breaking-change to gewarren
               if:
                 - payloadType: Issues
-                - or:                
+                - or:
                   - and:
-                    - isAction: 
+                    - isAction:
                         action: Opened
-                    - hasLabel: 
-                        label: 'breaking-change'                      
+                    - hasLabel:
+                        label: 'breaking-change'
                   - labelAdded:
                       label: 'breaking-change'
               then:
-                - assignTo: gewarren
+                - assignTo:
+                    user: gewarren
         
             - description: >-
                 Add "not triaged" label when:
@@ -47,12 +48,12 @@ configuration:
                 * 'needs-more-info' label removed
               if:
                 - payloadType: Issues
-                - or:                
+                - or:
                   - or:
-                    - isAction: 
+                    - isAction:
                         action: Opened
-                    - isAction: 
-                        action: Reopened                        
+                    - isAction:
+                        action: Reopened
                   - labelRemoved:
                       label: 'needs-more-info'
               then:
@@ -68,11 +69,11 @@ configuration:
                     label: ':watch: Not Triaged'
                 - or:
                   - and:
-                    - isAction: 
+                    - isAction:
                         action: Closed
                     - isActivitySender:
-                        issueAuthor: true                  
-                  - labelAdded: 
+                        issueAuthor: true
+                  - labelAdded:
                       label: ':world_map: reQUEST'
               then:
                 - removeLabel: ':watch: Not Triaged'


### PR DESCRIPTION
Lately, some breaking change issues have been opened through means other than the dedicated template, which means they aren't automatically assigned to me, and I've been missing them.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/policies/label-issues.yml](https://github.com/dotnet/docs/blob/4a5b9f5cb3017871b008dc16acc48fd8d78f0134/.github/policies/label-issues.yml) | [.github/policies/label-issues](https://review.learn.microsoft.com/en-us/dotnet/.github/policies/label-issues?branch=pr-en-us-52474) |


<!-- PREVIEW-TABLE-END -->