### PR TITLE
Include and link primary constructors to CS0236 example

### DIFF
--- a/docs/csharp/misc/cs0236.md
+++ b/docs/csharp/misc/cs0236.md
@@ -35,7 +35,7 @@ The compiler detects this pattern during compilation and reports CS0236 to preve
 
 4. **Lazy initialization**: Use properties with backing fields for complex initialization logic that depends on other instance members.
 
-5. **Primary constructor**: Use [primary constructors](../programming-guide/classes-and-structs/instance-constructors#primary-constructors) to initialize the public field with the value of instance field or value given as constructor argument.
+5. **Primary constructor**: Use [primary constructors](../programming-guide/classes-and-structs/instance-constructors.md#primary-constructors) to initialize the public field with the value of instance field or value given as constructor argument.
 
 ## Example
 

--- a/docs/csharp/misc/cs0236.md
+++ b/docs/csharp/misc/cs0236.md
@@ -35,6 +35,8 @@ The compiler detects this pattern during compilation and reports CS0236 to preve
 
 4. **Lazy initialization**: Use properties with backing fields for complex initialization logic that depends on other instance members.
 
+5. **Primary constructor**: Use [primary constructors](../programming-guide/classes-and-structs/instance-constructors#primary-constructors) to initialize the public field with the value of instance field or value given as constructor argument.
+
 ## Example
 
 The following sample generates CS0236, and shows how to fix it:
@@ -54,6 +56,22 @@ public class MyClass
         // before constructor code runs
         j = i;
     }
+}
+```
+
+CS0236 can also be fixed using the *primary constructor* as shown in the following example:
+
+```csharp
+public class MyClass
+{
+    public int i = 5;
+    public int j => i;
+}
+
+// or
+public class MyClass(int i)
+{
+    public int j => i;
 }
 ```
 


### PR DESCRIPTION
This pull request closes #43353.
It adds point 5. to the list of ways to solve the CS0236 error with the primary constructors (as a link to the page),
as well as shows a brief example of how to use that new feature in context of solving this specific problem of CS0236.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0236.md](https://github.com/dotnet/docs/blob/6b958f422f170e2fcaee1fba5e3ca503d2290521/docs/csharp/misc/cs0236.md) | [Compiler Error CS0236](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0236?branch=pr-en-us-52847) |


<!-- PREVIEW-TABLE-END -->