### PR TITLE
Async troubleshooting and pitfalls

### DIFF
--- a/docs/navigate/advanced-programming/toc.yml
+++ b/docs/navigate/advanced-programming/toc.yml
@@ -24,6 +24,12 @@ items:
       href: ../../standard/asynchronous-programming-patterns/executioncontext-synchronizationcontext.md
     - name: SynchronizationContext and console apps
       href: ../../standard/asynchronous-programming-patterns/synchronizationcontext-console-apps.md
+    - name: Best practices and troubleshooting
+      items:
+      - name: Common async/await bugs
+        href: ../../standard/asynchronous-programming-patterns/common-async-bugs.md
+      - name: Async lambda pitfalls
+        href: ../../standard/asynchronous-programming-patterns/async-lambda-pitfalls.md
   - name: Event-based asynchronous pattern (EAP)
     items:
     - name: Documentation overview

--- a/docs/standard/asynchronous-programming-patterns/async-lambda-pitfalls.md
+++ b/docs/standard/asynchronous-programming-patterns/async-lambda-pitfalls.md
@@ -16,38 +16,27 @@ helpviewer_keywords:
 ---
 # Async lambda pitfalls
 
-Async lambdas and anonymous methods are powerful features that let you create delegates representing asynchronous operations. However, passing them to methods that weren't designed for async delegates leads to subtle bugs. This article describes the most common scenarios and shows you how to fix them.
+Async lambdas and anonymous methods are powerful features that let you create delegates representing asynchronous operations. Use them with APIs that are designed for asynchronous delegates. This article shows the right patterns first, and then explains what goes wrong when you pass async lambdas to APIs that expect synchronous delegates.
 
-## Async lambdas assigned to Action delegates
+## Async lambdas assigned to `Action` delegates
 
-An async lambda can match a `void`-returning delegate type like <xref:System.Action>, not only `Func<Task>`. When the target parameter is an `Action`, the compiler maps the async lambda to an async void method—the caller has no way to track completion.
+Create an overload that accepts `Func<Task>` and await the result:
+
+:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="ActionFix":::
+:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="ActionFix":::
+
+Whenever you pass an async lambda to a method, verify the parameter's delegate type. If the parameter is `Action`, `Action<T>`, or any other void-returning delegate, switch to a task-returning delegate for asynchronous operations.
+
+An async lambda can match a `void`-returning delegate type like <xref:System.Action> in addition to `Func<Task>`. When the target parameter is an `Action`, the compiler maps the async lambda to an async void method. The caller has no way to track completion.
 
 Consider a timing helper that accepts an `Action`:
 
 :::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="ActionPitfall":::
 :::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="ActionPitfall":::
 
-When you pass a synchronous lambda, the measured time is accurate. With an async lambda, the `Action` delegate returns as soon as the first `await` yields—the timer captures only the synchronous portion instead of the full operation.
+When you pass a synchronous lambda, the measured time is accurate. With an async lambda, the `Action` delegate returns as soon as the first `await` yields, so the timer captures only the synchronous portion instead of the full operation.
 
-### Fix: accept Func\<Task> instead of Action
-
-Create an overload that accepts `Func<Task>` and awaits the result:
-
-:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="ActionFix":::
-:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="ActionFix":::
-
-Whenever you pass an async lambda to a method, check the parameter's delegate type. If the parameter is `Action`, `Action<T>`, or any other void-returning delegate, the callee can't observe when the async work completes.
-
-## Parallel.ForEach with async lambdas
-
-<xref:System.Threading.Tasks.Parallel.ForEach*> accepts an `Action<T>` for its body parameter. Passing an async lambda creates an async void delegate—`Parallel.ForEach` returns as soon as each delegate hits its first yielding `await`:
-
-:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="ParallelForEachBug":::
-:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="ParallelForEachBug":::
-
-The loop completes in milliseconds instead of the expected duration because the async lambdas become fire-and-forget operations.
-
-### Fix: use Task.WhenAll or Parallel.ForEachAsync
+## `Parallel.ForEach` with async lambdas
 
 In .NET 6 and later, use <xref:System.Threading.Tasks.Parallel.ForEachAsync*>, which accepts a `Func<TSource, CancellationToken, ValueTask>`:
 
@@ -59,16 +48,14 @@ Alternatively, project the items into tasks and use <xref:System.Threading.Tasks
 :::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="WhenAllAlternative":::
 :::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="WhenAllAlternative":::
 
-## Task.Factory.StartNew with async lambdas
+<xref:System.Threading.Tasks.Parallel.ForEach*> accepts an `Action<T>` for its body parameter. Passing an async lambda creates an async void delegate—`Parallel.ForEach` returns as soon as each delegate hits its first yielding `await`:
 
-When you pass an async lambda to <xref:System.Threading.Tasks.TaskFactory.StartNew*>, the return type is `Task<Task>` (or `Task<Task<TResult>>`). The outer task represents only the synchronous part of the delegate—it completes at the first yielding `await`. The inner task represents the full asynchronous operation:
+:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="ParallelForEachBug":::
+:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="ParallelForEachBug":::
 
-:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="StartNewBug":::
-:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="StartNewBug":::
+The loop completes in milliseconds instead of the expected duration because the async lambdas become fire-and-forget operations.
 
-If you treat the outer task as the whole operation, you'll observe completion before the async work actually finishes.
-
-### Fix: use Task.Run or Unwrap
+## `Task.Factory.StartNew` with async lambdas
 
 <xref:System.Threading.Tasks.Task.Run*> automatically unwraps async lambdas. It accepts `Func<Task>` and `Func<Task<TResult>>` overloads and returns the inner task:
 
