### PR TITLE
Update msbuild-props.md

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1750,6 +1750,7 @@ To define an explicit `global using` directive, add a [Using](#using) item.
 
 - [AssemblyMetadata](#assemblymetadata)
 - [InternalsVisibleTo](#internalsvisibleto)
+- [FrameworkReference](#frameworkreference)
 - [PackageReference](#packagereference)
 - [TrimmerRootAssembly](#trimmerrootassembly)
 - [Using](#using)


### PR DESCRIPTION
Missing list entry "FrameworkReference" added.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/project-sdk/msbuild-props.md](https://github.com/dotnet/docs/blob/eb7d5713debeae1f6b47f9fc41c65cad693b594e/docs/core/project-sdk/msbuild-props.md) | [MSBuild reference for .NET SDK projects](https://review.learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-52714) |

<!-- PREVIEW-TABLE-END -->