### PR TITLE
Fix typo: "how to uses" → "how to use"

### DIFF
--- a/docs/standard/parallel-programming/how-to-write-messages-to-and-read-messages-from-a-dataflow-block.md
+++ b/docs/standard/parallel-programming/how-to-write-messages-to-and-read-messages-from-a-dataflow-block.md
@@ -13,7 +13,7 @@ ms.assetid: 1a9bf078-aa82-46eb-b95a-f87237f028c5
 
 # How to: Write and read messages from a Dataflow block
 
-This article describes how to use the Task Parallel Library (TPL) Dataflow Library to write messages to and read messages from a dataflow block. The TPL Dataflow Library provides both synchronous and asynchronous methods for writing messages to and reading messages from a dataflow block. This article shows how to uses the <xref:System.Threading.Tasks.Dataflow.BufferBlock`1?displayProperty=nameWithType> class. The <xref:System.Threading.Tasks.Dataflow.BufferBlock`1> class buffers messages and behaves as both a message source and a message target.
+This article describes how to use the Task Parallel Library (TPL) Dataflow Library to write messages to and read messages from a dataflow block. The TPL Dataflow Library provides both synchronous and asynchronous methods for writing messages to and reading messages from a dataflow block. This article shows how to use the <xref:System.Threading.Tasks.Dataflow.BufferBlock`1?displayProperty=nameWithType> class. The <xref:System.Threading.Tasks.Dataflow.BufferBlock`1> class buffers messages and behaves as both a message source and a message target.
 
 [!INCLUDE [tpl-install-instructions](../../../includes/tpl-install-instructions.md)]
 


### PR DESCRIPTION
## Summary
Fix a typo in the article body. 
Changed "how to uses" to "how to use".


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/parallel-programming/how-to-write-messages-to-and-read-messages-from-a-dataflow-block.md](https://github.com/dotnet/docs/blob/dbd3f48c3c08665e2d432e4780d22c72cd384849/docs/standard/parallel-programming/how-to-write-messages-to-and-read-messages-from-a-dataflow-block.md) | [How to: Write and read messages from a Dataflow block](https://review.learn.microsoft.com/en-us/dotnet/standard/parallel-programming/how-to-write-messages-to-and-read-messages-from-a-dataflow-block?branch=pr-en-us-52991) |

<!-- PREVIEW-TABLE-END -->