### PR TITLE
Sync/Async wrapper article

### DIFF
--- a/docs/navigate/advanced-programming/toc.yml
+++ b/docs/navigate/advanced-programming/toc.yml
@@ -16,6 +16,10 @@ items:
       href: ../../standard/asynchronous-programming-patterns/consuming-the-task-based-asynchronous-pattern.md
     - name: Interop with other asynchronous patterns and types
       href: ../../standard/asynchronous-programming-patterns/interop-with-other-asynchronous-patterns-and-types.md
+    - name: Asynchronous wrappers for synchronous methods
+      href: ../../standard/asynchronous-programming-patterns/async-wrappers-for-synchronous-methods.md
+    - name: Synchronous wrappers for asynchronous methods
+      href: ../../standard/asynchronous-programming-patterns/synchronous-wrappers-for-asynchronous-methods.md
   - name: Event-based asynchronous pattern (EAP)
     items:
     - name: Documentation overview

--- a/docs/standard/asynchronous-programming-patterns/async-wrappers-for-synchronous-methods.md
+++ b/docs/standard/asynchronous-programming-patterns/async-wrappers-for-synchronous-methods.md
@@ -1,0 +1,93 @@
+---
+title: "Asynchronous wrappers for synchronous methods"
+description: Learn why you should avoid exposing asynchronous wrappers for synchronous methods in .NET libraries, and when consumers should use Task.Run instead.
+ms.date: 04/06/2026
+ai-usage: ai-assisted
+dev_langs:
+  - "csharp"
+  - "vb"
+helpviewer_keywords:
+  - "async over sync"
+  - "Task.Run wrapper"
+  - "asynchronous programming, wrappers"
+  - "TAP, async wrappers"
+---
+# Asynchronous wrappers for synchronous methods
+
+When you have a synchronous method in a library, you might be tempted to expose an asynchronous counterpart that wraps it in <xref:System.Threading.Tasks.Task.Run*?displayProperty=nameWithType>:
+
+```csharp
+public T Foo() { /* synchronous work */ }
+
+// Don't do this in a library:
+public Task<T> FooAsync()
+{
+    return Task.Run(() => Foo());
+}
+```
+
+This article explains why that approach is almost always wrong for libraries and how to think about the tradeoffs.
+
+## Scalability vs. offloading
+
+Asynchronous programming provides two distinct benefits:
+
+- **Scalability** — Reduce resource consumption by freeing threads during I/O waits.
+- **Offloading** — Move work to a different thread to maintain responsiveness (for example, keeping a UI thread free) or achieve parallelism.
+
+These benefits require different approaches. The critical distinction: **wrapping a synchronous method in `Task.Run` helps with offloading but does nothing for scalability.**
+
+### Why `Task.Run` doesn't improve scalability
+
+A truly asynchronous implementation reduces the number of threads consumed during a long-running operation. A `Task.Run` wrapper still blocks a thread — it just moves the blocking from one thread to another:
+
+:::code language="csharp" source="./snippets/async-wrappers-for-synchronous-methods/csharp/Program.cs" id="ScalabilityWrong":::
+:::code language="vb" source="./snippets/async-wrappers-for-synchronous-methods/vb/Program.vb" id="ScalabilityWrong":::
+
+Compare that with a truly asynchronous implementation that consumes no threads while waiting:
+
+:::code language="csharp" source="./snippets/async-wrappers-for-synchronous-methods/csharp/Program.cs" id="ScalabilityRight":::
+:::code language="vb" source="./snippets/async-wrappers-for-synchronous-methods/vb/Program.vb" id="ScalabilityRight":::
+
+Both implementations complete after the specified delay, but the second doesn't block any thread while waiting. For server applications handling many concurrent requests, that difference directly affects how many requests a server can process simultaneously.
+
+### Offloading is the consumer's responsibility
+
+Wrapping synchronous calls in `Task.Run` *is* useful for offloading work from a UI thread. However, that wrapping should be done by the consumer, not by the library:
+
+:::code language="csharp" source="./snippets/async-wrappers-for-synchronous-methods/csharp/Program.cs" id="OffloadFromUI":::
+:::code language="vb" source="./snippets/async-wrappers-for-synchronous-methods/vb/Program.vb" id="OffloadFromUI":::
+
+The consumer knows their context — whether they're on a UI thread, how much granularity they need, and whether offloading adds value. The library doesn't.
+
+## Why libraries shouldn't expose async-over-sync wrappers
+
+When a library exposes only the synchronous method (and not an async wrapper), consumers benefit in several ways:
+
+- **Reduced API surface area** — Fewer methods to learn, test, and maintain.
+- **No misleading scalability expectations** — Users know that only the methods exposed as asynchronous actually provide scalability benefits.
+- **Consumer control** — Users choose *whether* and *how* to offload, at the right level of granularity. A high-throughput server application can call the synchronous method directly, avoiding unnecessary overhead from `Task.Run`.
+- **Better performance** — Asynchronous wrappers add overhead (allocations, context switches, thread pool scheduling). For fine-grained operations, that overhead can be significant.
+
+## Exceptions: when async-over-sync wrappers make sense
+
+Some base classes expose asynchronous methods so that derived classes can override them with truly asynchronous implementations. The base class provides an async-over-sync default.
+
+For example, <xref:System.IO.Stream> exposes <xref:System.IO.Stream.ReadAsync*> and <xref:System.IO.Stream.WriteAsync*>. The base implementations wrap the synchronous <xref:System.IO.Stream.Read*> and <xref:System.IO.Stream.Write*> methods. Derived classes like <xref:System.IO.FileStream> and <xref:System.Net.Sockets.NetworkStream> override these methods with asynchronous I/O implementations that provide real scalability benefits.
+
+Similarly, <xref:System.IO.TextReader> provides <xref:System.IO.TextReader.ReadToEndAsync*> on the base class as a wrapper, and <xref:System.IO.StreamReader> overrides it with a truly asynchronous implementation that calls <xref:System.IO.Stream.ReadAsync*> internally.
+
+These are valid exceptions because:
+
+- The pattern is designed for polymorphism — callers interact with the base type.
+- Derived types are expected to provide truly asynchronous overrides.
+
+## Guideline
+
+Expose asynchronous methods from a library only when the implementation provides real scalability benefits over its synchronous counterpart. Don't expose asynchronous methods purely for offloading — leave that choice to the consumer.
+
+## See also
+
+- [Task-based asynchronous pattern (TAP)](task-based-asynchronous-pattern-tap.md)
+- [Implement the task-based asynchronous pattern](implementing-the-task-based-asynchronous-pattern.md)
+- [Synchronous wrappers for asynchronous methods](synchronous-wrappers-for-asynchronous-methods.md)

