### PR TITLE
Fix how to set data classification through JSON

### DIFF
--- a/docs/core/extensions/data-classification.md
+++ b/docs/core/extensions/data-classification.md
@@ -90,10 +90,19 @@ To bind your data classification settings, use the .NET configuration system. Fo
 ```json
 {
     "Key": {
-        "PhoneNumber": "MyTaxonomy:PrivateInformation",
+        "PhoneNumber": {
+            "taxonomyName": "MyTaxonomy",
+            "value": "PrivateInformation"
+        },
         "ExampleDictionary": {
-            "CreditCard": "MyTaxonomy:CreditCardNumber",
-            "SSN": "MyTaxonomy:SocialSecurityNumber"
+            "CreditCard": {
+                "taxonomyName": "MyTaxonomy",
+                "value": "CreditCardNumber"
+            },
+            "SSN":{
+                "taxonomyName": "MyTaxonomy",
+                "value": "SocialSecurityNumber"
+            } 
         }
     }
 }

--- a/docs/core/extensions/data-classification.md
+++ b/docs/core/extensions/data-classification.md
@@ -91,18 +91,18 @@ To bind your data classification settings, use the .NET configuration system. Fo
 {
     "Key": {
         "PhoneNumber": {
-            "taxonomyName": "MyTaxonomy",
-            "value": "PrivateInformation"
+            "TaxonomyName": "MyTaxonomy",
+            "Value": "PrivateInformation"
         },
         "ExampleDictionary": {
             "CreditCard": {
-                "taxonomyName": "MyTaxonomy",
-                "value": "CreditCardNumber"
+                "TaxonomyName": "MyTaxonomy",
+                "Value": "CreditCardNumber"
             },
-            "SSN":{
-                "taxonomyName": "MyTaxonomy",
-                "value": "SocialSecurityNumber"
-            } 
+            "SSN": {
+                "TaxonomyName": "MyTaxonomy",
+                "Value": "SocialSecurityNumber"
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Due to this [issue ](https://github.com/dotnet/runtime/issues/83599) with configuration binder source generator, we can't specify data classification in JSON using this syntax `"TaxonomyName:DataClassification"`. 
It needs to be separated to 2 fields: taxonomyName, and Value. therefore docs needs update
Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/data-classification.md](https://github.com/dotnet/docs/blob/b5504b55f0b5e0b7a5478353cfe6d53d893c1b6f/docs/core/extensions/data-classification.md) | [docs/core/extensions/data-classification](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/data-classification?branch=pr-en-us-52767) |


<!-- PREVIEW-TABLE-END -->