### PR TITLE
Clarify Orleans constructor migration guidance

### DIFF
--- a/docs/orleans/includes/orleans-10-breaking-changes.md
+++ b/docs/orleans/includes/orleans-10-breaking-changes.md
@@ -10,5 +10,5 @@
 | `CancelRequestOnTimeout` default changed | Behavioral | Explicitly set to `true` if needed |
 | ADO.NET provider requires `Microsoft.Data.SqlClient` | Compile/Runtime error | Replace `System.Data.SqlClient` package |
 | `[Unordered]` attribute obsoleted | Warning | Remove attribute (has no effect) |
-| `OrleansConstructorAttribute` obsoleted | Warning | Use <xref:Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute> for serializer constructors and <xref:Orleans.GeneratedActivatorConstructorAttribute> for generated activators |
+| `OrleansConstructorAttribute` obsoleted | Warning | Use <xref:Orleans.GeneratedActivatorConstructorAttribute> or <xref:Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute> only for constructors which require dependency injection, not for serialized data properties |
 | `RegisterTimer` obsoleted | Warning | Use <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> |

--- a/docs/orleans/includes/orleans-10-breaking-changes.md
+++ b/docs/orleans/includes/orleans-10-breaking-changes.md
@@ -10,5 +10,5 @@
 | `CancelRequestOnTimeout` default changed | Behavioral | Explicitly set to `true` if needed |
 | ADO.NET provider requires `Microsoft.Data.SqlClient` | Compile/Runtime error | Replace `System.Data.SqlClient` package |
 | `[Unordered]` attribute obsoleted | Warning | Remove attribute (has no effect) |
-| `OrleansConstructorAttribute` obsoleted | Warning | Use <xref:Orleans.GeneratedActivatorConstructorAttribute> |
+| `OrleansConstructorAttribute` obsoleted | Warning | Use <xref:Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute> for serializer constructors and <xref:Orleans.GeneratedActivatorConstructorAttribute> for generated activators |
 | `RegisterTimer` obsoleted | Warning | Use <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> |

--- a/docs/orleans/includes/orleans-10-breaking-changes.md
+++ b/docs/orleans/includes/orleans-10-breaking-changes.md
@@ -10,5 +10,5 @@
 | `CancelRequestOnTimeout` default changed | Behavioral | Explicitly set to `true` if needed |
 | ADO.NET provider requires `Microsoft.Data.SqlClient` | Compile/Runtime error | Replace `System.Data.SqlClient` package |
 | `[Unordered]` attribute obsoleted | Warning | Remove attribute (has no effect) |
-| `OrleansConstructorAttribute` obsoleted | Warning | Use <xref:Orleans.GeneratedActivatorConstructorAttribute> or <xref:Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute> only for constructors which require dependency injection, not for serialized data properties |
+| `OrleansConstructorAttribute` obsoleted | Warning | Use <xref:Orleans.GeneratedActivatorConstructorAttribute> or <xref:Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute> only for constructors that require dependency injection, not for serialized data properties |
 | `RegisterTimer` obsoleted | Warning | Use <xref:Orleans.GrainBaseExtensions.RegisterGrainTimer*> |

--- a/docs/orleans/migration-guide.md
+++ b/docs/orleans/migration-guide.md
@@ -156,7 +156,7 @@ public interface IMyGrain : IGrainWithStringKey
 
 ### Breaking change: `OrleansConstructorAttribute` obsoleted
 
-The `OrleansConstructorAttribute` has been obsoleted. Use <xref:Orleans.GeneratedActivatorConstructorAttribute> or `ActivatorUtilitiesConstructorAttribute` instead to specify which constructor the serializer should use.
+The `OrleansConstructorAttribute` has been obsoleted. Because it derives from <xref:Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute>, replace it with that attribute when you need to specify which constructor the serializer should use to create an instance from serialized data. Use <xref:Orleans.GeneratedActivatorConstructorAttribute> only when generated activators should call a specific constructor, such as one which takes injected dependencies that are not part of the serialized state.
 
 ```csharp
 // Orleans 7.x
@@ -171,7 +171,7 @@ public class MyClass
 [GenerateSerializer]
 public class MyClass
 {
-    [GeneratedActivatorConstructor]
+    [ActivatorUtilitiesConstructor]
     public MyClass(string value) { }
 }
 ```

