### PR TITLE
Fix backtick formatting problem in grain-identity.md

### DIFF
--- a/docs/orleans/grains/grain-identity.md
+++ b/docs/orleans/grains/grain-identity.md
@@ -44,7 +44,7 @@ public class DictionaryGrain<K, V> : IDictionaryGrain<K, V>
 }
 ```
 
-The grain class has two generic parameters, so a backtick `` ` `` followed by the generic arity, 2, is added to the end of the grain type name `dict` to create the grain type name ``dict`2``. This is specified in the attribute on the grain class: `[GrainType("dict`2")]`.
+The grain class has two generic parameters, so a backtick `` ` `` followed by the generic arity, 2, is added to the end of the grain type name `dict` to create the grain type name ``dict`2``. This is specified in the attribute on the grain class: ``[GrainType("dict`2")]``.
 
 ## Grain keys
 


### PR DESCRIPTION
## Summary

Added additional surrounding backticks in markdown to escape backtick in content.

Fixes #52781


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/grains/grain-identity.md](https://github.com/dotnet/docs/blob/720b10d3311590f2268a8ca0dc5fc79409f34fc8/docs/orleans/grains/grain-identity.md) | [Grain identity](https://review.learn.microsoft.com/en-us/dotnet/orleans/grains/grain-identity?branch=pr-en-us-52782) |

<!-- PREVIEW-TABLE-END -->