### PR TITLE
Remove dependencies that are already installed in alpine base images

### DIFF
--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -75,10 +75,6 @@ When you install with a package manager, these libraries are installed for you. 
 
 ### 3.20+
 
-- ca-certificates
-- libgcc
-- libssl3
-- libstdc++
 - zlib (.NET 8 only)
 - icu-libs and icu-data-full (unless the .NET app is running in [globalization-invariant mode](../runtime-config/globalization.md#invariant-mode))
 - tzdata

--- a/docs/core/install/linux-alpine.md
+++ b/docs/core/install/linux-alpine.md
@@ -3,7 +3,7 @@ title: Install .NET on Alpine
 description: Learn about which versions of .NET SDK and .NET Runtime are supported, and how to install .NET on Alpine.
 author: adegeo
 ms.author: adegeo
-ms.date: 12/11/2025
+ms.date: 03/20/2026
 ms.custom: linux-related-content
 ---
 


### PR DESCRIPTION
## Summary
I noticed that the list of Alpine dependencies is inaccurate, these packages:
- ca-certificates
- libgcc
- libssl3
- libstdc++

They are already installed in the base images here
https://github.com/dotnet/dotnet-docker/tree/main/src/runtime-deps/8.0/alpine3.23
https://github.com/dotnet/dotnet-docker/tree/main/src/runtime-deps/9.0/alpine3.23
https://github.com/dotnet/dotnet-docker/tree/main/src/runtime-deps/10.0/alpine3.23
https://github.com/dotnet/dotnet-docker/tree/main/src/runtime-deps/11.0/alpine3.23

Describe your changes here.
Update Alpine dependency list based on which packages are installed in the alpine base images for dotnet 8, 9, 10 and 11


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/install/linux-alpine.md](https://github.com/dotnet/docs/blob/de6051bbd8acd05da0b963630fd63cc1aa9d169d/docs/core/install/linux-alpine.md) | [docs/core/install/linux-alpine](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-alpine?branch=pr-en-us-52481) |

<!-- PREVIEW-TABLE-END -->