--- a/docs/standard/asynchronous-programming-patterns/async-wrappers-for-synchronous-methods.md
+++ b/docs/standard/asynchronous-programming-patterns/async-wrappers-for-synchronous-methods.md
@@ -69,7 +69,7 @@ When a library exposes only the synchronous method (and not an async wrapper), c
 - **Consumer control**: Callers choose *whether* and *how* to offload, at the right level of granularity. A high-throughput server application can call the synchronous method directly, avoiding unnecessary overhead from `Task.Run`.
 - **Better performance**: Asynchronous wrappers add overhead through allocations, context switches, and thread pool scheduling. For fine-grained operations, that overhead can be significant.
 
-## Exceptions: when async-over-sync wrappers make sense
+## Exceptions to the rule
 
 Some base classes expose asynchronous methods so that derived classes can override them with truly asynchronous implementations. The base class provides an async-over-sync default.
 

--- a/docs/standard/asynchronous-programming-patterns/async-wrappers-for-synchronous-methods.md
+++ b/docs/standard/asynchronous-programming-patterns/async-wrappers-for-synchronous-methods.md
@@ -44,30 +44,30 @@ A truly asynchronous implementation reduces the number of threads consumed durin
 :::code language="csharp" source="./snippets/async-wrappers-for-synchronous-methods/csharp/Program.cs" id="ScalabilityWrong":::
 :::code language="vb" source="./snippets/async-wrappers-for-synchronous-methods/vb/Program.vb" id="ScalabilityWrong":::
 
-Compare that with a truly asynchronous implementation that consumes no threads while waiting:
+Compare that approach with a truly asynchronous implementation that consumes no threads while waiting:
 
 :::code language="csharp" source="./snippets/async-wrappers-for-synchronous-methods/csharp/Program.cs" id="ScalabilityRight":::
 :::code language="vb" source="./snippets/async-wrappers-for-synchronous-methods/vb/Program.vb" id="ScalabilityRight":::
 
-Both implementations complete after the specified delay, but the second doesn't block any thread while waiting. For server applications handling many concurrent requests, that difference directly affects how many requests a server can process simultaneously.
+Both implementations complete after the specified delay, but the second implementation doesn't block any thread while waiting. For server applications handling many concurrent requests, that difference directly affects how many requests a server can process simultaneously.
 
 ### Offloading is the consumer's responsibility
 
-Wrapping synchronous calls in `Task.Run` *is* useful for offloading work from a UI thread. However, that wrapping should be done by the consumer, not by the library:
+Wrapping synchronous calls in `Task.Run` is useful for offloading work from a UI thread. However, the consumer, not the library, should handle this wrapping:
 
 :::code language="csharp" source="./snippets/async-wrappers-for-synchronous-methods/csharp/Program.cs" id="OffloadFromUI":::
 :::code language="vb" source="./snippets/async-wrappers-for-synchronous-methods/vb/Program.vb" id="OffloadFromUI":::
 
-The consumer knows their context — whether they're on a UI thread, how much granularity they need, and whether offloading adds value. The library doesn't.
+The consumer knows their context: whether they're on a UI thread, how much granularity they need, and whether offloading adds value. The library doesn't.
 
 ## Why libraries shouldn't expose async-over-sync wrappers
 
 When a library exposes only the synchronous method (and not an async wrapper), consumers benefit in several ways:
 
-- **Reduced API surface area** — Fewer methods to learn, test, and maintain.
-- **No misleading scalability expectations** — Users know that only the methods exposed as asynchronous actually provide scalability benefits.
-- **Consumer control** — Users choose *whether* and *how* to offload, at the right level of granularity. A high-throughput server application can call the synchronous method directly, avoiding unnecessary overhead from `Task.Run`.
-- **Better performance** — Asynchronous wrappers add overhead (allocations, context switches, thread pool scheduling). For fine-grained operations, that overhead can be significant.
+- **Reduced API surface area**: Fewer methods to learn, test, and maintain.
+- **No misleading scalability expectations**: Users know that only the methods exposed as asynchronous actually provide scalability benefits.
+- **Consumer control**: Callers choose *whether* and *how* to offload, at the right level of granularity. A high-throughput server application can call the synchronous method directly, avoiding unnecessary overhead from `Task.Run`.
+- **Better performance**: Asynchronous wrappers add overhead through allocations, context switches, and thread pool scheduling. For fine-grained operations, that overhead can be significant.
 
 ## Exceptions: when async-over-sync wrappers make sense
 
@@ -77,14 +77,14 @@ For example, <xref:System.IO.Stream> exposes <xref:System.IO.Stream.ReadAsync*> 
 
 Similarly, <xref:System.IO.TextReader> provides <xref:System.IO.TextReader.ReadToEndAsync*> on the base class as a wrapper, and <xref:System.IO.StreamReader> overrides it with a truly asynchronous implementation that calls <xref:System.IO.Stream.ReadAsync*> internally.
 
-These are valid exceptions because:
+These exceptions are valid because:
 
-- The pattern is designed for polymorphism — callers interact with the base type.
-- Derived types are expected to provide truly asynchronous overrides.
+- The pattern is designed for polymorphism. Callers interact with the base type.
+- Derived types provide truly asynchronous overrides.
 
 ## Guideline
 
