### PR TITLE
Fix typo in custom .NET host tutorial

### DIFF
--- a/docs/core/tutorials/netcore-hosting.md
+++ b/docs/core/tutorials/netcore-hosting.md
@@ -18,7 +18,7 @@ This article gives an overview of the steps necessary to start the .NET runtime 
 
 Because hosts are native applications, this tutorial covers constructing a C++ application to host .NET. You need a C++ development environment (such as that provided by [Visual Studio](https://aka.ms/vsdownload?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link)).
 
-You also need to build a .NET component to test the host with, so you should install the [latests .NET SDK](https://dotnet.microsoft.com/download). It includes the necessary headers and libraries to link with.
+You also need to build a .NET component to test the host with, so you should install the [latest .NET SDK](https://dotnet.microsoft.com/download). It includes the necessary headers and libraries to link with.
 
 ## Hosting APIs
 


### PR DESCRIPTION
## Summary
- fix a typo in the custom .NET host tutorial
- change "latests .NET SDK" to "latest .NET SDK"
- no unrelated changes

## Validation
- verified the source file locally
- kept the change limited to one docs line

AI assistance: used only to help draft the PR text and prepare the minimal patch. I reviewed and verified the final change myself.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tutorials/netcore-hosting.md](https://github.com/dotnet/docs/blob/511b5f6db73656ac20b6f1a924cdc87f94e04c0b/docs/core/tutorials/netcore-hosting.md) | [Write a custom .NET host to control the .NET runtime from your native code](https://review.learn.microsoft.com/en-us/dotnet/core/tutorials/netcore-hosting?branch=pr-en-us-52684) |

<!-- PREVIEW-TABLE-END -->