### PR TITLE
Update command for adding project reference

### DIFF
--- a/docs/core/testing/unit-testing-csharp-with-mstest.md
+++ b/docs/core/testing/unit-testing-csharp-with-mstest.md
@@ -75,7 +75,7 @@ The test project requires other packages to create and run unit tests. `dotnet n
 Add the `PrimeService` class library as another dependency to the project. Use the [`dotnet reference add`](../tools/dotnet-reference-add.md) command:
 
 ```dotnetcli
-dotnet reference add ../PrimeService/PrimeService.csproj
+dotnet add reference ../PrimeService/PrimeService.csproj
 ```
 
 You can see the entire file in the [samples repository](https://github.com/dotnet/samples/blob/main/core/getting-started/unit-testing-using-mstest/PrimeService.Tests/PrimeService.Tests.csproj) on GitHub.


### PR DESCRIPTION
~The old "reference add" doesn't work in the current version. Switching it to "add reference" fixes the issue.~

`dotnet reference add` is the current way, and `dotnet add reference` is the old way, yet only the old way works for me, mysteriously. See below.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-csharp-with-mstest.md](https://github.com/dotnet/docs/blob/7214bfe87548a2fc24c04507386f74b0d3edc9e9/docs/core/testing/unit-testing-csharp-with-mstest.md) | [Get started with C# and MSTest](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-csharp-with-mstest?branch=pr-en-us-52478) |

<!-- PREVIEW-TABLE-END -->