-Expose asynchronous methods from a library only when the implementation provides real scalability benefits over its synchronous counterpart. Don't expose asynchronous methods purely for offloading — leave that choice to the consumer.
+Expose asynchronous methods from a library only when the implementation provides real scalability benefits over its synchronous counterpart. Don't expose asynchronous methods purely for offloading. Leave that choice to the consumer.
 
 ## See also
 

--- a/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/csharp/AsyncWrappersForSync.csproj
+++ b/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/csharp/AsyncWrappersForSync.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/csharp/Program.cs
@@ -1,0 +1,74 @@
+using System.Text.RegularExpressions;
+
+// <ScalabilityWrong>
+public static class TimerExampleWrong
+{
+    // Don't do this in a library — wrapping a synchronous method with Task.Run
+    // doesn't improve scalability. It just shifts which thread is blocked.
+    public static Task SleepAsync(int millisecondsTimeout)
+    {
+        return Task.Run(() => Thread.Sleep(millisecondsTimeout));
+    }
+}
+// </ScalabilityWrong>
+
+// <ScalabilityRight>
+public static class TimerExampleRight
+{
+    // A truly asynchronous implementation consumes no threads while waiting.
+    public static Task SleepAsync(int millisecondsTimeout)
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        var timer = new Timer(
+            _ => tcs.TrySetResult(true), null, millisecondsTimeout, Timeout.Infinite);
+
+        // Ensure the timer is kept alive until the task completes,
+        // then dispose it.
+        tcs.Task.ContinueWith(
+            _ => timer.Dispose(), TaskScheduler.Default);
+
+        return tcs.Task;
+    }
+}
+// </ScalabilityRight>
+
+// <OffloadFromUI>
+public static class UIOffloadExample
+{
+    // The consumer offloads to a background thread — not the library.
+    // This keeps the library simple and lets the caller choose the right approach.
+    public static int ComputeIntensive(int input)
+    {
+        // Simulate CPU-bound work.
+        int result = 0;
+        for (int i = 0; i < input; i++)
+        {
+            result += i;
+        }
+        return result;
+    }
+
+    public static async Task ConsumeFromUIThreadAsync()
+    {
+        // The caller decides to offload, at the right level of granularity.
+        int result = await Task.Run(() => ComputeIntensive(10_000));
+        Console.WriteLine($"Result: {result}");
+    }
+}
+// </OffloadFromUI>
+
+// Verification entry point
+public class Program
+{
+    public static async Task Main()
+    {
+        Console.WriteLine("--- ScalabilityRight demo ---");
+        await TimerExampleRight.SleepAsync(100);
+        Console.WriteLine("SleepAsync completed (100ms).");
+
+        Console.WriteLine("--- OffloadFromUI demo ---");
+        await UIOffloadExample.ConsumeFromUIThreadAsync();
+
+        Console.WriteLine("Done.");
+    }
+}

