### PR TITLE
The hub link should point to 15

### DIFF
--- a/docs/csharp/index.yml
+++ b/docs/csharp/index.yml
@@ -32,7 +32,7 @@ highlightedContent:
     # Card
     - title: What's new
       itemType: whats-new
-      url: ./whats-new/csharp-14.md
+      url: ./whats-new/csharp-15.md
     # Card
     - title: Learn C# video series
       itemType: video


### PR DESCRIPTION
Update the link to What's new in C# to point to version 15.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/index.yml](https://github.com/dotnet/docs/blob/a88e7b6b99b7728de2c5d3fd2e82c8d2d5ff2640/docs/csharp/index.yml) | [highlightedContent section (Optional; Remove if not applicable.)](https://review.learn.microsoft.com/en-us/dotnet/csharp/index?branch=pr-en-us-52706) |

<!-- PREVIEW-TABLE-END -->