### PR TITLE
docs(csharp): correct Point extension methods to mutate via ref

### DIFF
--- a/docs/csharp/whats-new/tutorials/snippets/PointExtensions/ExtensionMethods.cs
+++ b/docs/csharp/whats-new/tutorials/snippets/PointExtensions/ExtensionMethods.cs
@@ -8,19 +8,19 @@ public static class PointExtensions
     public static Vector2 ToVector(this Point point) =>
         new Vector2(point.X, point.Y);
 
-    public static void Translate(this Point point, int xDist, int yDist)
+    public static void Translate(this ref Point point, int xDist, int yDist)
     {
         point.X += xDist;
         point.Y += yDist;
     }
 
-    public static void Scale(this Point point, int xScale, int yScale)
+    public static void Scale(this ref Point point, int xScale, int yScale)
     {
         point.X *= xScale;
         point.Y *= yScale;
     }
 
-    public static void Rotate(this Point point, int angleInDegrees)
+    public static void Rotate(this ref Point point, int angleInDegrees)
     {
         double theta = ((double)angleInDegrees * Math.PI) / 180.0;
         double sinTheta = Math.Sin(theta);

--- a/docs/csharp/whats-new/tutorials/snippets/PointExtensions/NewExtensionsMembers.cs
+++ b/docs/csharp/whats-new/tutorials/snippets/PointExtensions/NewExtensionsMembers.cs
@@ -5,7 +5,7 @@ namespace ExtensionMembers;
 
 public static class PointExtensions
 {
-    extension(Point point)
+    extension(ref Point point)
     {
         public static Point Origin => Point.Empty;
 


### PR DESCRIPTION
Fixes #52617

## Summary
Update the Point extension-method snippets to use `ref` receivers for struct mutation.

## Details
- Change `Translate`, `Scale`, and `Rotate` receiver signatures from `this Point point` to `this ref Point point`.
- This aligns the sample behavior with the tutorial output expectation (mutating the caller instance).

## Validation
- Verified the sample now updates coordinates after method calls.