### PR TITLE
Add missing C# 8.0 feature: lambda parameter shadowing

### DIFF
--- a/docs/csharp/whats-new/csharp-version-history.md
+++ b/docs/csharp/whats-new/csharp-version-history.md
@@ -212,6 +212,7 @@ C# 8.0 is the first major C# release that specifically targets .NET Core. Some f
   - Positional patterns
 - [Using declarations](../language-reference/statements/using.md)
 - [Static local functions](../programming-guide/classes-and-structs/local-functions.md)
+_ [Lambda and local function parameters can shadow names from the enclosing scope](../language-reference/declarations/scope.md)
 - [Disposable ref structs](../language-reference/builtin-types/ref-struct.md)
 - [Nullable reference types](../language-reference/builtin-types/nullable-reference-types.md)
 - [Asynchronous streams](../language-reference/statements/iteration-statements.md#await-foreach)


### PR DESCRIPTION
## Summary
Add missing C# 8.0 feature to the version history.

Lambda and local function parameters can shadow names 
from the enclosing scope was not listed in the C# 8.0 
features list.

Fixes #52972


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-version-history.md](https://github.com/dotnet/docs/blob/8753d37ee5839dd65d4a5205db7db86d5659ee66/docs/csharp/whats-new/csharp-version-history.md) | [The history of C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history?branch=pr-en-us-52992) |

<!-- PREVIEW-TABLE-END -->