### PR TITLE
Add article back to TOC

### DIFF
--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -270,7 +270,7 @@ items:
               - name: Troubleshooting
                 href: ../../core/testing/microsoft-testing-platform-troubleshooting.md
               - name: "Use with 'dotnet test' (VSTest mode)"
-                href: ../../core/testing/microsoft-testing-platform-integration-dotnet-test.md        
+                href: ../../core/testing/microsoft-testing-platform-integration-dotnet-test.md
               - name: Features
                 items:
                   - name: Overview

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -269,6 +269,8 @@ items:
                 href: ../../core/testing/microsoft-testing-platform-config.md
               - name: Troubleshooting
                 href: ../../core/testing/microsoft-testing-platform-troubleshooting.md
+              - name: "Use with 'dotnet test' (VSTest mode)"
+                href: ../../core/testing/microsoft-testing-platform-integration-dotnet-test.md        
               - name: Features
                 items:
                   - name: Overview


### PR DESCRIPTION
Dropped presumably by accident in https://github.com/dotnet/docs/pull/51854 @Evangelink.

Contributes to #50869.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/navigate/devops-testing/toc.yml](https://github.com/dotnet/docs/blob/20de897078cb1c24d5e996052b87b51f0d574c33/docs/navigate/devops-testing/toc.yml) | [docs/navigate/devops-testing/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/devops-testing/toc?branch=pr-en-us-52852) |


<!-- PREVIEW-TABLE-END -->