### PR TITLE
Coerce copilot to avoid emdash everywhere

### DIFF
--- a/.github/agents/docseditor.agent.md
+++ b/.github/agents/docseditor.agent.md
@@ -230,6 +230,9 @@ When editing, focus on these areas in order of priority:
 - ALWAYS use one space after periods, colons, question marks
 - ALWAYS use no spaces around dashes: "Use pipelines—logical groups—to consolidate"
 - ALWAYS add blank lines around markdown elements (don't add extra if they exist)
+- TRY to avoid emdash and the various alternative dash characters; try to use other punctuation or formatting to achieve the same effect. Choose words over characters when possible
+- OK to use compound adjectives with hyphens
+- OK to use emdash mid-sentence for a clause or example; use sparingly
 
 ## API REFERENCES
 

--- a/.github/agents/docseditor.agent.md
+++ b/.github/agents/docseditor.agent.md
@@ -228,11 +228,10 @@ When editing, focus on these areas in order of priority:
 
 ### Spacing and Punctuation
 - ALWAYS use one space after periods, colons, question marks
-- ALWAYS use no spaces around dashes: "Use pipelines—logical groups—to consolidate"
 - ALWAYS add blank lines around markdown elements (don't add extra if they exist)
-- TRY to avoid emdash and the various alternative dash characters; try to use other punctuation or formatting to achieve the same effect. Choose words over characters when possible
-- OK to use compound adjectives with hyphens
-- OK to use emdash mid-sentence for a clause or example; use sparingly
+- TRY to avoid em dashes (—) where possible; prefer other punctuation, formatting, or clearer wording
+- If you must use an em dash (—), use no spaces around it: "Use pipelines—logical groups—to consolidate"
+- OK to use hyphens (-) in compound adjectives
 
 ## API REFERENCES
 


### PR DESCRIPTION
## Summary

Copilot used the agent to write some docs and I noticed it was heavily relying on emdash everywhere which doesn't make for good reading. These instructions seemed to have helped it avoid it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/agents/docseditor.agent.md](https://github.com/dotnet/docs/blob/43cc81393d6bbb695e03bc419a6b8fb4284fb465/.github/agents/docseditor.agent.md) | [Article Writing and Editing Instructions for LLMs](https://review.learn.microsoft.com/en-us/dotnet/.github/agents/docseditor.agent?branch=pr-en-us-52978) |


<!-- PREVIEW-TABLE-END -->