--- a/docs/orleans/migration-guide.md
+++ b/docs/orleans/migration-guide.md
@@ -170,7 +170,7 @@ public class MyClass
     [Id(0)]
     public string Value { get; set; }
 
-    [OrleansConstructor] // Obsolete
+    [OrleansConstructor] // Obsolete and ignored
     public MyClass(IMyDependency dependency)
     {
         Dependency = dependency;

--- a/docs/orleans/migration-guide.md
+++ b/docs/orleans/migration-guide.md
@@ -156,23 +156,43 @@ public interface IMyGrain : IGrainWithStringKey
 
 ### Breaking change: `OrleansConstructorAttribute` obsoleted
 
-The `OrleansConstructorAttribute` has been obsoleted. Because it derives from <xref:Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute>, replace it with that attribute when you need to specify which constructor the serializer should use to create an instance from serialized data. Use <xref:Orleans.GeneratedActivatorConstructorAttribute> only when generated activators should call a specific constructor, such as one which takes injected dependencies that are not part of the serialized state.
+The `OrleansConstructorAttribute` has been obsoleted. Use <xref:Orleans.GeneratedActivatorConstructorAttribute> or <xref:Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute> instead. Only apply these attributes to constructors which require services to be injected via dependency injection. Don't use them to indicate how Orleans should set serialized data properties or fields.
 
 ```csharp
+public interface IMyDependency
+{
+}
+
 // Orleans 7.x
 [GenerateSerializer]
 public class MyClass
 {
+    [Id(0)]
+    public string Value { get; set; }
+
     [OrleansConstructor] // Obsolete
-    public MyClass(string value) { }
+    public MyClass(IMyDependency dependency)
+    {
+        Dependency = dependency;
+    }
+
+    public IMyDependency Dependency { get; }
 }
 
 // Orleans 10.0
 [GenerateSerializer]
 public class MyClass
 {
-    [ActivatorUtilitiesConstructor]
-    public MyClass(string value) { }
+    [Id(0)]
+    public string Value { get; set; }
+
+    [GeneratedActivatorConstructor]
+    public MyClass(IMyDependency dependency)
+    {
+        Dependency = dependency;
+    }
+
+    public IMyDependency Dependency { get; }
 }
 ```
 

--- a/docs/orleans/migration-guide.md
+++ b/docs/orleans/migration-guide.md
@@ -156,7 +156,7 @@ public interface IMyGrain : IGrainWithStringKey
 
 ### Breaking change: `OrleansConstructorAttribute` obsoleted
 
-The `OrleansConstructorAttribute` has been obsoleted. Use <xref:Orleans.GeneratedActivatorConstructorAttribute> or <xref:Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute> instead. Only apply these attributes to constructors which require services to be injected via dependency injection. Don't use them to indicate how Orleans should set serialized data properties or fields.
+The `OrleansConstructorAttribute` has been obsoleted. Use <xref:Orleans.GeneratedActivatorConstructorAttribute> or <xref:Microsoft.Extensions.DependencyInjection.ActivatorUtilitiesConstructorAttribute> instead. Only apply these attributes to constructors that require services to be injected via dependency injection. Don't use them to indicate how Orleans should set serialized data properties or fields.
 
 ```csharp
 public interface IMyDependency

--- a/docs/orleans/migration-guide.md
+++ b/docs/orleans/migration-guide.md
@@ -176,6 +176,7 @@ public class MyClass
         Dependency = dependency;
     }
 
+    [field: NonSerialized]
     public IMyDependency Dependency { get; }
 }
 
@@ -192,6 +193,7 @@ public class MyClass
         Dependency = dependency;
     }
 
+    [field: NonSerialized]
     public IMyDependency Dependency { get; }
 }
 ```


### PR DESCRIPTION
## Summary
- clarify that OrleansConstructorAttribute should be replaced with ActivatorUtilitiesConstructorAttribute when selecting a serializer constructor
- explain that GeneratedActivatorConstructorAttribute is only for generated activators, such as DI-based activation
- update the Orleans 10 breaking changes summary to match

Fixes dotnet/orleans#9895

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/migration-guide.md](https://github.com/dotnet/docs/blob/c83454310987871802d51cd7bd9332541dc3f8ce/docs/orleans/migration-guide.md) | [Orleans migration guides](https://review.learn.microsoft.com/en-us/dotnet/orleans/migration-guide?branch=pr-en-us-52870) |


<!-- PREVIEW-TABLE-END -->