### PR TITLE
Remove duplicate @ prefix from issueAuthor in GitOps

### DIFF
--- a/.github/policies/disallow-edits.yml
+++ b/.github/policies/disallow-edits.yml
@@ -36,7 +36,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                  @${issueAuthor} - This PR edits a file in the .github folder, which is not allowed. CC @dotnet/docs.
+                  ${issueAuthor} - This PR edits a file in the .github folder, which is not allowed. CC @dotnet/docs.
           - closePullRequest
 
       - description: Close PRs that change Framework Design Guidelines.
@@ -51,7 +51,7 @@ configuration:
         then:
           - addReply:
               reply: >-
-                  @${issueAuthor} - This PR edits a file in the design-guidelines folder, which is disallowed. This content is reprinted by permission of Pearson Education, Inc. from Framework Design Guidelines: Conventions, Idioms, and Patterns for Reusable .NET Libraries, 2nd Edition, and cannot be edited. CC @dotnet/docs.
+                  ${issueAuthor} - This PR edits a file in the design-guidelines folder, which is disallowed. This content is reprinted by permission of Pearson Education, Inc. from Framework Design Guidelines: Conventions, Idioms, and Patterns for Reusable .NET Libraries, 2nd Edition, and cannot be edited. CC @dotnet/docs.
           - if:
               - or:
                   - activitySenderHasPermission:


### PR DESCRIPTION
## Summary

https://github.com/GitOps-microsoft/GitOps.PullRequestIssueManagement/pull/262 (internal Microsoft link) changed the ` ${issueAuthor}` placeholder to include the `@` character.

Remove the one we added so we don't duplicate it.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/policies/disallow-edits.yml](https://github.com/dotnet/docs/blob/0701095fd1abf68d0c0be5f29dc07a2d62bae856/.github/policies/disallow-edits.yml) | [.github/policies/disallow-edits](https://review.learn.microsoft.com/en-us/dotnet/.github/policies/disallow-edits?branch=pr-en-us-52877) |

<!-- PREVIEW-TABLE-END -->