@@ -79,6 +66,13 @@ If you need `StartNew`-specific options (such as <xref:System.Threading.Tasks.Ta
 
 :::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="StartNewFix2":::
 :::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="StartNewFix2":::
+
+When you pass an async lambda to <xref:System.Threading.Tasks.TaskFactory.StartNew*>, the return type is `Task<Task>` (or `Task<Task<TResult>>`). The outer task represents only the synchronous part of the delegate—it completes at the first yielding `await`. The inner task represents the full asynchronous operation:
+
+:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="StartNewBug":::
+:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="StartNewBug":::
+
+If you treat the outer task as the whole operation, you'll observe completion before the async work actually finishes.
 
 ## Summary
 

--- a/docs/standard/asynchronous-programming-patterns/async-lambda-pitfalls.md
+++ b/docs/standard/asynchronous-programming-patterns/async-lambda-pitfalls.md
@@ -1,0 +1,97 @@
+---
+title: "Async lambda pitfalls"
+description: Learn how to avoid common pitfalls when passing async lambdas to methods that expect Action delegates, Parallel.ForEach, or Task.Factory.StartNew.
+ms.date: 04/09/2026
+ai-usage: ai-assisted
+dev_langs:
+  - "csharp"
+  - "vb"
+helpviewer_keywords:
+  - "async lambda"
+  - "async void, lambda"
+  - "Parallel.ForEach, async"
+  - "Task.Factory.StartNew, async"
+  - "Task<Task>"
+  - "Action delegate, async"
+---
+# Async lambda pitfalls
+
+Async lambdas and anonymous methods are powerful features that let you create delegates representing asynchronous operations. However, passing them to methods that weren't designed for async delegates leads to subtle bugs. This article describes the most common scenarios and shows you how to fix them.
+
+## Async lambdas assigned to Action delegates
+
+An async lambda can match a `void`-returning delegate type like <xref:System.Action>, not only `Func<Task>`. When the target parameter is an `Action`, the compiler maps the async lambda to an async void method—the caller has no way to track completion.
+
+Consider a timing helper that accepts an `Action`:
+
+:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="ActionPitfall":::
+:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="ActionPitfall":::
+
+When you pass a synchronous lambda, the measured time is accurate. With an async lambda, the `Action` delegate returns as soon as the first `await` yields—the timer captures only the synchronous portion instead of the full operation.
+
+### Fix: accept Func\<Task> instead of Action
+
+Create an overload that accepts `Func<Task>` and awaits the result:
+
+:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="ActionFix":::
+:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="ActionFix":::
+
+Whenever you pass an async lambda to a method, check the parameter's delegate type. If the parameter is `Action`, `Action<T>`, or any other void-returning delegate, the callee can't observe when the async work completes.
+
+## Parallel.ForEach with async lambdas
+
+<xref:System.Threading.Tasks.Parallel.ForEach*> accepts an `Action<T>` for its body parameter. Passing an async lambda creates an async void delegate—`Parallel.ForEach` returns as soon as each delegate hits its first yielding `await`:
+
+:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="ParallelForEachBug":::
+:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="ParallelForEachBug":::
+
+The loop completes in milliseconds instead of the expected duration because the async lambdas become fire-and-forget operations.
+
+### Fix: use Task.WhenAll or Parallel.ForEachAsync
+
+In .NET 6 and later, use <xref:System.Threading.Tasks.Parallel.ForEachAsync*>, which accepts a `Func<TSource, CancellationToken, ValueTask>`:
+
+:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="ParallelForEachFix":::
+:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="ParallelForEachFix":::
+
+Alternatively, project the items into tasks and use <xref:System.Threading.Tasks.Task.WhenAll*>:
+
+:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="WhenAllAlternative":::
+:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="WhenAllAlternative":::
+
+## Task.Factory.StartNew with async lambdas
+
+When you pass an async lambda to <xref:System.Threading.Tasks.TaskFactory.StartNew*>, the return type is `Task<Task>` (or `Task<Task<TResult>>`). The outer task represents only the synchronous part of the delegate—it completes at the first yielding `await`. The inner task represents the full asynchronous operation:
+
+:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="StartNewBug":::
+:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="StartNewBug":::
+
+If you treat the outer task as the whole operation, you'll observe completion before the async work actually finishes.
+
+### Fix: use Task.Run or Unwrap
+
+<xref:System.Threading.Tasks.Task.Run*> automatically unwraps async lambdas. It accepts `Func<Task>` and `Func<Task<TResult>>` overloads and returns the inner task:
+
+:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="StartNewFix1":::
+:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="StartNewFix1":::
+
+If you need `StartNew`-specific options (such as <xref:System.Threading.Tasks.TaskCreationOptions.LongRunning>), call <xref:System.Threading.Tasks.TaskExtensions.Unwrap*> on the result:
+
+:::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="StartNewFix2":::
+:::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="StartNewFix2":::
+
+## Summary
+
+When you pass an async lambda to any method, verify the target parameter's delegate type:
+
+| Delegate type | Async behavior | Risk |
+|---|---|---|
+| `Func<Task>`, `Func<Task<T>>` | Caller receives a task that represents completion | Safe |
+| `Action`, `Action<T>` | Becomes async void—caller can't observe completion | High |
+| `Func<TResult>` where `TResult` is `Task` | Returns `Task<Task>`—outer task doesn't represent full work | Medium |
+
+## See also
+
+- [Common async/await bugs](common-async-bugs.md)
+- [Task-based asynchronous pattern (TAP)](task-based-asynchronous-pattern-tap.md)
+- [Consume the task-based asynchronous pattern](consuming-the-task-based-asynchronous-pattern.md)

--- a/docs/standard/asynchronous-programming-patterns/async-lambda-pitfalls.md
+++ b/docs/standard/asynchronous-programming-patterns/async-lambda-pitfalls.md
@@ -48,7 +48,7 @@ Alternatively, project the items into tasks and use <xref:System.Threading.Tasks
 :::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="WhenAllAlternative":::
 :::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="WhenAllAlternative":::
 
-<xref:System.Threading.Tasks.Parallel.ForEach*> accepts an `Action<T>` for its body parameter. Passing an async lambda creates an async void delegate—`Parallel.ForEach` returns as soon as each delegate hits its first yielding `await`:
+<xref:System.Threading.Tasks.Parallel.ForEach*> accepts an `Action<T>` for its body parameter. Passing an async lambda creates an async void delegate. `Parallel.ForEach` returns as soon as each delegate hits its first yielding `await`:
 
 :::code language="csharp" source="./snippets/async-lambda-pitfalls/csharp/Program.cs" id="ParallelForEachBug":::
 :::code language="vb" source="./snippets/async-lambda-pitfalls/vb/Program.vb" id="ParallelForEachBug":::

--- a/docs/standard/asynchronous-programming-patterns/async-lambda-pitfalls.md
+++ b/docs/standard/asynchronous-programming-patterns/async-lambda-pitfalls.md
@@ -78,10 +78,10 @@ If you treat the outer task as the whole operation, you'll observe completion be
 
 When you pass an async lambda to any method, verify the target parameter's delegate type:
 
-| Delegate type | Async behavior | Risk |
-|---|---|---|
-| `Func<Task>`, `Func<Task<T>>` | Caller receives a task that represents completion | Safe |
-| `Action`, `Action<T>` | Becomes async void—caller can't observe completion | High |
+| Delegate type                             | Async behavior                                              | Risk   |
+|-------------------------------------------|-------------------------------------------------------------|--------|
+| `Func<Task>`, `Func<Task<T>>`             | Caller receives a task that represents completion           | Safe   |
+| `Action`, `Action<T>`                     | Becomes async void—caller can't observe completion          | High   |
 | `Func<TResult>` where `TResult` is `Task` | Returns `Task<Task>`—outer task doesn't represent full work | Medium |
 
 ## See also

--- a/docs/standard/asynchronous-programming-patterns/common-async-bugs.md
+++ b/docs/standard/asynchronous-programming-patterns/common-async-bugs.md
@@ -1,6 +1,6 @@
 ---
 title: "Common async/await bugs"
-description: Learn to diagnose the four most common bugs in async/await code, including synchronous execution, async void, SynchronizationContext deadlocks, and Task unwrapping.
+description: Learn to diagnose the five most common bugs in async/await code, including synchronous execution, async void, SynchronizationContext deadlocks, miassing `await` expressions and Task unwrapping.
 ms.date: 04/09/2026
 ai-usage: ai-assisted
 dev_langs:
@@ -16,7 +16,7 @@ helpviewer_keywords:
 ---
 # Common async/await bugs
 
-Async/await simplifies asynchronous programming, but certain mistakes appear repeatedly. This article describes the four most common bugs in async code and shows you how to fix each one.
+Async/await simplifies asynchronous programming, but certain mistakes appear repeatedly. This article describes the five most common bugs in async code and shows you how to fix each one.
 
 ## Async method runs synchronously
 

--- a/docs/standard/asynchronous-programming-patterns/common-async-bugs.md
+++ b/docs/standard/asynchronous-programming-patterns/common-async-bugs.md
@@ -106,7 +106,7 @@ Fix this problem in one of three ways:
 
 ## Missing await on a task-returning call
 
-If you call a task-returning method in an `async` method without awaiting it, the method starts the asynchronous operation but doesn't wait for it to complete. The compiler emits warning CS4014 for this case:
+If you call a task-returning method in an `async` method without awaiting it, the method starts the asynchronous operation but doesn't wait for it to complete. The compiler warns you about this case with `CS4014` in C# and `BC42358` in Visual Basic:
 
 :::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="MissingAwait":::
 :::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="MissingAwait":::

--- a/docs/standard/asynchronous-programming-patterns/common-async-bugs.md
+++ b/docs/standard/asynchronous-programming-patterns/common-async-bugs.md
@@ -36,20 +36,20 @@ For more guidance on when to use `Task.Run`, see [Asynchronous wrappers for sync
 
 ## Can't await an async void method
 
-When you convert a synchronous `void`-returning method to async, you must change the return type to <xref:System.Threading.Tasks.Task>. If you leave the return type as `void`, the method becomes "async void," which can't be awaited:
+When you convert a synchronous `void`-returning method to async, change the return type to <xref:System.Threading.Tasks.Task>. If you leave the return type as `void`, the method becomes "async void," which you can't await:
 
 :::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="AsyncVoid":::
 :::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="AsyncVoid":::
 
-Async void methods are designed for a specific purpose: top-level event handlers in UI frameworks. Outside of event handlers, always return `Task` or `Task<T>` from async methods. Async void methods have additional drawbacks:
+Async void methods serve a specific purpose: top-level event handlers in UI frameworks. Outside of event handlers, always return `Task` or `Task<T>` from async methods. Async void methods have these drawbacks:
 
-- **Exceptions go unobserved.** Exceptions thrown in an async void method propagate to the <xref:System.Threading.SynchronizationContext> that was active when the method started. They can't be caught by the caller.
+- **Exceptions go unobserved.** Exceptions thrown in an async void method propagate to the <xref:System.Threading.SynchronizationContext> that was active when the method started. The caller can't catch these exceptions.
 - **Callers can't track completion.** Without a `Task`, there's no mechanism to know when the operation finishes.
 - **Testing is difficult.** You can't await the method in a test to verify its behavior.
 
 ## Deadlocks from blocking on async code
 
-This bug is the most common cause of async code that "never completes." It happens when you synchronously block (call <xref:System.Threading.Tasks.Task.Wait*>, <xref:System.Threading.Tasks.Task.Result>, or <xref:System.Threading.Tasks.Task.GetAwaiter*>.<xref:System.Runtime.CompilerServices.TaskAwaiter.GetResult*>) on a thread that has a single-threaded <xref:System.Threading.SynchronizationContext>.
+This bug is the most common cause of async code that "never completes." It happens when you synchronously block (call <xref:System.Threading.Tasks.Task.Wait*>, <xref:System.Threading.Tasks.Task`1.Result?displayProperty=nameWithType>, or <xref:System.Threading.Tasks.Task.GetAwaiter*>.<xref:System.Runtime.CompilerServices.TaskAwaiter.GetResult*>) on a thread that has a single-threaded <xref:System.Threading.SynchronizationContext>.
 
 The sequence that causes a deadlock:
 
@@ -75,19 +75,19 @@ Use one or more of these strategies:
   :::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="DeadlockFix2":::
   :::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="DeadlockFix2":::
 
-  Using `ConfigureAwait(false)` tells the runtime not to marshal the continuation back to the original `SynchronizationContext`. This approach protects callers who do block, and it improves performance by avoiding unnecessary thread hops.
+  Using `ConfigureAwait(false)` tells the runtime not to marshal the continuation back to the original `SynchronizationContext`. This approach protects callers who block, and it improves performance by avoiding unnecessary thread hops.
 
 > [!WARNING]
 > **Static constructor deadlocks.** The CLR holds a lock while running static constructors (`cctor`s). If a static constructor blocks on a task, and that task's continuation needs to run code in the same type (or a type involved in the construction chain), the continuation can't proceed because the `cctor` lock is held. Avoid blocking calls inside static constructors entirely.
 
 ## Task\<Task> unwrapping
 
-When you pass an async lambda to a method like <xref:System.Threading.Tasks.TaskFactory.StartNew*>, the returned object is a `Task<Task>` (or `Task<Task<TResult>>`), not a simple `Task`. The outer task completes as soon as the async lambda hits its first yielding `await`—it doesn't wait for the inner task to finish:
+When you pass an async lambda to a method like <xref:System.Threading.Tasks.TaskFactory.StartNew*>, the returned object is a `Task<Task>` (or `Task<Task<TResult>>`), not a simple `Task`. The outer task completes as soon as the async lambda hits its first yielding `await`. It doesn't wait for the inner task to finish:
 
 :::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="TaskTaskBug":::
 :::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="TaskTaskBug":::
 
-Fix this in one of three ways:
+Fix this problem in one of three ways:
 
 - **Use <xref:System.Threading.Tasks.Task.Run*> instead.** `Task.Run` automatically unwraps `Task<Task>`:
 

--- a/docs/standard/asynchronous-programming-patterns/common-async-bugs.md
+++ b/docs/standard/asynchronous-programming-patterns/common-async-bugs.md
@@ -1,0 +1,121 @@
+---
+title: "Common async/await bugs"
+description: Learn to diagnose the four most common bugs in async/await code, including synchronous execution, async void, SynchronizationContext deadlocks, and Task unwrapping.
+ms.date: 04/09/2026
+ai-usage: ai-assisted
+dev_langs:
+  - "csharp"
+  - "vb"
+helpviewer_keywords:
+  - "async debugging"
+  - "async void"
+  - "deadlock, async"
+  - "SynchronizationContext, deadlock"
+  - "Task<Task>, unwrapping"
+  - "ConfigureAwait"
+---
+# Common async/await bugs
+
+Async/await simplifies asynchronous programming, but certain mistakes appear repeatedly. This article describes the four most common bugs in async code and shows you how to fix each one.
+
+## Async method runs synchronously
+
+Adding the `async` keyword to a method doesn't make the method run on a background thread. It tells the compiler to allow `await` inside the method body and to wrap the return value in a <xref:System.Threading.Tasks.Task>. When you invoke an async method, it runs synchronously until it reaches the first `await` on an incomplete awaitable. If the method contains no `await` expressions, or if every awaitable it awaits is already complete, the method completes entirely on the calling thread:
+
+:::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="SyncExecution":::
+:::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="SyncExecution":::
+
+Here the method returns a completed task immediately because it never yields. The compiler emits a warning when an async method lacks `await` expressions.
+
+If your goal is to offload CPU-bound work to a thread pool thread, use <xref:System.Threading.Tasks.Task.Run*> instead of `async`:
+
+:::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="OffloadCorrectly":::
+:::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="OffloadCorrectly":::
+
+For more guidance on when to use `Task.Run`, see [Asynchronous wrappers for synchronous methods](async-wrappers-for-synchronous-methods.md).
+
+## Can't await an async void method
+
+When you convert a synchronous `void`-returning method to async, you must change the return type to <xref:System.Threading.Tasks.Task>. If you leave the return type as `void`, the method becomes "async void," which can't be awaited:
+
+:::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="AsyncVoid":::
+:::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="AsyncVoid":::
+
+Async void methods are designed for a specific purpose: top-level event handlers in UI frameworks. Outside of event handlers, always return `Task` or `Task<T>` from async methods. Async void methods have additional drawbacks:
+
+- **Exceptions go unobserved.** Exceptions thrown in an async void method propagate to the <xref:System.Threading.SynchronizationContext> that was active when the method started. They can't be caught by the caller.
+- **Callers can't track completion.** Without a `Task`, there's no mechanism to know when the operation finishes.
+- **Testing is difficult.** You can't await the method in a test to verify its behavior.
+
+## Deadlocks from blocking on async code
+
+This bug is the most common cause of async code that "never completes." It happens when you synchronously block (call <xref:System.Threading.Tasks.Task.Wait*>, <xref:System.Threading.Tasks.Task.Result>, or <xref:System.Threading.Tasks.Task.GetAwaiter*>.<xref:System.Runtime.CompilerServices.TaskAwaiter.GetResult*>) on a thread that has a single-threaded <xref:System.Threading.SynchronizationContext>.
+
+The sequence that causes a deadlock:
+
+1. Code on the UI thread (or an ASP.NET request thread in older ASP.NET) calls an async method and blocks on the returned task.
+1. The async method awaits an incomplete task without using `ConfigureAwait(false)`.
+1. When the awaited task completes, the continuation tries to post back to the original `SynchronizationContext`.
+1. That context's thread is blocked waiting for the task to complete—deadlock.
+
+:::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="Deadlock":::
+:::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="Deadlock":::
+
+### How to avoid deadlocks
+
+Use one or more of these strategies:
+
+- **Don't block.** Use `await` instead of `.Result` or `.Wait()`:
+
+  :::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="DeadlockFix1":::
+  :::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="DeadlockFix1":::
+
+- **Use `ConfigureAwait(false)` in library code.** When your library method doesn't need to resume on the caller's context, specify `ConfigureAwait(false)` on every `await`:
+
+  :::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="DeadlockFix2":::
+  :::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="DeadlockFix2":::
+
+  Using `ConfigureAwait(false)` tells the runtime not to marshal the continuation back to the original `SynchronizationContext`. This approach protects callers who do block, and it improves performance by avoiding unnecessary thread hops.
+
+> [!WARNING]
+> **Static constructor deadlocks.** The CLR holds a lock while running static constructors (`cctor`s). If a static constructor blocks on a task, and that task's continuation needs to run code in the same type (or a type involved in the construction chain), the continuation can't proceed because the `cctor` lock is held. Avoid blocking calls inside static constructors entirely.
+
+## Task\<Task> unwrapping
+
+When you pass an async lambda to a method like <xref:System.Threading.Tasks.TaskFactory.StartNew*>, the returned object is a `Task<Task>` (or `Task<Task<TResult>>`), not a simple `Task`. The outer task completes as soon as the async lambda hits its first yielding `await`—it doesn't wait for the inner task to finish:
+
+:::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="TaskTaskBug":::
+:::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="TaskTaskBug":::
+
+Fix this in one of three ways:
+
+- **Use <xref:System.Threading.Tasks.Task.Run*> instead.** `Task.Run` automatically unwraps `Task<Task>`:
+
+  :::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="TaskTaskFix1":::
+  :::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="TaskTaskFix1":::
+
+- **Call <xref:System.Threading.Tasks.TaskExtensions.Unwrap*> on the result:**
+
+  :::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="TaskTaskFix2":::
+  :::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="TaskTaskFix2":::
+
+- **Await twice** (first the outer task, then the inner):
+
+  :::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="TaskTaskFix3":::
+  :::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="TaskTaskFix3":::
+
+## Missing await on a task-returning call
+
+If you call a task-returning method in an `async` method without awaiting it, the method starts the asynchronous operation but doesn't wait for it to complete. The compiler emits warning CS4014 for this case:
+
+:::code language="csharp" source="./snippets/common-async-bugs/csharp/Program.cs" id="MissingAwait":::
+:::code language="vb" source="./snippets/common-async-bugs/vb/Program.vb" id="MissingAwait":::
+
+Storing the result in a variable suppresses the warning but doesn't fix the underlying bug. Always `await` the task unless you intentionally want fire-and-forget behavior.
+
+## See also
+
+- [Task-based asynchronous pattern (TAP)](task-based-asynchronous-pattern-tap.md)
+- [Async lambda pitfalls](async-lambda-pitfalls.md)
+- [Asynchronous wrappers for synchronous methods](async-wrappers-for-synchronous-methods.md)
+- [Synchronous wrappers for asynchronous methods](synchronous-wrappers-for-asynchronous-methods.md)

--- a/docs/standard/asynchronous-programming-patterns/snippets/async-lambda-pitfalls/csharp/AsyncLambdaPitfalls.csproj
+++ b/docs/standard/asynchronous-programming-patterns/snippets/async-lambda-pitfalls/csharp/AsyncLambdaPitfalls.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/asynchronous-programming-patterns/snippets/async-lambda-pitfalls/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/async-lambda-pitfalls/csharp/Program.cs
@@ -44,22 +44,22 @@ public static class TimingHelperFixed
         return sw.Elapsed.TotalSeconds / iterations;
     }
 
-    public static double Time(Func<Task> func, int iterations = 10)
+    public static async Task<double> TimeAsync(Func<Task> func, int iterations = 10)
     {
         var sw = Stopwatch.StartNew();
         for (int i = 0; i < iterations; i++)
-            func().GetAwaiter().GetResult();
+            await func();
         return sw.Elapsed.TotalSeconds / iterations;
     }
 }
 
 public static class ActionFixDemo
 {
-    public static void Run()
+    public static async Task Run()
     {
         // Now the async lambda maps to Func<Task>, and
-        // the timer waits for each iteration to complete.
-        double seconds = TimingHelperFixed.Time(async () =>
+        // the timer awaits each iteration to complete.
+        double seconds = await TimingHelperFixed.TimeAsync(async () =>
         {
             await Task.Delay(100);
         }, iterations: 3);

--- a/docs/standard/asynchronous-programming-patterns/snippets/async-lambda-pitfalls/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/async-lambda-pitfalls/csharp/Program.cs
@@ -1,0 +1,207 @@
+using System.Diagnostics;
+
+// <ActionPitfall>
+public static class TimingHelper
+{
+    public static double Time(Action action, int iterations = 10)
+    {
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < iterations; i++)
+            action();
+        return sw.Elapsed.TotalSeconds / iterations;
+    }
+}
+
+public static class ActionPitfallDemo
+{
+    public static void Run()
+    {
+        // Synchronous lambda — timing is accurate.
+        double syncSeconds = TimingHelper.Time(() =>
+        {
+            Thread.Sleep(100);
+        }, iterations: 3);
+        Console.WriteLine($"Sync: {syncSeconds:F4}s per iteration");
+
+        // Async lambda — becomes async void, returns immediately.
+        double asyncSeconds = TimingHelper.Time(async () =>
+        {
+            await Task.Delay(100);
+        }, iterations: 3);
+        Console.WriteLine($"Async (buggy): {asyncSeconds:F4}s per iteration");
+    }
+}
+// </ActionPitfall>
+
+// <ActionFix>
+public static class TimingHelperFixed
+{
+    public static double Time(Action action, int iterations = 10)
+    {
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < iterations; i++)
+            action();
+        return sw.Elapsed.TotalSeconds / iterations;
+    }
+
+    public static double Time(Func<Task> func, int iterations = 10)
+    {
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < iterations; i++)
+            func().GetAwaiter().GetResult();
+        return sw.Elapsed.TotalSeconds / iterations;
+    }
+}
+
+public static class ActionFixDemo
+{
+    public static void Run()
+    {
+        // Now the async lambda maps to Func<Task>, and
+        // the timer waits for each iteration to complete.
+        double seconds = TimingHelperFixed.Time(async () =>
+        {
+            await Task.Delay(100);
+        }, iterations: 3);
+        Console.WriteLine($"Async (fixed): {seconds:F4}s per iteration");
+    }
+}
+// </ActionFix>
+
+// <ParallelForEachBug>
+public static class ParallelForEachBugDemo
+{
+    public static void Run()
+    {
+        var sw = Stopwatch.StartNew();
+        Parallel.ForEach(Enumerable.Range(0, 10), async i =>
+        {
+            await Task.Delay(200);
+        });
+        // Completes almost immediately — the async lambdas are fire-and-forget.
+        Console.WriteLine($"Parallel.ForEach (buggy): {sw.Elapsed.TotalSeconds:F2}s");
+    }
+}
+// </ParallelForEachBug>
+
+// <ParallelForEachFix>
+public static class ParallelForEachFixDemo
+{
+    public static async Task RunAsync()
+    {
+        var sw = Stopwatch.StartNew();
+        await Parallel.ForEachAsync(
+            Enumerable.Range(0, 10),
+            new ParallelOptions { MaxDegreeOfParallelism = 4 },
+            async (i, ct) =>
+            {
+                await Task.Delay(200, ct);
+            });
+        Console.WriteLine($"Parallel.ForEachAsync (fixed): {sw.Elapsed.TotalSeconds:F2}s");
+    }
+}
+// </ParallelForEachFix>
+
+// <WhenAllAlternative>
+public static class WhenAllAlternativeDemo
+{
+    public static async Task RunAsync()
+    {
+        var sw = Stopwatch.StartNew();
+        var tasks = Enumerable.Range(0, 10)
+            .Select(async i =>
+            {
+                await Task.Delay(200);
+            });
+        await Task.WhenAll(tasks);
+        Console.WriteLine($"Task.WhenAll: {sw.Elapsed.TotalSeconds:F2}s");
+    }
+}
+// </WhenAllAlternative>
+
+// <StartNewBug>
+public static class StartNewBugDemo
+{
+    public static async Task RunAsync()
+    {
+        var sw = Stopwatch.StartNew();
+        // t is Task<Task> — the outer task completes at the first yielding await.
+        Task<Task> t = Task.Factory.StartNew(async () =>
+        {
+            await Task.Delay(1000);
+        });
+        await t; // Awaits only the outer task.
+        Console.WriteLine($"StartNew (buggy): {sw.Elapsed.TotalSeconds:F2}s");
+    }
+}
+// </StartNewBug>
+
+// <StartNewFix1>
+public static class StartNewFix1Demo
+{
+    public static async Task RunAsync()
+    {
+        var sw = Stopwatch.StartNew();
+        await Task.Run(async () =>
+        {
+            await Task.Delay(1000);
+        });
+        Console.WriteLine($"Task.Run (fixed): {sw.Elapsed.TotalSeconds:F2}s");
+    }
+}
+// </StartNewFix1>
+
+// <StartNewFix2>
+public static class StartNewFix2Demo
+{
+    public static async Task RunAsync()
+    {
+        var sw = Stopwatch.StartNew();
+        await Task.Factory.StartNew(async () =>
+        {
+            await Task.Delay(1000);
+        }).Unwrap();
+        Console.WriteLine($"StartNew + Unwrap (fixed): {sw.Elapsed.TotalSeconds:F2}s");
+    }
+}
+// </StartNewFix2>
+
+public class Program
+{
+    public static async Task Main()
+    {
+        Console.WriteLine("=== Action pitfall ===");
+        ActionPitfallDemo.Run();
+
+        Console.WriteLine();
+        Console.WriteLine("=== Action fix ===");
+        ActionFixDemo.Run();
+
+        Console.WriteLine();
+        Console.WriteLine("=== Parallel.ForEach bug ===");
+        ParallelForEachBugDemo.Run();
+
+        Console.WriteLine();
+        Console.WriteLine("=== Parallel.ForEachAsync fix ===");
+        await ParallelForEachFixDemo.RunAsync();
+
+        Console.WriteLine();
+        Console.WriteLine("=== Task.WhenAll alternative ===");
+        await WhenAllAlternativeDemo.RunAsync();
+
+        Console.WriteLine();
+        Console.WriteLine("=== StartNew bug ===");
+        await StartNewBugDemo.RunAsync();
+
+        Console.WriteLine();
+        Console.WriteLine("=== Task.Run fix ===");
+        await StartNewFix1Demo.RunAsync();
+
+        Console.WriteLine();
+        Console.WriteLine("=== StartNew + Unwrap fix ===");
+        await StartNewFix2Demo.RunAsync();
+
+        Console.WriteLine();
+        Console.WriteLine("Done.");
+    }
+}

--- a/docs/standard/asynchronous-programming-patterns/snippets/async-lambda-pitfalls/vb/AsyncLambdaPitfalls.vbproj
+++ b/docs/standard/asynchronous-programming-patterns/snippets/async-lambda-pitfalls/vb/AsyncLambdaPitfalls.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>AsyncLambdaPitfalls</RootNamespace>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/asynchronous-programming-patterns/snippets/async-lambda-pitfalls/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/async-lambda-pitfalls/vb/Program.vb
@@ -37,25 +37,25 @@ Public Module TimingHelperFixed
         Return sw.Elapsed.TotalSeconds / iterations
     End Function
 
-    Public Function Time(func As Func(Of Task), Optional iterations As Integer = 10) As Double
+    Public Async Function Time(func As Func(Of Task), Optional iterations As Integer = 10) As Task(Of Double)
         Dim sw = Stopwatch.StartNew()
         For i As Integer = 0 To iterations - 1
-            func().GetAwaiter().GetResult()
+            Await func()
         Next
         Return sw.Elapsed.TotalSeconds / iterations
     End Function
 End Module
 
 Public Module ActionFixDemo
-    Public Sub Run()
+    Public Async Function Run() As Task
         ' Now the async lambda maps to Func(Of Task), and
         ' the timer waits for each iteration to complete.
-        Dim seconds As Double = TimingHelperFixed.Time(
+        Dim seconds As Double = Await TimingHelperFixed.Time(
             Async Function()
                 Await Task.Delay(100)
             End Function, iterations:=3)
         Console.WriteLine($"Async (fixed): {seconds:F4}s per iteration")
-    End Sub
+    End Function
 End Module
 ' </ActionFix>
 

--- a/docs/standard/asynchronous-programming-patterns/snippets/async-lambda-pitfalls/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/async-lambda-pitfalls/vb/Program.vb
@@ -1,0 +1,181 @@
+Imports System.Diagnostics
+Imports System.Threading
+
+' <ActionPitfall>
+Public Module TimingHelper
+    Public Function Time(action As Action, Optional iterations As Integer = 10) As Double
+        Dim sw = Stopwatch.StartNew()
+        For i As Integer = 0 To iterations - 1
+            action()
+        Next
+        Return sw.Elapsed.TotalSeconds / iterations
+    End Function
+End Module
+
+Public Module ActionPitfallDemo
+    Public Sub Run()
+        ' Synchronous lambda — timing is accurate.
+        Dim syncSeconds As Double = TimingHelper.Time(
+            Sub() Thread.Sleep(100), iterations:=3)
+        Console.WriteLine($"Sync: {syncSeconds:F4}s per iteration")
+
+        ' Async lambda — becomes Async Sub, returns immediately.
+        Dim asyncSeconds As Double = TimingHelper.Time(
+            Async Sub() Await Task.Delay(100), iterations:=3)
+        Console.WriteLine($"Async (buggy): {asyncSeconds:F4}s per iteration")
+    End Sub
+End Module
+' </ActionPitfall>
+
+' <ActionFix>
+Public Module TimingHelperFixed
+    Public Function Time(action As Action, Optional iterations As Integer = 10) As Double
+        Dim sw = Stopwatch.StartNew()
+        For i As Integer = 0 To iterations - 1
+            action()
+        Next
+        Return sw.Elapsed.TotalSeconds / iterations
+    End Function
+
+    Public Function Time(func As Func(Of Task), Optional iterations As Integer = 10) As Double
+        Dim sw = Stopwatch.StartNew()
+        For i As Integer = 0 To iterations - 1
+            func().GetAwaiter().GetResult()
+        Next
+        Return sw.Elapsed.TotalSeconds / iterations
+    End Function
+End Module
+
+Public Module ActionFixDemo
+    Public Sub Run()
+        ' Now the async lambda maps to Func(Of Task), and
+        ' the timer waits for each iteration to complete.
+        Dim seconds As Double = TimingHelperFixed.Time(
+            Async Function()
+                Await Task.Delay(100)
+            End Function, iterations:=3)
+        Console.WriteLine($"Async (fixed): {seconds:F4}s per iteration")
+    End Sub
+End Module
+' </ActionFix>
+
+' <ParallelForEachBug>
+Public Module ParallelForEachBugDemo
+    Public Sub Run()
+        Dim sw = Stopwatch.StartNew()
+        Parallel.ForEach(Enumerable.Range(0, 10),
+            Async Sub(i As Integer)
+                Await Task.Delay(200)
+            End Sub)
+        ' Completes almost immediately — the async lambdas are fire-and-forget.
+        Console.WriteLine($"Parallel.ForEach (buggy): {sw.Elapsed.TotalSeconds:F2}s")
+    End Sub
+End Module
+' </ParallelForEachBug>
+
+' <ParallelForEachFix>
+Public Module ParallelForEachFixDemo
+    Private Function ProcessItemAsync(i As Integer, ct As CancellationToken) As ValueTask
+        Return New ValueTask(Task.Delay(200, ct))
+    End Function
+
+    Public Async Function RunAsync() As Task
+        Dim sw = Stopwatch.StartNew()
+        Await Parallel.ForEachAsync(
+            Enumerable.Range(0, 10),
+            New ParallelOptions With {.MaxDegreeOfParallelism = 4},
+            AddressOf ProcessItemAsync)
+        Console.WriteLine($"Parallel.ForEachAsync (fixed): {sw.Elapsed.TotalSeconds:F2}s")
+    End Function
+End Module
+' </ParallelForEachFix>
+
+' <WhenAllAlternative>
+Public Module WhenAllAlternativeDemo
+    Public Async Function RunAsync() As Task
+        Dim sw = Stopwatch.StartNew()
+        Dim tasks = Enumerable.Range(0, 10).
+            Select(Async Function(i)
+                       Await Task.Delay(200)
+                   End Function)
+        Await Task.WhenAll(tasks)
+        Console.WriteLine($"Task.WhenAll: {sw.Elapsed.TotalSeconds:F2}s")
+    End Function
+End Module
+' </WhenAllAlternative>
+
+' <StartNewBug>
+Public Module StartNewBugDemo
+    Public Async Function RunAsync() As Task
+        Dim sw = Stopwatch.StartNew()
+        ' t is Task(Of Task) — the outer task completes at the first yielding Await.
+        Dim t As Task(Of Task) = Task.Factory.StartNew(Async Function()
+                                                           Await Task.Delay(1000)
+                                                       End Function)
+        Await t ' Awaits only the outer task.
+        Console.WriteLine($"StartNew (buggy): {sw.Elapsed.TotalSeconds:F2}s")
+    End Function
+End Module
+' </StartNewBug>
+
+' <StartNewFix1>
+Public Module StartNewFix1Demo
+    Public Async Function RunAsync() As Task
+        Dim sw = Stopwatch.StartNew()
+        Await Task.Run(Async Function()
+                           Await Task.Delay(1000)
+                       End Function)
+        Console.WriteLine($"Task.Run (fixed): {sw.Elapsed.TotalSeconds:F2}s")
+    End Function
+End Module
+' </StartNewFix1>
+
+' <StartNewFix2>
+Public Module StartNewFix2Demo
+    Public Async Function RunAsync() As Task
+        Dim sw = Stopwatch.StartNew()
+        Await Task.Factory.StartNew(Async Function()
+                                        Await Task.Delay(1000)
+                                    End Function).Unwrap()
+        Console.WriteLine($"StartNew + Unwrap (fixed): {sw.Elapsed.TotalSeconds:F2}s")
+    End Function
+End Module
+' </StartNewFix2>
+
+Module Program
+    Sub Main()
+        Console.WriteLine("=== Action pitfall ===")
+        ActionPitfallDemo.Run()
+
+        Console.WriteLine()
+        Console.WriteLine("=== Action fix ===")
+        ActionFixDemo.Run()
+
+        Console.WriteLine()
+        Console.WriteLine("=== Parallel.ForEach bug ===")
+        ParallelForEachBugDemo.Run()
+
+        Console.WriteLine()
+        Console.WriteLine("=== Parallel.ForEachAsync fix ===")
+        ParallelForEachFixDemo.RunAsync().Wait()
+
+        Console.WriteLine()
+        Console.WriteLine("=== Task.WhenAll alternative ===")
+        WhenAllAlternativeDemo.RunAsync().Wait()
+
+        Console.WriteLine()
+        Console.WriteLine("=== StartNew bug ===")
+        StartNewBugDemo.RunAsync().Wait()
+
+        Console.WriteLine()
+        Console.WriteLine("=== Task.Run fix ===")
+        StartNewFix1Demo.RunAsync().Wait()
+
+        Console.WriteLine()
+        Console.WriteLine("=== StartNew + Unwrap fix ===")
+        StartNewFix2Demo.RunAsync().Wait()
+
+        Console.WriteLine()
+        Console.WriteLine("Done.")
+    End Sub
+End Module

--- a/docs/standard/asynchronous-programming-patterns/snippets/common-async-bugs/csharp/CommonAsyncBugs.csproj
+++ b/docs/standard/asynchronous-programming-patterns/snippets/common-async-bugs/csharp/CommonAsyncBugs.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/asynchronous-programming-patterns/snippets/common-async-bugs/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/common-async-bugs/csharp/Program.cs
@@ -1,0 +1,216 @@
+using System.Diagnostics;
+
+// <SyncExecution>
+public static class SyncExecutionExample
+{
+    public static async Task<int> ComputeAsync()
+    {
+        // No await in this method — it runs entirely synchronously.
+        return 42;
+    }
+}
+// </SyncExecution>
+
+// <OffloadCorrectly>
+public static class OffloadExample
+{
+    public static int ComputeIntensive()
+    {
+        int sum = 0;
+        for (int i = 0; i < 1_000; i++)
+            sum += i;
+        return sum;
+    }
+
+    public static Task<int> ComputeOnThreadPoolAsync()
+    {
+        return Task.Run(() => ComputeIntensive());
+    }
+}
+// </OffloadCorrectly>
+
+// <AsyncVoid>
+public static class AsyncVoidExample
+{
+    // BAD: async void — can't be awaited.
+    public static async void DoWorkBadAsync()
+    {
+        await Task.Delay(100);
+    }
+
+    // GOOD: async Task — callers can await this.
+    public static async Task DoWorkGoodAsync()
+    {
+        await Task.Delay(100);
+    }
+}
+// </AsyncVoid>
+
+// <Deadlock>
+public static class DeadlockExample
+{
+    public static async Task<string> GetDataAsync()
+    {
+        // Without ConfigureAwait(false), this continuation
+        // posts back to the original SynchronizationContext.
+        await Task.Delay(100);
+        return "data";
+    }
+
+    public static void CallerThatDeadlocks()
+    {
+        // On a single-threaded SynchronizationContext (e.g. UI thread),
+        // the following line deadlocks because the continuation needs
+        // the same thread that .Result is blocking.
+        string result = GetDataAsync().Result;
+    }
+}
+// </Deadlock>
+
+// <DeadlockFix1>
+public static class DeadlockFix1
+{
+    public static async Task CallerFixedAsync()
+    {
+        // Use await instead of .Result
+        string result = await DeadlockExample.GetDataAsync();
+        Console.WriteLine(result);
+    }
+}
+// </DeadlockFix1>
+
+// <DeadlockFix2>
+public static class DeadlockFix2
+{
+    public static async Task<string> GetDataSafeAsync()
+    {
+        await Task.Delay(100).ConfigureAwait(false);
+        return "data";
+    }
+}
+// </DeadlockFix2>
+
+// <TaskTaskBug>
+public static class TaskTaskBugExample
+{
+    public static async Task DemoAsync()
+    {
+        var sw = Stopwatch.StartNew();
+        // StartNew returns Task<Task>, not Task.
+        // The outer task completes immediately when the lambda yields.
+        await Task.Factory.StartNew(async () =>
+        {
+            await Task.Delay(1000);
+        });
+        // Elapsed shows ~0 seconds, not ~1 second.
+        Console.WriteLine($"Elapsed: {sw.Elapsed.TotalSeconds:F2}s");
+    }
+}
+// </TaskTaskBug>
+
+// <TaskTaskFix1>
+public static class TaskTaskFix1
+{
+    public static async Task DemoAsync()
+    {
+        var sw = Stopwatch.StartNew();
+        await Task.Run(async () =>
+        {
+            await Task.Delay(1000);
+        });
+        Console.WriteLine($"Elapsed: {sw.Elapsed.TotalSeconds:F2}s");
+    }
+}
+// </TaskTaskFix1>
+
+// <TaskTaskFix2>
+public static class TaskTaskFix2
+{
+    public static async Task DemoAsync()
+    {
+        var sw = Stopwatch.StartNew();
+        await Task.Factory.StartNew(async () =>
+        {
+            await Task.Delay(1000);
+        }).Unwrap();
+        Console.WriteLine($"Elapsed: {sw.Elapsed.TotalSeconds:F2}s");
+    }
+}
+// </TaskTaskFix2>
+
+// <TaskTaskFix3>
+public static class TaskTaskFix3
+{
+    public static async Task DemoAsync()
+    {
+        var sw = Stopwatch.StartNew();
+        Task<Task> outerTask = Task.Factory.StartNew(async () =>
+        {
+            await Task.Delay(1000);
+        });
+        Task innerTask = await outerTask;
+        await innerTask;
+        Console.WriteLine($"Elapsed: {sw.Elapsed.TotalSeconds:F2}s");
+    }
+}
+// </TaskTaskFix3>
+
+// <MissingAwait>
+public static class MissingAwaitExample
+{
+    // BAD: Task.Delay is started but never awaited.
+    public static async Task PauseOneSecondBuggyAsync()
+    {
+        Task.Delay(1000); // CS4014 warning
+    }
+
+    // GOOD: await the task.
+    public static async Task PauseOneSecondAsync()
+    {
+        await Task.Delay(1000);
+    }
+}
+// </MissingAwait>
+
+public class Program
+{
+    public static async Task Main()
+    {
+        Console.WriteLine("--- SyncExecution demo ---");
+        int result1 = await SyncExecutionExample.ComputeAsync();
+        Console.WriteLine($"Result: {result1}");
+
+        Console.WriteLine("--- OffloadCorrectly demo ---");
+        int result2 = await OffloadExample.ComputeOnThreadPoolAsync();
+        Console.WriteLine($"Result: {result2}");
+
+        Console.WriteLine("--- AsyncVoid demo ---");
+        await AsyncVoidExample.DoWorkGoodAsync();
+        Console.WriteLine("DoWorkGoodAsync completed.");
+
+        Console.WriteLine("--- DeadlockFix1 demo ---");
+        await DeadlockFix1.CallerFixedAsync();
+
+        Console.WriteLine("--- DeadlockFix2 demo ---");
+        string safe = await DeadlockFix2.GetDataSafeAsync();
+        Console.WriteLine($"Safe result: {safe}");
+
+        Console.WriteLine("--- TaskTaskBug demo (outer task only) ---");
+        await TaskTaskBugExample.DemoAsync();
+
+        Console.WriteLine("--- TaskTaskFix1 (Task.Run) ---");
+        await TaskTaskFix1.DemoAsync();
+
+        Console.WriteLine("--- TaskTaskFix2 (Unwrap) ---");
+        await TaskTaskFix2.DemoAsync();
+
+        Console.WriteLine("--- TaskTaskFix3 (double await) ---");
+        await TaskTaskFix3.DemoAsync();
+
+        Console.WriteLine("--- MissingAwait demo ---");
+        await MissingAwaitExample.PauseOneSecondAsync();
+        Console.WriteLine("PauseOneSecondAsync completed.");
+
+        Console.WriteLine("Done.");
+    }
+}

--- a/docs/standard/asynchronous-programming-patterns/snippets/common-async-bugs/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/common-async-bugs/csharp/Program.cs
@@ -3,10 +3,10 @@ using System.Diagnostics;
 // <SyncExecution>
 public static class SyncExecutionExample
 {
-    public static async Task<int> ComputeAsync()
+    public static Task<int> ComputeAsync()
     {
         // No await in this method — it runs entirely synchronously.
-        return 42;
+        return Task.FromResult(42);
     }
 }
 // </SyncExecution>

--- a/docs/standard/asynchronous-programming-patterns/snippets/common-async-bugs/vb/CommonAsyncBugs.vbproj
+++ b/docs/standard/asynchronous-programming-patterns/snippets/common-async-bugs/vb/CommonAsyncBugs.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>CommonAsyncBugs</RootNamespace>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/asynchronous-programming-patterns/snippets/common-async-bugs/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/common-async-bugs/vb/Program.vb
@@ -2,9 +2,9 @@ Imports System.Diagnostics
 
 ' <SyncExecution>
 Public Module SyncExecutionExample
-    Public Async Function ComputeAsync() As Task(Of Integer)
+    Public Function ComputeAsync() As Task(Of Integer)
         ' No Await in this method — it runs entirely synchronously.
-        Return 42
+        Return Task.FromResult(42)
     End Function
 End Module
 ' </SyncExecution>

--- a/docs/standard/asynchronous-programming-patterns/snippets/common-async-bugs/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/common-async-bugs/vb/Program.vb
@@ -1,0 +1,185 @@
+Imports System.Diagnostics
+
+' <SyncExecution>
+Public Module SyncExecutionExample
+    Public Async Function ComputeAsync() As Task(Of Integer)
+        ' No Await in this method — it runs entirely synchronously.
+        Return 42
+    End Function
+End Module
+' </SyncExecution>
+
+' <OffloadCorrectly>
+Public Module OffloadExample
+    Public Function ComputeIntensive() As Integer
+        Dim sum As Integer = 0
+        For i As Integer = 0 To 999
+            sum += i
+        Next
+        Return sum
+    End Function
+
+    Public Function ComputeOnThreadPoolAsync() As Task(Of Integer)
+        Return Task.Run(Function() ComputeIntensive())
+    End Function
+End Module
+' </OffloadCorrectly>
+
+' <AsyncVoid>
+Public Module AsyncVoidExample
+    ' BAD: Async Sub — can't be awaited.
+    Public Async Sub DoWorkBadAsync()
+        Await Task.Delay(100)
+    End Sub
+
+    ' GOOD: Async Function returning Task — callers can await this.
+    Public Async Function DoWorkGoodAsync() As Task
+        Await Task.Delay(100)
+    End Function
+End Module
+' </AsyncVoid>
+
+' <Deadlock>
+Public Module DeadlockExample
+    Public Async Function GetDataAsync() As Task(Of String)
+        ' Without ConfigureAwait(False), this continuation
+        ' posts back to the original SynchronizationContext.
+        Await Task.Delay(100)
+        Return "data"
+    End Function
+
+    Public Sub CallerThatDeadlocks()
+        ' On a single-threaded SynchronizationContext (e.g. UI thread),
+        ' the following line deadlocks because the continuation needs
+        ' the same thread that .Result is blocking.
+        Dim result As String = GetDataAsync().Result
+    End Sub
+End Module
+' </Deadlock>
+
+' <DeadlockFix1>
+Public Module DeadlockFix1
+    Public Async Function CallerFixedAsync() As Task
+        ' Use Await instead of .Result
+        Dim result As String = Await DeadlockExample.GetDataAsync()
+        Console.WriteLine(result)
+    End Function
+End Module
+' </DeadlockFix1>
+
+' <DeadlockFix2>
+Public Module DeadlockFix2
+    Public Async Function GetDataSafeAsync() As Task(Of String)
+        Await Task.Delay(100).ConfigureAwait(False)
+        Return "data"
+    End Function
+End Module
+' </DeadlockFix2>
+
+' <TaskTaskBug>
+Public Module TaskTaskBugExample
+    Public Async Function DemoAsync() As Task
+        Dim sw = Stopwatch.StartNew()
+        ' StartNew returns Task(Of Task), not Task.
+        ' The outer task completes immediately when the lambda yields.
+        Await Task.Factory.StartNew(Async Function()
+                                        Await Task.Delay(1000)
+                                    End Function)
+        ' Elapsed shows ~0 seconds, not ~1 second.
+        Console.WriteLine($"Elapsed: {sw.Elapsed.TotalSeconds:F2}s")
+    End Function
+End Module
+' </TaskTaskBug>
+
+' <TaskTaskFix1>
+Public Module TaskTaskFix1
+    Public Async Function DemoAsync() As Task
+        Dim sw = Stopwatch.StartNew()
+        Await Task.Run(Async Function()
+                           Await Task.Delay(1000)
+                       End Function)
+        Console.WriteLine($"Elapsed: {sw.Elapsed.TotalSeconds:F2}s")
+    End Function
+End Module
+' </TaskTaskFix1>
+
+' <TaskTaskFix2>
+Public Module TaskTaskFix2
+    Public Async Function DemoAsync() As Task
+        Dim sw = Stopwatch.StartNew()
+        Await Task.Factory.StartNew(Async Function()
+                                        Await Task.Delay(1000)
+                                    End Function).Unwrap()
+        Console.WriteLine($"Elapsed: {sw.Elapsed.TotalSeconds:F2}s")
+    End Function
+End Module
+' </TaskTaskFix2>
+
+' <TaskTaskFix3>
+Public Module TaskTaskFix3
+    Public Async Function DemoAsync() As Task
+        Dim sw = Stopwatch.StartNew()
+        Dim outerTask As Task(Of Task) = Task.Factory.StartNew(Async Function()
+                                                                   Await Task.Delay(1000)
+                                                               End Function)
+        Dim innerTask As Task = Await outerTask
+        Await innerTask
+        Console.WriteLine($"Elapsed: {sw.Elapsed.TotalSeconds:F2}s")
+    End Function
+End Module
+' </TaskTaskFix3>
+
+' <MissingAwait>
+Public Module MissingAwaitExample
+    ' BAD: Task.Delay is started but never awaited.
+    Public Async Function PauseOneSecondBuggyAsync() As Task
+        Task.Delay(1000) ' Warning BC42358
+    End Function
+
+    ' GOOD: Await the task.
+    Public Async Function PauseOneSecondAsync() As Task
+        Await Task.Delay(1000)
+    End Function
+End Module
+' </MissingAwait>
+
+Module Program
+    Sub Main()
+        Console.WriteLine("--- SyncExecution demo ---")
+        Dim result1 As Integer = SyncExecutionExample.ComputeAsync().Result
+        Console.WriteLine($"Result: {result1}")
+
+        Console.WriteLine("--- OffloadCorrectly demo ---")
+        Dim result2 As Integer = OffloadExample.ComputeOnThreadPoolAsync().Result
+        Console.WriteLine($"Result: {result2}")
+
+        Console.WriteLine("--- AsyncVoid demo ---")
+        AsyncVoidExample.DoWorkGoodAsync().Wait()
+        Console.WriteLine("DoWorkGoodAsync completed.")
+
+        Console.WriteLine("--- DeadlockFix1 demo ---")
+        DeadlockFix1.CallerFixedAsync().Wait()
+
+        Console.WriteLine("--- DeadlockFix2 demo ---")
+        Dim safe As String = DeadlockFix2.GetDataSafeAsync().Result
+        Console.WriteLine($"Safe result: {safe}")
+
+        Console.WriteLine("--- TaskTaskBug demo (outer task only) ---")
+        TaskTaskBugExample.DemoAsync().Wait()
+
+        Console.WriteLine("--- TaskTaskFix1 (Task.Run) ---")
+        TaskTaskFix1.DemoAsync().Wait()
+
+        Console.WriteLine("--- TaskTaskFix2 (Unwrap) ---")
+        TaskTaskFix2.DemoAsync().Wait()
+
+        Console.WriteLine("--- TaskTaskFix3 (double await) ---")
+        TaskTaskFix3.DemoAsync().Wait()
+
+        Console.WriteLine("--- MissingAwait demo ---")
+        MissingAwaitExample.PauseOneSecondAsync().Wait()
+        Console.WriteLine("PauseOneSecondAsync completed.")
+
+        Console.WriteLine("Done.")
+    End Sub
+End Module


### PR DESCRIPTION
Contributes to #17714  

1. Create `common-async-bugs.md` — from "Psychic Debugging of Async Methods." Covers the 4 most common bugs: method runs synchronously despite `async`, can't await `void`, deadlocks with `SynchronizationContext`, `Task<Task>` unwrapping. Also incorporate mentions of UI deadlocks (from "Await and UI and deadlocks") and static constructor deadlocks as warning notes.
1. Create `async-lambda-pitfalls.md` — from "Potential pitfalls to avoid when passing around async lambdas." Covers: async lambdas assigned to `Action` delegates (becomes async void), `Parallel.ForEach` with async lambdas, `Task.Factory.StartNew` returning `Task<Task>`.
1. Decompose relevant Async/Await FAQ content into both articles (FAQ answers about async void, `Task.Wait` vs `await`, the `async` keyword not forcing asynchrony).
1. Add both to TOC. Consider grouping under a new "Best practices and troubleshooting" sub-section.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/navigate/advanced-programming/toc.yml](https://github.com/dotnet/docs/blob/ccd9b6aebe2b9c0e979596c042d00a777692980d/docs/navigate/advanced-programming/toc.yml) | [docs/navigate/advanced-programming/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/advanced-programming/toc?branch=pr-en-us-52959) |
| [docs/standard/asynchronous-programming-patterns/async-lambda-pitfalls.md](https://github.com/dotnet/docs/blob/ccd9b6aebe2b9c0e979596c042d00a777692980d/docs/standard/asynchronous-programming-patterns/async-lambda-pitfalls.md) | [Async lambda pitfalls](https://review.learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/async-lambda-pitfalls?branch=pr-en-us-52959) |
| [docs/standard/asynchronous-programming-patterns/common-async-bugs.md](https://github.com/dotnet/docs/blob/ccd9b6aebe2b9c0e979596c042d00a777692980d/docs/standard/asynchronous-programming-patterns/common-async-bugs.md) | [Common async/await bugs](https://review.learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/common-async-bugs?branch=pr-en-us-52959) |


<!-- PREVIEW-TABLE-END -->