--- a/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/csharp/Program.cs
@@ -1,5 +1,3 @@
-using System.Text.RegularExpressions;
-
 // <ScalabilityWrong>
 public static class TimerExampleWrong
 {

--- a/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/csharp/Program.cs
@@ -3,8 +3,6 @@ using System.Text.RegularExpressions;
 // <ScalabilityWrong>
 public static class TimerExampleWrong
 {
-    // Don't do this in a library — wrapping a synchronous method with Task.Run
-    // doesn't improve scalability. It just shifts which thread is blocked.
     public static Task SleepAsync(int millisecondsTimeout)
     {
         return Task.Run(() => Thread.Sleep(millisecondsTimeout));
@@ -15,15 +13,12 @@ public static class TimerExampleWrong
 // <ScalabilityRight>
 public static class TimerExampleRight
 {
-    // A truly asynchronous implementation consumes no threads while waiting.
     public static Task SleepAsync(int millisecondsTimeout)
     {
         var tcs = new TaskCompletionSource<bool>();
         var timer = new Timer(
             _ => tcs.TrySetResult(true), null, millisecondsTimeout, Timeout.Infinite);
 
-        // Ensure the timer is kept alive until the task completes,
-        // then dispose it.
         tcs.Task.ContinueWith(
             _ => timer.Dispose(), TaskScheduler.Default);
 
@@ -35,11 +30,8 @@ public static class TimerExampleRight
 // <OffloadFromUI>
 public static class UIOffloadExample
 {
-    // The consumer offloads to a background thread — not the library.
-    // This keeps the library simple and lets the caller choose the right approach.
     public static int ComputeIntensive(int input)
     {
-        // Simulate CPU-bound work.
         int result = 0;
         for (int i = 0; i < input; i++)
         {
@@ -50,7 +42,6 @@ public static class UIOffloadExample
 
     public static async Task ConsumeFromUIThreadAsync()
     {
-        // The caller decides to offload, at the right level of granularity.
         int result = await Task.Run(() => ComputeIntensive(10_000));
         Console.WriteLine($"Result: {result}");
     }

--- a/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/vb/AsyncWrappersForSync.vbproj
+++ b/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/vb/AsyncWrappersForSync.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>AsyncWrappersForSync</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/vb/Program.vb
@@ -2,8 +2,6 @@ Imports System.Threading
 
 ' <ScalabilityWrong>
 Public Module TimerExampleWrong
-    ' Don't do this in a library — wrapping a synchronous method with Task.Run
-    ' doesn't improve scalability.
     Public Function SleepAsync(millisecondsTimeout As Integer) As Task
         Return Task.Run(Sub() Thread.Sleep(millisecondsTimeout))
     End Function
@@ -12,7 +10,6 @@ End Module
 
 ' <ScalabilityRight>
 Public Module TimerExampleRight
-    ' A truly asynchronous implementation consumes no threads while waiting.
     Public Function SleepAsync(millisecondsTimeout As Integer) As Task
         Dim tcs As New TaskCompletionSource(Of Boolean)()
         Dim tmr As New Timer(

--- a/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/async-wrappers-for-synchronous-methods/vb/Program.vb
@@ -1,0 +1,57 @@
+Imports System.Threading
+
+' <ScalabilityWrong>
+Public Module TimerExampleWrong
+    ' Don't do this in a library — wrapping a synchronous method with Task.Run
+    ' doesn't improve scalability.
+    Public Function SleepAsync(millisecondsTimeout As Integer) As Task
+        Return Task.Run(Sub() Thread.Sleep(millisecondsTimeout))
+    End Function
+End Module
+' </ScalabilityWrong>
+
+' <ScalabilityRight>
+Public Module TimerExampleRight
+    ' A truly asynchronous implementation consumes no threads while waiting.
+    Public Function SleepAsync(millisecondsTimeout As Integer) As Task
+        Dim tcs As New TaskCompletionSource(Of Boolean)()
+        Dim tmr As New Timer(
+            Sub(state) tcs.TrySetResult(True), Nothing, millisecondsTimeout, Timeout.Infinite)
+
+        tcs.Task.ContinueWith(
+            Sub(t) tmr.Dispose(), TaskScheduler.Default)
+
+        Return tcs.Task
+    End Function
+End Module
+' </ScalabilityRight>
+
+' <OffloadFromUI>
+Public Module UIOffloadExample
+    Public Function ComputeIntensive(input As Integer) As Integer
+        Dim result As Integer = 0
+        For i As Integer = 0 To input - 1
+            result += i
+        Next
+        Return result
+    End Function
+
+    Public Async Function ConsumeFromUIThreadAsync() As Task
+        Dim result As Integer = Await Task.Run(Function() ComputeIntensive(10_000))
+        Console.WriteLine($"Result: {result}")
+    End Function
+End Module
+' </OffloadFromUI>
+
+Module Program
+    Sub Main()
+        Console.WriteLine("--- ScalabilityRight demo ---")
+        TimerExampleRight.SleepAsync(100).Wait()
+        Console.WriteLine("SleepAsync completed (100ms).")
+
+        Console.WriteLine("--- OffloadFromUI demo ---")
+        UIOffloadExample.ConsumeFromUIThreadAsync().Wait()
+
+        Console.WriteLine("Done.")
+    End Sub
+End Module

--- a/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs
@@ -65,7 +65,7 @@ public static class ConfigureAwaitMitigation
 // Verification entry point
 public class Program
 {
-    public static async Task Main()
+    public static void Main()
     {
         Console.WriteLine("--- ConfigureAwait mitigation demo ---");
         int result = ConfigureAwaitMitigation.Sync();

--- a/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs
@@ -57,7 +57,7 @@ public static class ConfigureAwaitMitigation
 
     public static int Sync()
     {
-        return Task.Run(() => LibraryMethodAsync()).Result;
+        return LibraryMethodAsync().GetAwaiter().GetResult();
     }
 }
 // </ConfigureAwaitMitigation>

--- a/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs
@@ -1,0 +1,107 @@
+// <SyncOverAsyncAPM>
+public class ApmWrapper
+{
+    // Wrapping an APM implementation with a synchronous method.
+    // EndFoo blocks until the async operation completes.
+    public static int Foo(Func<AsyncCallback?, object?, IAsyncResult> beginFoo,
+                          Func<IAsyncResult, int> endFoo)
+    {
+        IAsyncResult ar = beginFoo(null, null);
+        return endFoo(ar);
+    }
+}
+// </SyncOverAsyncAPM>
+
+// <SyncOverAsyncTAP>
+public class TapWrapper
+{
+    // Wrapping a TAP method with a synchronous method.
+    // Accessing .Result blocks until the task completes.
+    public static int Foo(Func<Task<int>> fooAsync)
+    {
+        return fooAsync().Result;
+    }
+}
+// </SyncOverAsyncTAP>
+
+// <DeadlockExample>
+public static class DeadlockExample
+{
+    // This method deadlocks when called from a UI thread
+    // or any thread with a single-threaded SynchronizationContext.
+    private static void Delay(int milliseconds)
+    {
+        DelayAsync(milliseconds).Wait();
+    }
+
+    private static async Task DelayAsync(int milliseconds)
+    {
+        await Task.Delay(milliseconds);
+        // When there's a SynchronizationContext, the continuation
+        // tries to post back to the calling thread — but that thread
+        // is blocked in .Wait() above. Deadlock!
+    }
+}
+// </DeadlockExample>
+
+// <ThreadPoolDeadlock>
+public static class ThreadPoolDeadlockExample
+{
+    // When FooAsync depends on the thread pool to complete its internal work,
+    // blocking all pool threads with synchronous wrappers causes deadlock.
+    public static int Foo(Func<Task<int>> fooAsync)
+    {
+        return fooAsync().Result;
+    }
+
+    public static async Task DemonstrateDeadlockRiskAsync()
+    {
+        // If the thread pool maximum is low (e.g., 25 threads) and all threads
+        // call Foo simultaneously, the async I/O completions can't run
+        // because no threads are available — all are blocked in .Result.
+        var tasks = Enumerable.Range(0, 25)
+            .Select(_ => Task.Run(() => Foo(() => SomeIOOperationAsync())));
+        await Task.WhenAll(tasks);
+    }
+
+    private static async Task<int> SomeIOOperationAsync()
+    {
+        await Task.Delay(100);
+        return 42;
+    }
+}
+// </ThreadPoolDeadlock>
+
+// <ConfigureAwaitMitigation>
+public static class ConfigureAwaitMitigation
+{
+    // If you must wrap sync over async, ensure the async implementation
+    // uses ConfigureAwait(false) on all awaits to avoid marshaling
+    // back to the calling context.
+    public static async Task<int> LibraryMethodAsync()
+    {
+        await Task.Delay(100).ConfigureAwait(false);
+        return 42;
+    }
+
+    // The consumer offloads to the thread pool, ensuring there's no
+    // SynchronizationContext that could cause a deadlock.
+    public static int Sync()
+    {
+        return Task.Run(() => LibraryMethodAsync()).Result;
+    }
+}
+// </ConfigureAwaitMitigation>
+
+// Verification entry point
+public class Program
+{
+    public static async Task Main()
+    {
+        Console.WriteLine("--- ConfigureAwait mitigation demo ---");
+        int result = ConfigureAwaitMitigation.Sync();
+        Console.WriteLine($"Result: {result}");
+
+        Console.WriteLine("Done.");
+    }
+}

--- a/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs
@@ -1,22 +1,6 @@
-// <SyncOverAsyncAPM>
-public class ApmWrapper
-{
-    // Wrapping an APM implementation with a synchronous method.
-    // EndFoo blocks until the async operation completes.
-    public static int Foo(Func<AsyncCallback?, object?, IAsyncResult> beginFoo,
-                          Func<IAsyncResult, int> endFoo)
-    {
-        IAsyncResult ar = beginFoo(null, null);
-        return endFoo(ar);
-    }
-}
-// </SyncOverAsyncAPM>
-
 // <SyncOverAsyncTAP>
 public class TapWrapper
 {
-    // Wrapping a TAP method with a synchronous method.
-    // Accessing .Result blocks until the task completes.
     public static int Foo(Func<Task<int>> fooAsync)
     {
         return fooAsync().Result;
@@ -27,8 +11,6 @@ public class TapWrapper
 // <DeadlockExample>
 public static class DeadlockExample
 {
-    // This method deadlocks when called from a UI thread
-    // or any thread with a single-threaded SynchronizationContext.
     private static void Delay(int milliseconds)
     {
         DelayAsync(milliseconds).Wait();
@@ -37,9 +19,6 @@ public static class DeadlockExample
     private static async Task DelayAsync(int milliseconds)
     {
         await Task.Delay(milliseconds);
-        // When there's a SynchronizationContext, the continuation
-        // tries to post back to the calling thread — but that thread
-        // is blocked in .Wait() above. Deadlock!
     }
 }
 // </DeadlockExample>
@@ -47,8 +26,6 @@ public static class DeadlockExample
 // <ThreadPoolDeadlock>
 public static class ThreadPoolDeadlockExample
 {
-    // When FooAsync depends on the thread pool to complete its internal work,
-    // blocking all pool threads with synchronous wrappers causes deadlock.
     public static int Foo(Func<Task<int>> fooAsync)
     {
         return fooAsync().Result;
@@ -56,9 +33,6 @@ public static class ThreadPoolDeadlockExample
 
     public static async Task DemonstrateDeadlockRiskAsync()
     {
-        // If the thread pool maximum is low (e.g., 25 threads) and all threads
-        // call Foo simultaneously, the async I/O completions can't run
-        // because no threads are available — all are blocked in .Result.
         var tasks = Enumerable.Range(0, 25)
             .Select(_ => Task.Run(() => Foo(() => SomeIOOperationAsync())));
         await Task.WhenAll(tasks);
@@ -75,17 +49,12 @@ public static class ThreadPoolDeadlockExample
 // <ConfigureAwaitMitigation>
 public static class ConfigureAwaitMitigation
 {
-    // If you must wrap sync over async, ensure the async implementation
-    // uses ConfigureAwait(false) on all awaits to avoid marshaling
-    // back to the calling context.
     public static async Task<int> LibraryMethodAsync()
     {
         await Task.Delay(100).ConfigureAwait(false);
         return 42;
     }
 
-    // The consumer offloads to the thread pool, ensuring there's no
-    // SynchronizationContext that could cause a deadlock.
     public static int Sync()
     {
         return Task.Run(() => LibraryMethodAsync()).Result;

--- a/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/csharp/SyncWrappersForAsync.csproj
+++ b/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/csharp/SyncWrappersForAsync.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/vb/Program.vb
@@ -1,7 +1,5 @@
 ' <SyncOverAsyncTAP>
 Public Module TapWrapper
-    ' Wrapping a TAP method with a synchronous method.
-    ' Accessing .Result blocks until the task completes.
     Public Function Foo(fooAsync As Func(Of Task(Of Integer))) As Integer
         Return fooAsync().Result
     End Function
@@ -10,8 +8,6 @@ End Module
 
 ' <DeadlockExample>
 Public Module DeadlockExample
-    ' This method deadlocks when called from a UI thread
-    ' or any thread with a single-threaded SynchronizationContext.
     Private Sub Delay(milliseconds As Integer)
         DelayAsync(milliseconds).Wait()
     End Sub
@@ -29,7 +25,6 @@ Public Module ConfigureAwaitMitigation
         Return 42
     End Function
 
-    ' Offload to the thread pool so there's no SynchronizationContext.
     Public Function Sync() As Integer
         Return Task.Run(Function() LibraryMethodAsync()).Result
     End Function

--- a/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/vb/Program.vb
@@ -1,0 +1,46 @@
+' <SyncOverAsyncTAP>
+Public Module TapWrapper
+    ' Wrapping a TAP method with a synchronous method.
+    ' Accessing .Result blocks until the task completes.
+    Public Function Foo(fooAsync As Func(Of Task(Of Integer))) As Integer
+        Return fooAsync().Result
+    End Function
+End Module
+' </SyncOverAsyncTAP>
+
+' <DeadlockExample>
+Public Module DeadlockExample
+    ' This method deadlocks when called from a UI thread
+    ' or any thread with a single-threaded SynchronizationContext.
+    Private Sub Delay(milliseconds As Integer)
+        DelayAsync(milliseconds).Wait()
+    End Sub
+
+    Private Async Function DelayAsync(milliseconds As Integer) As Task
+        Await Task.Delay(milliseconds)
+    End Function
+End Module
+' </DeadlockExample>
+
+' <ConfigureAwaitMitigation>
+Public Module ConfigureAwaitMitigation
+    Public Async Function LibraryMethodAsync() As Task(Of Integer)
+        Await Task.Delay(100).ConfigureAwait(False)
+        Return 42
+    End Function
+
+    ' Offload to the thread pool so there's no SynchronizationContext.
+    Public Function Sync() As Integer
+        Return Task.Run(Function() LibraryMethodAsync()).Result
+    End Function
+End Module
+' </ConfigureAwaitMitigation>
+
+Module Program
+    Sub Main()
+        Console.WriteLine("--- ConfigureAwait mitigation demo ---")
+        Dim result As Integer = ConfigureAwaitMitigation.Sync()
+        Console.WriteLine($"Result: {result}")
+        Console.WriteLine("Done.")
+    End Sub
+End Module

--- a/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/vb/Program.vb
@@ -26,7 +26,7 @@ Public Module ConfigureAwaitMitigation
     End Function
 
     Public Function Sync() As Integer
-        Return Task.Run(Function() LibraryMethodAsync()).Result
+        Return LibraryMethodAsync().Result
     End Function
 End Module
 ' </ConfigureAwaitMitigation>

--- a/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/vb/SyncWrappersForAsync.vbproj
+++ b/docs/standard/asynchronous-programming-patterns/snippets/synchronous-wrappers-for-async-methods/vb/SyncWrappersForAsync.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>SyncWrappersForAsync</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/asynchronous-programming-patterns/synchronous-wrappers-for-asynchronous-methods.md
+++ b/docs/standard/asynchronous-programming-patterns/synchronous-wrappers-for-asynchronous-methods.md
@@ -48,17 +48,18 @@ Here's what happens step by step:
 
 ## Thread pool exhaustion
 
-Deadlocks aren't limited to UI threads. If an asynchronous method depends on the thread pool to complete its work (for example, queuing a final processing step), blocking all pool threads with synchronous wrappers can starve the pool:
+Deadlocks aren't limited to UI threads. If an asynchronous method depends on the thread pool to complete its work, for example, by queuing a final processing step, blocking many pool threads with synchronous wrappers can starve the pool:
 
 :::code language="csharp" source="./snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs" id="ThreadPoolDeadlock":::
 
 In this scenario:
 
-1. All 25 thread pool threads call `Foo`, which blocks in `.Result`.
+1. Many thread pool threads call `Foo`, which blocks in `.Result`.
 1. Each async operation completes its I/O and needs a thread pool thread to run its completion callback.
-1. No threads are available. They're all blocked. Deadlock!
+1. Because blocked calls occupy available worker threads, completions might wait a long time for a thread to become available.
+1. Modern .NET can add more thread pool threads over time, but the application can still suffer severe thread pool starvation, poor throughput, long delays, or an apparent hang.
 
-This exact pattern affected `HttpWebRequest.GetResponse` in .NET Framework 1.x, where the synchronous method was implemented as a wrapper around the asynchronous `BeginGetResponse`/`EndGetResponse`.
+This pattern affected `HttpWebRequest.GetResponse` in .NET Framework 1.x, where the synchronous method was implemented as a wrapper around the asynchronous `BeginGetResponse`/`EndGetResponse`.
 
 ## Guideline: avoid exposing synchronous wrappers
 

--- a/docs/standard/asynchronous-programming-patterns/synchronous-wrappers-for-asynchronous-methods.md
+++ b/docs/standard/asynchronous-programming-patterns/synchronous-wrappers-for-asynchronous-methods.md
@@ -19,20 +19,16 @@ When a library exposes only asynchronous APIs, consumers sometimes wrap them in 
 
 ## Basic wrapping patterns
 
-A synchronous wrapper around an Asynchronous Programming Model (APM) implementation calls the `Begin` method and immediately blocks on the `End` method:
-
-:::code language="csharp" source="./snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs" id="SyncOverAsyncAPM":::
-
 A synchronous wrapper around a Task-based Asynchronous Pattern (TAP) method accesses the task's <xref:System.Threading.Tasks.Task%601.Result> property, which blocks the calling thread:
 
 :::code language="csharp" source="./snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs" id="SyncOverAsyncTAP":::
 :::code language="vb" source="./snippets/synchronous-wrappers-for-async-methods/vb/Program.vb" id="SyncOverAsyncTAP":::
 
-Both approaches look simple, but they can cause serious problems depending on the environment in which they run.
+This approach looks simple, but it can cause serious problems depending on the environment in which it runs.
 
 ## Deadlocks with single-threaded contexts
 
-The most dangerous scenario occurs when you call a synchronous wrapper from a thread that has a single-threaded <xref:System.Threading.SynchronizationContext> — typically a UI thread in WPF, Windows Forms, or MAUI applications.
+The most dangerous scenario occurs when you call a synchronous wrapper from a thread that has a single-threaded <xref:System.Threading.SynchronizationContext>. This scenario is typically a UI thread in WPF, Windows Forms, or MAUI applications.
 
 :::code language="csharp" source="./snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs" id="DeadlockExample":::
 :::code language="vb" source="./snippets/synchronous-wrappers-for-async-methods/vb/Program.vb" id="DeadlockExample":::
@@ -41,9 +37,9 @@ Here's what happens step by step:
 
 1. The UI thread calls `Delay`, which calls `DelayAsync(milliseconds).Wait()`.
 1. `DelayAsync` runs synchronously until it reaches `await Task.Delay(milliseconds)`.
-1. Because the delay hasn't completed yet, `await` captures the current <xref:System.Threading.SynchronizationContext> and suspends. `DelayAsync` returns a <xref:System.Threading.Tasks.Task> to the caller.
+1. Because the delay isn't complete yet, `await` captures the current <xref:System.Threading.SynchronizationContext> and suspends. `DelayAsync` returns a <xref:System.Threading.Tasks.Task> to the caller.
 1. The UI thread blocks in `.Wait()`, waiting for that task to complete.
-1. When the delay finishes, the continuation needs to run on the original `SynchronizationContext` — the UI thread.
+1. When the delay finishes, the continuation needs to run on the original `SynchronizationContext` which is the UI thread.
 1. The UI thread can't process the continuation because it's blocked in `.Wait()`.
 1. **Deadlock.**
 
@@ -60,7 +56,7 @@ In this scenario:
 
 1. All 25 thread pool threads call `Foo`, which blocks in `.Result`.
 1. Each async operation completes its I/O and needs a thread pool thread to run its completion callback.
-1. No threads are available — they're all blocked. Deadlock!
+1. No threads are available. They're all blocked. Deadlock!
 
 This exact pattern affected `HttpWebRequest.GetResponse` in .NET Framework 1.x, where the synchronous method was implemented as a wrapper around the asynchronous `BeginGetResponse`/`EndGetResponse`.
 
@@ -72,7 +68,7 @@ If you find yourself needing to call an asynchronous method synchronously, consi
 
 ## Mitigation strategies when sync-over-async is unavoidable
 
-Sometimes sync-over-async is truly unavoidable — for example, when implementing an interface that requires a synchronous method, and the only available implementation is asynchronous. In those cases, apply these strategies to reduce the risk.
+Sometimes sync-over-async is truly unavoidable. For example, when implementing an interface that requires a synchronous method, and the only available implementation is asynchronous. In those cases, apply these strategies to reduce the risk.
 
 ### Use ConfigureAwait(false) in the async implementation
 

--- a/docs/standard/asynchronous-programming-patterns/synchronous-wrappers-for-asynchronous-methods.md
+++ b/docs/standard/asynchronous-programming-patterns/synchronous-wrappers-for-asynchronous-methods.md
@@ -1,0 +1,118 @@
+---
+title: "Synchronous wrappers for asynchronous methods"
+description: Learn why you should avoid exposing synchronous wrappers for asynchronous methods in .NET libraries, and how to mitigate issues when sync-over-async is unavoidable.
+ms.date: 04/06/2026
+ai-usage: ai-assisted
+dev_langs:
+  - "csharp"
+  - "vb"
+helpviewer_keywords:
+  - "sync over async"
+  - "async deadlock"
+  - "ConfigureAwait"
+  - "asynchronous programming, wrappers"
+  - "TAP, synchronous wrappers"
+---
+# Synchronous wrappers for asynchronous methods
+
+When a library exposes only asynchronous APIs, consumers sometimes wrap them in synchronous calls to satisfy a synchronous interface or contract. This "sync-over-async" pattern can seem straightforward, but it's a common source of deadlocks and performance problems.
+
+## Basic wrapping patterns
+
+A synchronous wrapper around an Asynchronous Programming Model (APM) implementation calls the `Begin` method and immediately blocks on the `End` method:
+
+:::code language="csharp" source="./snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs" id="SyncOverAsyncAPM":::
+
+A synchronous wrapper around a Task-based Asynchronous Pattern (TAP) method accesses the task's <xref:System.Threading.Tasks.Task%601.Result> property, which blocks the calling thread:
+
+:::code language="csharp" source="./snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs" id="SyncOverAsyncTAP":::
+:::code language="vb" source="./snippets/synchronous-wrappers-for-async-methods/vb/Program.vb" id="SyncOverAsyncTAP":::
+
+Both approaches look simple, but they can cause serious problems depending on the environment in which they run.
+
+## Deadlocks with single-threaded contexts
+
+The most dangerous scenario occurs when you call a synchronous wrapper from a thread that has a single-threaded <xref:System.Threading.SynchronizationContext> — typically a UI thread in WPF, Windows Forms, or MAUI applications.
+
+:::code language="csharp" source="./snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs" id="DeadlockExample":::
+:::code language="vb" source="./snippets/synchronous-wrappers-for-async-methods/vb/Program.vb" id="DeadlockExample":::
+
+Here's what happens step by step:
+
+1. The UI thread calls `Delay`, which calls `DelayAsync(milliseconds).Wait()`.
+1. `DelayAsync` runs synchronously until it reaches `await Task.Delay(milliseconds)`.
+1. Because the delay hasn't completed yet, `await` captures the current <xref:System.Threading.SynchronizationContext> and suspends. `DelayAsync` returns a <xref:System.Threading.Tasks.Task> to the caller.
+1. The UI thread blocks in `.Wait()`, waiting for that task to complete.
+1. When the delay finishes, the continuation needs to run on the original `SynchronizationContext` — the UI thread.
+1. The UI thread can't process the continuation because it's blocked in `.Wait()`.
+1. **Deadlock.**
+
+> [!IMPORTANT]
+> The success or failure of sync-over-async code depends on the environment in which it runs. Code that works in a console app might deadlock on a UI thread or in ASP.NET (on .NET Framework). This environmental dependency is a core reason to avoid exposing synchronous wrappers.
+
+## Thread pool exhaustion
+
+Deadlocks aren't limited to UI threads. If an asynchronous method depends on the thread pool to complete its work (for example, queuing a final processing step), blocking all pool threads with synchronous wrappers can starve the pool:
+
+:::code language="csharp" source="./snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs" id="ThreadPoolDeadlock":::
+
+In this scenario:
+
+1. All 25 thread pool threads call `Foo`, which blocks in `.Result`.
+1. Each async operation completes its I/O and needs a thread pool thread to run its completion callback.
+1. No threads are available — they're all blocked. Deadlock!
+
+This exact pattern affected `HttpWebRequest.GetResponse` in .NET Framework 1.x, where the synchronous method was implemented as a wrapper around the asynchronous `BeginGetResponse`/`EndGetResponse`.
+
+## Guideline: avoid exposing synchronous wrappers
+
+Don't expose a synchronous method that wraps an asynchronous implementation. Instead, leave the decision of whether to block to the consumer. The consumer knows their threading environment and can make an informed choice.
+
+If you find yourself needing to call an asynchronous method synchronously, consider first whether you can restructure the code to be "async all the way down." Refactoring is often the better long-term solution.
+
+## Mitigation strategies when sync-over-async is unavoidable
+
+Sometimes sync-over-async is truly unavoidable — for example, when implementing an interface that requires a synchronous method, and the only available implementation is asynchronous. In those cases, apply these strategies to reduce the risk.
+
+### Use ConfigureAwait(false) in the async implementation
+
+If you control the async method, use <xref:System.Threading.Tasks.Task.ConfigureAwait*?displayProperty=nameWithType> with `false` on every `await` to prevent the continuation from marshaling back to the original `SynchronizationContext`:
+
+:::code language="csharp" source="./snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs" id="ConfigureAwaitMitigation":::
+:::code language="vb" source="./snippets/synchronous-wrappers-for-async-methods/vb/Program.vb" id="ConfigureAwaitMitigation":::
+
+As a library author, use `ConfigureAwait(false)` on all awaits unless your code specifically needs to resume on the captured context. Using `ConfigureAwait(false)` is a best practice for performance and helps prevent deadlocks when consumers block.
+
+### Offload to the thread pool
+
+If you don't control the async implementation (and it might not use `ConfigureAwait(false)`), offload the call to the thread pool. The thread pool doesn't have a <xref:System.Threading.SynchronizationContext>, so the await won't try to marshal back to a blocked thread:
+
+```csharp
+public int Sync()
+{
+    return Task.Run(() => Library.FooAsync()).Result;
+}
+```
+
+```vb
+Public Function Sync() As Integer
+    Return Task.Run(Function() Library.FooAsync()).Result
+End Function
+```
+
+### Test in multiple environments
+
+If you must ship a synchronous wrapper, test it from:
+
+- A UI thread (WPF, Windows Forms).
+- The thread pool under load.
+- The thread pool with a low maximum thread count.
+- A console application.
+
+Behavior that works in one environment might deadlock in another.
+
+## See also
+
+- [Task-based asynchronous pattern (TAP)](task-based-asynchronous-pattern-tap.md)
+- [Consume the task-based asynchronous pattern](consuming-the-task-based-asynchronous-pattern.md)
+- [Asynchronous wrappers for synchronous methods](async-wrappers-for-synchronous-methods.md)

--- a/docs/standard/asynchronous-programming-patterns/synchronous-wrappers-for-asynchronous-methods.md
+++ b/docs/standard/asynchronous-programming-patterns/synchronous-wrappers-for-asynchronous-methods.md
@@ -19,7 +19,7 @@ When a library exposes only asynchronous APIs, consumers sometimes wrap them in 
 
 ## Basic wrapping patterns
 
-A synchronous wrapper around a Task-based Asynchronous Pattern (TAP) method accesses the task's <xref:System.Threading.Tasks.Task%601.Result> property, which blocks the calling thread:
+A synchronous wrapper around a Task-based Asynchronous Pattern (TAP) method accesses the task's <xref:System.Threading.Tasks.Task`1.Result> property, which blocks the calling thread:
 
 :::code language="csharp" source="./snippets/synchronous-wrappers-for-async-methods/csharp/Program.cs" id="SyncOverAsyncTAP":::
 :::code language="vb" source="./snippets/synchronous-wrappers-for-async-methods/vb/Program.vb" id="SyncOverAsyncTAP":::
@@ -61,7 +61,7 @@ In this scenario:
 
 This pattern affected `HttpWebRequest.GetResponse` in .NET Framework 1.x, where the synchronous method was implemented as a wrapper around the asynchronous `BeginGetResponse`/`EndGetResponse`.
 
-## Guideline: avoid exposing synchronous wrappers
+## Guideline: Avoid exposing synchronous wrappers
 
 Don't expose a synchronous method that wraps an asynchronous implementation. Instead, leave the decision of whether to block to the consumer. The consumer knows their threading environment and can make an informed choice.
 
@@ -69,9 +69,9 @@ If you find yourself needing to call an asynchronous method synchronously, consi
 
 ## Mitigation strategies when sync-over-async is unavoidable
 
-Sometimes sync-over-async is truly unavoidable. For example, when implementing an interface that requires a synchronous method, and the only available implementation is asynchronous. In those cases, apply these strategies to reduce the risk.
+Sometimes sync-over-async is truly unavoidable. For example, it's unavoidable when you implement an interface that requires a synchronous method, and the only available implementation is asynchronous. In those cases, apply the following strategies to reduce the risk.
 
-### Use ConfigureAwait(false) in the async implementation
+### Use `ConfigureAwait(false)` in the async implementation
 
 If you control the async method, use <xref:System.Threading.Tasks.Task.ConfigureAwait*?displayProperty=nameWithType> with `false` on every `await` to prevent the continuation from marshaling back to the original `SynchronizationContext`:
 


### PR DESCRIPTION
Contributes to #17714

Port the first two articles for wrapping async methods in synchronous methods, and wrapping synchronous methods in asynchronous methods.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/navigate/advanced-programming/toc.yml](https://github.com/dotnet/docs/blob/a5a6ca2e4efd851ddd7dbd52b7dc673bf7807587/docs/navigate/advanced-programming/toc.yml) | [docs/navigate/advanced-programming/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/advanced-programming/toc?branch=pr-en-us-52879) |
| [docs/standard/asynchronous-programming-patterns/async-wrappers-for-synchronous-methods.md](https://github.com/dotnet/docs/blob/a5a6ca2e4efd851ddd7dbd52b7dc673bf7807587/docs/standard/asynchronous-programming-patterns/async-wrappers-for-synchronous-methods.md) | [Asynchronous wrappers for synchronous methods](https://review.learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/async-wrappers-for-synchronous-methods?branch=pr-en-us-52879) |
| [docs/standard/asynchronous-programming-patterns/synchronous-wrappers-for-asynchronous-methods.md](https://github.com/dotnet/docs/blob/a5a6ca2e4efd851ddd7dbd52b7dc673bf7807587/docs/standard/asynchronous-programming-patterns/synchronous-wrappers-for-asynchronous-methods.md) | ["Synchronous wrappers for asynchronous methods"](https://review.learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/synchronous-wrappers-for-asynchronous-methods?branch=pr-en-us-52879) |


<!-- PREVIEW-TABLE-END -->