### PR TITLE
Task completion and exception handling

### DIFF
--- a/docs/navigate/advanced-programming/toc.yml
+++ b/docs/navigate/advanced-programming/toc.yml
@@ -30,6 +30,10 @@ items:
         href: ../../standard/asynchronous-programming-patterns/common-async-bugs.md
       - name: Async lambda pitfalls
         href: ../../standard/asynchronous-programming-patterns/async-lambda-pitfalls.md
+      - name: Task exception handling
+        href: ../../standard/asynchronous-programming-patterns/task-exception-handling.md
+      - name: Complete your tasks
+        href: ../../standard/asynchronous-programming-patterns/complete-your-tasks.md
   - name: Event-based asynchronous pattern (EAP)
     items:
     - name: Documentation overview

--- a/docs/standard/asynchronous-programming-patterns/complete-your-tasks.md
+++ b/docs/standard/asynchronous-programming-patterns/complete-your-tasks.md
@@ -16,38 +16,38 @@ helpviewer_keywords:
 
 # Complete your tasks
 
-When you expose a task from <xref:System.Threading.Tasks.TaskCompletionSource`1>, you own the task's lifetime. Complete that task on every path. If any path skips completion, callers wait forever.
+When you expose a task from <xref:System.Threading.Tasks.TaskCompletionSource%601>, you own the task's lifetime. Complete that task on every path. If any path skips completion, callers wait forever.
 
 ## Complete every code path
 
-This bug appears often: code catches an exception, logs it, and forgets to call `SetException` or `TrySetException`.
-
-:::code language="csharp" source="./snippets/complete-your-tasks/csharp/Program.cs" id="MissingSetExceptionBug":::
-:::code language="vb" source="./snippets/complete-your-tasks/vb/Program.vb" id="MissingSetExceptionBug":::
-
-Fix the bug by completing the task in success and failure paths. Use a `finally` block for cleanup logic that must always run.
+Always complete the task in success and failure paths. Use a `finally` block for cleanup logic that must always run. Here's the correct approach:
 
 :::code language="csharp" source="./snippets/complete-your-tasks/csharp/Program.cs" id="MissingSetExceptionFix":::
 :::code language="vb" source="./snippets/complete-your-tasks/vb/Program.vb" id="MissingSetExceptionFix":::
 
+The following code catches an exception, logs it, and forgets to call <xref:System.Threading.Tasks.TaskCompletionSource%601.SetException%2A> or <xref:System.Threading.Tasks.TaskCompletionSource%601.TrySetException%2A>. This bug appears often and causes callers to wait forever. For more details about exception handling with tasks, see [Task exception handling](task-exception-handling.md).
+
+:::code language="csharp" source="./snippets/complete-your-tasks/csharp/Program.cs" id="MissingSetExceptionBug":::
+:::code language="vb" source="./snippets/complete-your-tasks/vb/Program.vb" id="MissingSetExceptionBug":::
+
 ## Prefer `TrySet*` in completion races
 
-Concurrent paths often race to complete the same `TaskCompletionSource`. `SetResult`, `SetException`, and `SetCanceled` throw if the task already completed. In race-prone code, use `TrySetResult`, `TrySetException`, and `TrySetCanceled`.
+Concurrent paths often race to complete the same `TaskCompletionSource`. <xref:System.Threading.Tasks.TaskCompletionSource%601.SetResult%2A>, <xref:System.Threading.Tasks.TaskCompletionSource%601.SetException%2A>, and <xref:System.Threading.Tasks.TaskCompletionSource%601.SetCanceled%2A> throw if the task already completed. In race-prone code, use <xref:System.Threading.Tasks.TaskCompletionSource%601.TrySetResult%2A>, <xref:System.Threading.Tasks.TaskCompletionSource%601.TrySetException%2A>, and <xref:System.Threading.Tasks.TaskCompletionSource%601.TrySetCanceled%2A>. For more patterns to avoid in concurrent scenarios, see [Common async/await bugs](common-async-bugs.md).
 
 :::code language="csharp" source="./snippets/complete-your-tasks/csharp/Program.cs" id="TrySetRace":::
 :::code language="vb" source="./snippets/complete-your-tasks/vb/Program.vb" id="TrySetRace":::
 
 ## Don't drop references during reset
 
-Another common bug appears in resettable async primitives. If you replace a `TaskCompletionSource` instance before completing the previous one, waiters that hold the old task might never complete.
-
-:::code language="csharp" source="./snippets/complete-your-tasks/csharp/Program.cs" id="ResetBug":::
-:::code language="vb" source="./snippets/complete-your-tasks/vb/Program.vb" id="ResetBug":::
-
-Fix the reset path by atomically swapping references and completing the previous task (for example, with cancellation).
+A common bug appears in resettable async primitives. Fix the reset path by atomically swapping references and completing the previous task (for example, with cancellation):
 
 :::code language="csharp" source="./snippets/complete-your-tasks/csharp/Program.cs" id="ResetFix":::
 :::code language="vb" source="./snippets/complete-your-tasks/vb/Program.vb" id="ResetFix":::
+
+**Don't do this:** If you replace a `TaskCompletionSource` instance before completing the previous one, waiters that hold the old task might never complete.
+
+:::code language="csharp" source="./snippets/complete-your-tasks/csharp/Program.cs" id="ResetBug":::
+:::code language="vb" source="./snippets/complete-your-tasks/vb/Program.vb" id="ResetBug":::
 
 ## Checklist
 

--- a/docs/standard/asynchronous-programming-patterns/complete-your-tasks.md
+++ b/docs/standard/asynchronous-programming-patterns/complete-your-tasks.md
@@ -20,7 +20,7 @@ When you expose a task from <xref:System.Threading.Tasks.TaskCompletionSource%60
 
 ## Complete every code path
 
-Always complete the task in success and failure paths. Use a `finally` block for cleanup logic that must always run. Here's the correct approach:
+Always complete the task in success and failure paths. Use a `catch` block for cleanup logic when the task fails. Use a `finally` block for cleanup logic that must always run. The following code block shows adding cleanup for a failure path:
 
 :::code language="csharp" source="./snippets/complete-your-tasks/csharp/Program.cs" id="MissingSetExceptionFix":::
 :::code language="vb" source="./snippets/complete-your-tasks/vb/Program.vb" id="MissingSetExceptionFix":::

--- a/docs/standard/asynchronous-programming-patterns/complete-your-tasks.md
+++ b/docs/standard/asynchronous-programming-patterns/complete-your-tasks.md
@@ -1,0 +1,63 @@
+---
+title: "Complete your tasks"
+description: Learn how to complete TaskCompletionSource tasks on every code path, avoid hangs, and handle reset scenarios safely.
+ms.date: 04/14/2026
+ai-usage: ai-assisted
+dev_langs:
+  - "csharp"
+  - "vb"
+helpviewer_keywords:
+  - "TaskCompletionSource"
+  - "SetException"
+  - "TrySetResult"
+  - "async hangs"
+  - "resettable async primitives"
+---
+
+# Complete your tasks
+
+When you expose a task from <xref:System.Threading.Tasks.TaskCompletionSource`1>, you own the task's lifetime. Complete that task on every path. If any path skips completion, callers wait forever.
+
+## Complete every code path
+
+This bug appears often: code catches an exception, logs it, and forgets to call `SetException` or `TrySetException`.
+
+:::code language="csharp" source="./snippets/complete-your-tasks/csharp/Program.cs" id="MissingSetExceptionBug":::
+:::code language="vb" source="./snippets/complete-your-tasks/vb/Program.vb" id="MissingSetExceptionBug":::
+
+Fix the bug by completing the task in success and failure paths. Use a `finally` block for cleanup logic that must always run.
+
+:::code language="csharp" source="./snippets/complete-your-tasks/csharp/Program.cs" id="MissingSetExceptionFix":::
+:::code language="vb" source="./snippets/complete-your-tasks/vb/Program.vb" id="MissingSetExceptionFix":::
+
+## Prefer `TrySet*` in completion races
+
+Concurrent paths often race to complete the same `TaskCompletionSource`. `SetResult`, `SetException`, and `SetCanceled` throw if the task already completed. In race-prone code, use `TrySetResult`, `TrySetException`, and `TrySetCanceled`.
+
+:::code language="csharp" source="./snippets/complete-your-tasks/csharp/Program.cs" id="TrySetRace":::
+:::code language="vb" source="./snippets/complete-your-tasks/vb/Program.vb" id="TrySetRace":::
+
+## Don't drop references during reset
+
+Another common bug appears in resettable async primitives. If you replace a `TaskCompletionSource` instance before completing the previous one, waiters that hold the old task might never complete.
+
+:::code language="csharp" source="./snippets/complete-your-tasks/csharp/Program.cs" id="ResetBug":::
+:::code language="vb" source="./snippets/complete-your-tasks/vb/Program.vb" id="ResetBug":::
+
+Fix the reset path by atomically swapping references and completing the previous task (for example, with cancellation).
+
+:::code language="csharp" source="./snippets/complete-your-tasks/csharp/Program.cs" id="ResetFix":::
+:::code language="vb" source="./snippets/complete-your-tasks/vb/Program.vb" id="ResetFix":::
+
+## Checklist
+
+- Complete every exposed `TaskCompletionSource` task on success, failure, and cancellation paths.
+- Use `TrySet*` APIs in paths that might race.
+- During reset, complete or cancel the old task before you drop its reference.
+- Add timeout-based tests so hangs fail fast in CI.
+
+## See also
+
+- [Task exception handling](task-exception-handling.md)
+- [Implement the TAP](implementing-the-task-based-asynchronous-pattern.md)
+- [Common async/await bugs](common-async-bugs.md)

--- a/docs/standard/asynchronous-programming-patterns/snippets/complete-your-tasks/csharp/CompleteYourTasks.csproj
+++ b/docs/standard/asynchronous-programming-patterns/snippets/complete-your-tasks/csharp/CompleteYourTasks.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/asynchronous-programming-patterns/snippets/complete-your-tasks/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/complete-your-tasks/csharp/Program.cs
@@ -1,0 +1,164 @@
+using System.Threading;
+
+// <MissingSetExceptionBug>
+public sealed class MissingSetExceptionBug
+{
+    public Task<string> StartAsync(bool fail)
+    {
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        try
+        {
+            if (fail)
+            {
+                throw new InvalidOperationException("Simulated failure");
+            }
+
+            tcs.SetResult("success");
+        }
+        catch (Exception)
+        {
+            // BUG: forgot SetException or TrySetException.
+        }
+
+        return tcs.Task;
+    }
+}
+// </MissingSetExceptionBug>
+
+// <MissingSetExceptionFix>
+public sealed class MissingSetExceptionFix
+{
+    public Task<string> StartAsync(bool fail)
+    {
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        try
+        {
+            if (fail)
+            {
+                throw new InvalidOperationException("Simulated failure");
+            }
+
+            tcs.TrySetResult("success");
+        }
+        catch (Exception ex)
+        {
+            tcs.TrySetException(ex);
+        }
+
+        return tcs.Task;
+    }
+}
+// </MissingSetExceptionFix>
+
+// <TrySetRace>
+public static class TrySetRaceExample
+{
+    public static void ShowRaceSafeCompletion()
+    {
+        var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        bool first = tcs.TrySetResult(42);
+        bool second = tcs.TrySetException(new TimeoutException("Too late"));
+
+        Console.WriteLine($"First completion won: {first}");
+        Console.WriteLine($"Second completion accepted: {second}");
+        Console.WriteLine($"Result: {tcs.Task.Result}");
+    }
+}
+// </TrySetRace>
+
+// <ResetBug>
+public sealed class ResetBug
+{
+    private TaskCompletionSource<bool> _signal = NewSignal();
+
+    public Task WaitAsync() => _signal.Task;
+
+    public void Reset()
+    {
+        // BUG: waiters on the old task might never complete.
+        _signal = NewSignal();
+    }
+
+    public void Pulse()
+    {
+        _signal.TrySetResult(true);
+    }
+
+    private static TaskCompletionSource<bool> NewSignal() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+}
+// </ResetBug>
+
+// <ResetFix>
+public sealed class ResetFix
+{
+    private TaskCompletionSource<bool> _signal = NewSignal();
+
+    public Task WaitAsync() => _signal.Task;
+
+    public void Reset()
+    {
+        TaskCompletionSource<bool> previous = Interlocked.Exchange(ref _signal, NewSignal());
+        previous.TrySetCanceled();
+    }
+
+    public void Pulse()
+    {
+        _signal.TrySetResult(true);
+    }
+
+    private static TaskCompletionSource<bool> NewSignal() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+}
+// </ResetFix>
+
+public static class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine("--- MissingSetExceptionBug ---");
+        var buggy = new MissingSetExceptionBug();
+        Task<string> buggyTask = buggy.StartAsync(fail: true);
+        bool completed = buggyTask.Wait(200);
+        Console.WriteLine($"Task completed: {completed}");
+
+        Console.WriteLine("--- MissingSetExceptionFix ---");
+        var fixedVersion = new MissingSetExceptionFix();
+        Task<string> fixedTask = fixedVersion.StartAsync(fail: true);
+        try
+        {
+            fixedTask.GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Observed failure: {ex.GetType().Name}");
+        }
+
+        Console.WriteLine("--- TrySetRace ---");
+        TrySetRaceExample.ShowRaceSafeCompletion();
+
+        Console.WriteLine("--- ResetBug ---");
+        var resetBug = new ResetBug();
+        Task oldWaiter = resetBug.WaitAsync();
+        resetBug.Reset();
+        resetBug.Pulse();
+        Console.WriteLine($"Original waiter completed: {oldWaiter.Wait(200)}");
+
+        Console.WriteLine("--- ResetFix ---");
+        var resetFix = new ResetFix();
+        Task oldWaiterFixed = resetFix.WaitAsync();
+        resetFix.Reset();
+        resetFix.Pulse();
+        try
+        {
+            oldWaiterFixed.GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Original waiter completed with: {ex.GetType().Name}");
+        }
+    }
+}

--- a/docs/standard/asynchronous-programming-patterns/snippets/complete-your-tasks/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/complete-your-tasks/csharp/Program.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 
 // <MissingSetExceptionBug>
+// ⚠️ DON'T copy this snippet. It demonstrates a problem that causes hangs.
 public sealed class MissingSetExceptionBug
 {
     public Task<string> StartAsync(bool fail)
@@ -70,6 +71,7 @@ public static class TrySetRaceExample
 // </TrySetRace>
 
 // <ResetBug>
+// ⚠️ DON'T copy this snippet. It demonstrates a problem where old waiters never complete.
 public sealed class ResetBug
 {
     private TaskCompletionSource<bool> _signal = NewSignal();

--- a/docs/standard/asynchronous-programming-patterns/snippets/complete-your-tasks/vb/CompleteYourTasks.vbproj
+++ b/docs/standard/asynchronous-programming-patterns/snippets/complete-your-tasks/vb/CompleteYourTasks.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>CompleteYourTasks</RootNamespace>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/asynchronous-programming-patterns/snippets/complete-your-tasks/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/complete-your-tasks/vb/Program.vb
@@ -1,6 +1,7 @@
 Imports System.Threading
 
 ' <MissingSetExceptionBug>
+' ⚠️ DON'T copy this snippet. It demonstrates a problem that causes hangs.
 Public NotInheritable Class MissingSetExceptionBug
     Public Function StartAsync(fail As Boolean) As Task(Of String)
         Dim tcs = New TaskCompletionSource(Of String)(TaskCreationOptions.RunContinuationsAsynchronously)
@@ -56,6 +57,7 @@ End Module
 ' </TrySetRace>
 
 ' <ResetBug>
+' ⚠️ DON'T copy this snippet. It demonstrates a problem where old waiters never complete.
 Public NotInheritable Class ResetBug
     Private _signal As TaskCompletionSource(Of Boolean) = NewSignal()
 

--- a/docs/standard/asynchronous-programming-patterns/snippets/complete-your-tasks/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/complete-your-tasks/vb/Program.vb
@@ -1,0 +1,142 @@
+Imports System.Threading
+
+' <MissingSetExceptionBug>
+Public NotInheritable Class MissingSetExceptionBug
+    Public Function StartAsync(fail As Boolean) As Task(Of String)
+        Dim tcs = New TaskCompletionSource(Of String)(TaskCreationOptions.RunContinuationsAsynchronously)
+
+        Try
+            If fail Then
+                Throw New InvalidOperationException("Simulated failure")
+            End If
+
+            tcs.SetResult("success")
+        Catch ex As Exception
+            ' BUG: forgot SetException or TrySetException.
+        End Try
+
+        Return tcs.Task
+    End Function
+End Class
+' </MissingSetExceptionBug>
+
+' <MissingSetExceptionFix>
+Public NotInheritable Class MissingSetExceptionFix
+    Public Function StartAsync(fail As Boolean) As Task(Of String)
+        Dim tcs = New TaskCompletionSource(Of String)(TaskCreationOptions.RunContinuationsAsynchronously)
+
+        Try
+            If fail Then
+                Throw New InvalidOperationException("Simulated failure")
+            End If
+
+            tcs.TrySetResult("success")
+        Catch ex As Exception
+            tcs.TrySetException(ex)
+        End Try
+
+        Return tcs.Task
+    End Function
+End Class
+' </MissingSetExceptionFix>
+
+' <TrySetRace>
+Public Module TrySetRaceExample
+    Public Sub ShowRaceSafeCompletion()
+        Dim tcs = New TaskCompletionSource(Of Integer)(TaskCreationOptions.RunContinuationsAsynchronously)
+
+        Dim first As Boolean = tcs.TrySetResult(42)
+        Dim second As Boolean = tcs.TrySetException(New TimeoutException("Too late"))
+
+        Console.WriteLine($"First completion won: {first}")
+        Console.WriteLine($"Second completion accepted: {second}")
+        Console.WriteLine($"Result: {tcs.Task.Result}")
+    End Sub
+End Module
+' </TrySetRace>
+
+' <ResetBug>
+Public NotInheritable Class ResetBug
+    Private _signal As TaskCompletionSource(Of Boolean) = NewSignal()
+
+    Public Function WaitAsync() As Task
+        Return _signal.Task
+    End Function
+
+    Public Sub Reset()
+        ' BUG: waiters on the old task might never complete.
+        _signal = NewSignal()
+    End Sub
+
+    Public Sub Pulse()
+        _signal.TrySetResult(True)
+    End Sub
+
+    Private Shared Function NewSignal() As TaskCompletionSource(Of Boolean)
+        Return New TaskCompletionSource(Of Boolean)(TaskCreationOptions.RunContinuationsAsynchronously)
+    End Function
+End Class
+' </ResetBug>
+
+' <ResetFix>
+Public NotInheritable Class ResetFix
+    Private _signal As TaskCompletionSource(Of Boolean) = NewSignal()
+
+    Public Function WaitAsync() As Task
+        Return _signal.Task
+    End Function
+
+    Public Sub Reset()
+        Dim previous As TaskCompletionSource(Of Boolean) = Interlocked.Exchange(_signal, NewSignal())
+        previous.TrySetCanceled()
+    End Sub
+
+    Public Sub Pulse()
+        _signal.TrySetResult(True)
+    End Sub
+
+    Private Shared Function NewSignal() As TaskCompletionSource(Of Boolean)
+        Return New TaskCompletionSource(Of Boolean)(TaskCreationOptions.RunContinuationsAsynchronously)
+    End Function
+End Class
+' </ResetFix>
+
+Module Program
+    Sub Main()
+        Console.WriteLine("--- MissingSetExceptionBug ---")
+        Dim buggy = New MissingSetExceptionBug()
+        Dim buggyTask As Task(Of String) = buggy.StartAsync(True)
+        Dim completed As Boolean = buggyTask.Wait(200)
+        Console.WriteLine($"Task completed: {completed}")
+
+        Console.WriteLine("--- MissingSetExceptionFix ---")
+        Dim fixedVersion = New MissingSetExceptionFix()
+        Dim fixedTask As Task(Of String) = fixedVersion.StartAsync(True)
+        Try
+            fixedTask.GetAwaiter().GetResult()
+        Catch ex As Exception
+            Console.WriteLine($"Observed failure: {ex.GetType().Name}")
+        End Try
+
+        Console.WriteLine("--- TrySetRace ---")
+        TrySetRaceExample.ShowRaceSafeCompletion()
+
+        Console.WriteLine("--- ResetBug ---")
+        Dim resetBug = New ResetBug()
+        Dim oldWaiter As Task = resetBug.WaitAsync()
+        resetBug.Reset()
+        resetBug.Pulse()
+        Console.WriteLine($"Original waiter completed: {oldWaiter.Wait(200)}")
+
+        Console.WriteLine("--- ResetFix ---")
+        Dim resetFix = New ResetFix()
+        Dim oldWaiterFixed As Task = resetFix.WaitAsync()
+        resetFix.Reset()
+        resetFix.Pulse()
+        Try
+            oldWaiterFixed.GetAwaiter().GetResult()
+        Catch ex As Exception
+            Console.WriteLine($"Original waiter completed with: {ex.GetType().Name}")
+        End Try
+    End Sub
+End Module

--- a/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/csharp/Program.cs
@@ -67,8 +67,15 @@ public static class MultiExceptionExample
             Console.WriteLine($"GetAwaiter().GetResult() surfaced: {ex.Message}");
         }
 
-        AggregateException allErrors = combined.Exception!.Flatten();
-        Console.WriteLine($"Task.Exception contains {allErrors.InnerExceptions.Count} exceptions.");
+        if (combined.IsFaulted && combined.Exception is not null)
+        {
+            AggregateException allErrors = combined.Exception.Flatten();
+            Console.WriteLine($"Task.Exception contains {allErrors.InnerExceptions.Count} exceptions.");
+        }
+        else
+        {
+            Console.WriteLine("Task.Exception is null because the task didn't fault.");
+        }
     }
 }
 // </MultiException>

--- a/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/csharp/Program.cs
@@ -1,0 +1,102 @@
+// <SingleException>
+public static class SingleExceptionExample
+{
+    public static Task<int> FaultAsync()
+    {
+        return Task.FromException<int>(new InvalidOperationException("Single failure"));
+    }
+
+    public static void ShowBlockingDifferences()
+    {
+        try
+        {
+            _ = FaultAsync().Result;
+        }
+        catch (AggregateException ex)
+        {
+            Console.WriteLine($".Result threw {ex.GetType().Name} with inner {ex.InnerException?.GetType().Name}");
+        }
+
+        try
+        {
+            _ = FaultAsync().GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"GetAwaiter().GetResult() threw {ex.GetType().Name}");
+        }
+    }
+}
+// </SingleException>
+
+// <MultiException>
+public static class MultiExceptionExample
+{
+    public static async Task FaultAfterDelayAsync(string name, int milliseconds)
+    {
+        await Task.Delay(milliseconds);
+        throw new InvalidOperationException($"{name} failed");
+    }
+
+    public static void ShowMultipleExceptions()
+    {
+        Task combined = Task.WhenAll(
+            FaultAfterDelayAsync("First", 10),
+            FaultAfterDelayAsync("Second", 20));
+
+        try
+        {
+            combined.GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"GetAwaiter().GetResult() surfaced: {ex.Message}");
+        }
+
+        AggregateException allErrors = combined.Exception!.Flatten();
+        Console.WriteLine($"Task.Exception contains {allErrors.InnerExceptions.Count} exceptions.");
+    }
+}
+// </MultiException>
+
+// <UnobservedTaskException>
+public static class UnobservedTaskExceptionExample
+{
+    public static void ShowEventBehavior()
+    {
+        bool eventRaised = false;
+
+        TaskScheduler.UnobservedTaskException += (_, args) =>
+        {
+            eventRaised = true;
+            Console.WriteLine($"UnobservedTaskException raised with {args.Exception.InnerExceptions.Count} exception(s).");
+            args.SetObserved();
+        };
+
+        _ = Task.Run(() => throw new ApplicationException("Background failure"));
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        Console.WriteLine(eventRaised
+            ? "Event was raised. The process continued."
+            : "Event was not observed in this short run. The process still continued.");
+    }
+}
+// </UnobservedTaskException>
+
+public static class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine("--- SingleException ---");
+        SingleExceptionExample.ShowBlockingDifferences();
+
+        Console.WriteLine("--- MultiException ---");
+        MultiExceptionExample.ShowMultipleExceptions();
+
+        Console.WriteLine("--- UnobservedTaskException ---");
+        UnobservedTaskExceptionExample.ShowEventBehavior();
+    }
+}

--- a/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/csharp/Program.cs
+++ b/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/csharp/Program.cs
@@ -10,15 +10,6 @@ public static class SingleExceptionExample
     {
         try
         {
-            _ = FaultAsync().Result;
-        }
-        catch (AggregateException ex)
-        {
-            Console.WriteLine($".Result threw {ex.GetType().Name} with inner {ex.InnerException?.GetType().Name}");
-        }
-
-        try
-        {
             _ = FaultAsync().GetAwaiter().GetResult();
         }
         catch (Exception ex)
@@ -28,6 +19,29 @@ public static class SingleExceptionExample
     }
 }
 // </SingleException>
+
+// <SingleExceptionBad>
+// ⚠️ DON'T copy this snippet. It demonstrates a problem where exceptions get wrapped unnecessarily.
+public static class SingleExceptionBadExample
+{
+    public static Task<int> FaultAsync()
+    {
+        return Task.FromException<int>(new InvalidOperationException("Single failure"));
+    }
+
+    public static void ShowBlockingDifferences()
+    {
+        try
+        {
+            _ = FaultAsync().Result;
+        }
+        catch (AggregateException ex)
+        {
+            Console.WriteLine($".Result threw {ex.GetType().Name} with inner {ex.InnerException?.GetType().Name}");
+        }
+    }
+}
+// </SingleExceptionBad>
 
 // <MultiException>
 public static class MultiExceptionExample
@@ -92,6 +106,9 @@ public static class Program
     {
         Console.WriteLine("--- SingleException ---");
         SingleExceptionExample.ShowBlockingDifferences();
+
+        Console.WriteLine("--- SingleExceptionBad ---");
+        SingleExceptionBadExample.ShowBlockingDifferences();
 
         Console.WriteLine("--- MultiException ---");
         MultiExceptionExample.ShowMultipleExceptions();

--- a/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/csharp/TaskExceptionHandling.csproj
+++ b/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/csharp/TaskExceptionHandling.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/vb/Program.vb
@@ -1,0 +1,85 @@
+' <SingleException>
+Public Module SingleExceptionExample
+    Public Function FaultAsync() As Task(Of Integer)
+        Return Task.FromException(Of Integer)(New InvalidOperationException("Single failure"))
+    End Function
+
+    Public Sub ShowBlockingDifferences()
+        Try
+            Dim ignored = FaultAsync().Result
+        Catch ex As AggregateException
+            Console.WriteLine($".Result threw {ex.GetType().Name} with inner {ex.InnerException?.GetType().Name}")
+        End Try
+
+        Try
+            Dim ignored = FaultAsync().GetAwaiter().GetResult()
+        Catch ex As Exception
+            Console.WriteLine($"GetAwaiter().GetResult() threw {ex.GetType().Name}")
+        End Try
+    End Sub
+End Module
+' </SingleException>
+
+' <MultiException>
+Public Module MultiExceptionExample
+    Public Async Function FaultAfterDelayAsync(name As String, milliseconds As Integer) As Task
+        Await Task.Delay(milliseconds)
+        Throw New InvalidOperationException($"{name} failed")
+    End Function
+
+    Public Sub ShowMultipleExceptions()
+        Dim combined As Task = Task.WhenAll(
+            FaultAfterDelayAsync("First", 10),
+            FaultAfterDelayAsync("Second", 20))
+
+        Try
+            combined.GetAwaiter().GetResult()
+        Catch ex As Exception
+            Console.WriteLine($"GetAwaiter().GetResult() surfaced: {ex.Message}")
+        End Try
+
+        Dim allErrors As AggregateException = combined.Exception.Flatten()
+        Console.WriteLine($"Task.Exception contains {allErrors.InnerExceptions.Count} exceptions.")
+    End Sub
+End Module
+' </MultiException>
+
+' <UnobservedTaskException>
+Public Module UnobservedTaskExceptionExample
+    Public Sub ShowEventBehavior()
+        Dim eventRaised As Boolean = False
+
+        AddHandler TaskScheduler.UnobservedTaskException,
+            Sub(sender, args)
+                eventRaised = True
+                Console.WriteLine($"UnobservedTaskException raised with {args.Exception.InnerExceptions.Count} exception(s).")
+                args.SetObserved()
+            End Sub
+
+        Dim ignored = Task.Run(Sub() Throw New ApplicationException("Background failure"))
+
+        GC.Collect()
+        GC.WaitForPendingFinalizers()
+        GC.Collect()
+
+        If eventRaised Then
+            Console.WriteLine("Event was raised. The process continued.")
+        Else
+            Console.WriteLine("Event was not observed in this short run. The process still continued.")
+        End If
+    End Sub
+End Module
+' </UnobservedTaskException>
+
+Module Program
+    Sub Main()
+        Console.WriteLine("--- SingleException ---")
+        SingleExceptionExample.ShowBlockingDifferences()
+
+        Console.WriteLine("--- MultiException ---")
+        MultiExceptionExample.ShowMultipleExceptions()
+
+        Console.WriteLine("--- UnobservedTaskException ---")
+        UnobservedTaskExceptionExample.ShowEventBehavior()
+    End Sub
+End Module

--- a/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/vb/Program.vb
@@ -49,8 +49,12 @@ Public Module MultiExceptionExample
             Console.WriteLine($"GetAwaiter().GetResult() surfaced: {ex.Message}")
         End Try
 
-        Dim allErrors As AggregateException = combined.Exception.Flatten()
-        Console.WriteLine($"Task.Exception contains {allErrors.InnerExceptions.Count} exceptions.")
+        If combined.IsFaulted AndAlso combined.Exception IsNot Nothing Then
+            Dim allErrors As AggregateException = combined.Exception.Flatten()
+            Console.WriteLine($"Task.Exception contains {allErrors.InnerExceptions.Count} exceptions.")
+        Else
+            Console.WriteLine("Task.Exception was not available because the task did not fault.")
+        End If
     End Sub
 End Module
 ' </MultiException>

--- a/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/vb/Program.vb
@@ -71,7 +71,7 @@ Public Module UnobservedTaskExceptionExample
                 args.SetObserved()
             End Sub
 
-        Dim ignored = Task.Run(Sub() Throw New ApplicationException("Background failure"))
+        Task.Run(Sub() Throw New ApplicationException("Background failure"))
 
         GC.Collect()
         GC.WaitForPendingFinalizers()

--- a/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/vb/Program.vb
+++ b/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/vb/Program.vb
@@ -6,12 +6,6 @@ Public Module SingleExceptionExample
 
     Public Sub ShowBlockingDifferences()
         Try
-            Dim ignored = FaultAsync().Result
-        Catch ex As AggregateException
-            Console.WriteLine($".Result threw {ex.GetType().Name} with inner {ex.InnerException?.GetType().Name}")
-        End Try
-
-        Try
             Dim ignored = FaultAsync().GetAwaiter().GetResult()
         Catch ex As Exception
             Console.WriteLine($"GetAwaiter().GetResult() threw {ex.GetType().Name}")
@@ -19,6 +13,23 @@ Public Module SingleExceptionExample
     End Sub
 End Module
 ' </SingleException>
+
+' <SingleExceptionBad>
+' ⚠️ DON'T copy this snippet. It demonstrates a problem where exceptions get wrapped unnecessarily.
+Public Module SingleExceptionBadExample
+    Public Function FaultAsync() As Task(Of Integer)
+        Return Task.FromException(Of Integer)(New InvalidOperationException("Single failure"))
+    End Function
+
+    Public Sub ShowBlockingDifferences()
+        Try
+            Dim ignored = FaultAsync().Result
+        Catch ex As AggregateException
+            Console.WriteLine($".Result threw {ex.GetType().Name} with inner {ex.InnerException?.GetType().Name}")
+        End Try
+    End Sub
+End Module
+' </SingleExceptionBad>
 
 ' <MultiException>
 Public Module MultiExceptionExample
@@ -75,6 +86,9 @@ Module Program
     Sub Main()
         Console.WriteLine("--- SingleException ---")
         SingleExceptionExample.ShowBlockingDifferences()
+
+        Console.WriteLine("--- SingleExceptionBad ---")
+        SingleExceptionBadExample.ShowBlockingDifferences()
 
         Console.WriteLine("--- MultiException ---")
         MultiExceptionExample.ShowMultipleExceptions()

--- a/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/vb/TaskExceptionHandling.vbproj
+++ b/docs/standard/asynchronous-programming-patterns/snippets/task-exception-handling/vb/TaskExceptionHandling.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>TaskExceptionHandling</RootNamespace>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/docs/standard/asynchronous-programming-patterns/task-exception-handling.md
+++ b/docs/standard/asynchronous-programming-patterns/task-exception-handling.md
@@ -32,7 +32,7 @@ When you must block on a task, use <xref:System.Threading.Tasks.Task.GetAwaiter%
 :::code language="csharp" source="./snippets/task-exception-handling/csharp/Program.cs" id="SingleExceptionBad":::
 :::code language="vb" source="./snippets/task-exception-handling/vb/Program.vb" id="SingleExceptionBad":::
 
-For tasks that fault with multiple exceptions, `GetAwaiter().GetResult()` still throws one exception, but <xref:System.Threading.Tasks.Task.Exception%2A> stores an <xref:System.AggregateException> that contains all inner exceptions:
+For tasks that fault with multiple exceptions, `GetAwaiter().GetResult()` still throws one exception, but <xref:System.Threading.Tasks.Task.Exception?displayProperty=nameWithType> stores an <xref:System.AggregateException> that contains all inner exceptions:
 
 :::code language="csharp" source="./snippets/task-exception-handling/csharp/Program.cs" id="MultiException":::
 :::code language="vb" source="./snippets/task-exception-handling/vb/Program.vb" id="MultiException":::

--- a/docs/standard/asynchronous-programming-patterns/task-exception-handling.md
+++ b/docs/standard/asynchronous-programming-patterns/task-exception-handling.md
@@ -27,7 +27,7 @@ When you must block on a task, use <xref:System.Threading.Tasks.Task.GetAwaiter%
 :::code language="csharp" source="./snippets/task-exception-handling/csharp/Program.cs" id="SingleException":::
 :::code language="vb" source="./snippets/task-exception-handling/vb/Program.vb" id="SingleException":::
 
-**Don't do this:** <xref:System.Threading.Tasks.Task.Result%2A> and <xref:System.Threading.Tasks.Task.Wait%2A> wrap exceptions in <xref:System.AggregateException>, which complicates exception handling. The following code uses these APIs and receives the wrong exception type:
+<xref:System.Threading.Tasks.Task`1.Result?displayProperty=nameWithType> and <xref:System.Threading.Tasks.Task.Wait%2A> wrap exceptions in <xref:System.AggregateException>, which complicates exception handling. The following code uses these APIs and receives the wrong exception type:
 
 :::code language="csharp" source="./snippets/task-exception-handling/csharp/Program.cs" id="SingleExceptionBad":::
 :::code language="vb" source="./snippets/task-exception-handling/vb/Program.vb" id="SingleExceptionBad":::

--- a/docs/standard/asynchronous-programming-patterns/task-exception-handling.md
+++ b/docs/standard/asynchronous-programming-patterns/task-exception-handling.md
@@ -18,19 +18,21 @@ helpviewer_keywords:
 
 Use `await` as your default. `await` gives you natural exception flow, keeps your code readable, and avoids sync-over-async deadlocks.
 
-Sometimes you still need to block on a `Task`, for example, in legacy synchronous entry points. In those cases, you need to understand how each API surfaces exceptions.
+Sometimes you still need to block on a <xref:System.Threading.Tasks.Task>, for example, in legacy synchronous entry points. In those cases, you need to understand how each API surfaces exceptions.
 
 ## Compare exception propagation for blocking APIs
 
-When a faulted task throws through blocking APIs, the exception type depends on the API:
-
-- `Task.Result` and `Task.Wait()` throw <xref:System.AggregateException>.
-- `task.GetAwaiter().GetResult()` throws the original exception type.
+When you must block on a task, use <xref:System.Threading.Tasks.Task.GetAwaiter%2A>().GetResult() to preserve the original exception type:
 
 :::code language="csharp" source="./snippets/task-exception-handling/csharp/Program.cs" id="SingleException":::
 :::code language="vb" source="./snippets/task-exception-handling/vb/Program.vb" id="SingleException":::
 
-For tasks that fault with multiple exceptions, `GetAwaiter().GetResult()` still throws one exception, but <xref:System.Threading.Tasks.Task.Exception?displayProperty=nameWithType> stores an <xref:System.AggregateException> that contains all inner exceptions.
+**Don't do this:** <xref:System.Threading.Tasks.Task.Result%2A> and <xref:System.Threading.Tasks.Task.Wait%2A> wrap exceptions in <xref:System.AggregateException>, which complicates exception handling. The following code uses these APIs and receives the wrong exception type:
+
+:::code language="csharp" source="./snippets/task-exception-handling/csharp/Program.cs" id="SingleExceptionBad":::
+:::code language="vb" source="./snippets/task-exception-handling/vb/Program.vb" id="SingleExceptionBad":::
+
+For tasks that fault with multiple exceptions, `GetAwaiter().GetResult()` still throws one exception, but <xref:System.Threading.Tasks.Task.Exception%2A> stores an <xref:System.AggregateException> that contains all inner exceptions:
 
 :::code language="csharp" source="./snippets/task-exception-handling/csharp/Program.cs" id="MultiException":::
 :::code language="vb" source="./snippets/task-exception-handling/vb/Program.vb" id="MultiException":::
@@ -43,11 +45,11 @@ Use this guidance when you choose between the two APIs:
 - If you must block and you want original exception types, use `GetAwaiter().GetResult()`.
 - If your existing code expects <xref:System.AggregateException>, use `Result` or `Wait()` and inspect `InnerExceptions`.
 
-These rules affect exception shape only. Both APIs still block the current thread, so both can deadlock on single-threaded <xref:System.Threading.SynchronizationContext> environments.
+These rules affect exception shape only. Both APIs still block the current thread, so both can deadlock on single-threaded <xref:System.Threading.SynchronizationContext> environments. To understand how to properly complete tasks on all code paths, see [Complete your tasks](complete-your-tasks.md).
 
 ## Unobserved task exceptions in modern .NET
 
-The runtime raises <xref:System.Threading.Tasks.TaskScheduler.UnobservedTaskException?displayProperty=nameWithType> when a faulted task gets finalized before code observes its exception.
+The runtime raises <xref:System.Threading.Tasks.TaskScheduler.UnobservedTaskException?displayProperty=nameWithType> when a faulted `Task` gets finalized before code observes its exception.
 
 In modern .NET, unobserved exceptions no longer crash the process by default. The runtime reports them through the event, and then continues execution.
 

--- a/docs/standard/asynchronous-programming-patterns/task-exception-handling.md
+++ b/docs/standard/asynchronous-programming-patterns/task-exception-handling.md
@@ -1,0 +1,63 @@
+---
+title: "Task exception handling"
+description: Learn how exceptions propagate through Task APIs, when AggregateException appears, and how unobserved task exceptions behave in modern .NET.
+ms.date: 04/14/2026
+ai-usage: ai-assisted
+dev_langs:
+  - "csharp"
+  - "vb"
+helpviewer_keywords:
+  - "Task.Result"
+  - "GetAwaiter().GetResult()"
+  - "AggregateException"
+  - "TaskScheduler.UnobservedTaskException"
+  - "Task exception handling"
+---
+
+# Task exception handling
+
+Use `await` as your default. `await` gives you natural exception flow, keeps your code readable, and avoids sync-over-async deadlocks.
+
+Sometimes you still need to block on a `Task`, for example, in legacy synchronous entry points. In those cases, you need to understand how each API surfaces exceptions.
+
+## Compare exception propagation for blocking APIs
+
+When a faulted task throws through blocking APIs, the exception type depends on the API:
+
+- `Task.Result` and `Task.Wait()` throw <xref:System.AggregateException>.
+- `task.GetAwaiter().GetResult()` throws the original exception type.
+
+:::code language="csharp" source="./snippets/task-exception-handling/csharp/Program.cs" id="SingleException":::
+:::code language="vb" source="./snippets/task-exception-handling/vb/Program.vb" id="SingleException":::
+
+For tasks that fault with multiple exceptions, `GetAwaiter().GetResult()` still throws one exception, but <xref:System.Threading.Tasks.Task.Exception?displayProperty=nameWithType> stores an <xref:System.AggregateException> that contains all inner exceptions.
+
+:::code language="csharp" source="./snippets/task-exception-handling/csharp/Program.cs" id="MultiException":::
+:::code language="vb" source="./snippets/task-exception-handling/vb/Program.vb" id="MultiException":::
+
+## FAQ: `Task.Result` vs `GetAwaiter().GetResult()`
+
+Use this guidance when you choose between the two APIs:
+
+- Prefer `await` when you can. It avoids blocking and deadlock risk.
+- If you must block and you want original exception types, use `GetAwaiter().GetResult()`.
+- If your existing code expects <xref:System.AggregateException>, use `Result` or `Wait()` and inspect `InnerExceptions`.
+
+These rules affect exception shape only. Both APIs still block the current thread, so both can deadlock on single-threaded <xref:System.Threading.SynchronizationContext> environments.
+
+## Unobserved task exceptions in modern .NET
+
+The runtime raises <xref:System.Threading.Tasks.TaskScheduler.UnobservedTaskException?displayProperty=nameWithType> when a faulted task gets finalized before code observes its exception.
+
+In modern .NET, unobserved exceptions no longer crash the process by default. The runtime reports them through the event, and then continues execution.
+
+:::code language="csharp" source="./snippets/task-exception-handling/csharp/Program.cs" id="UnobservedTaskException":::
+:::code language="vb" source="./snippets/task-exception-handling/vb/Program.vb" id="UnobservedTaskException":::
+
+Use the event for diagnostics and telemetry. Don't use the event as a replacement for normal exception handling in async flows.
+
+## See also
+
+- [Common async/await bugs](common-async-bugs.md)
+- [Consume the TAP](consuming-the-task-based-asynchronous-pattern.md)
+- [Exception handling (Task Parallel Library)](../parallel-programming/exception-handling-task-parallel-library.md)

--- a/docs/standard/asynchronous-programming-patterns/task-exception-handling.md
+++ b/docs/standard/asynchronous-programming-patterns/task-exception-handling.md
@@ -42,7 +42,7 @@ For tasks that fault with multiple exceptions, `GetAwaiter().GetResult()` still 
 Use this guidance when you choose between the two APIs:
 
 - Prefer `await` when you can. It avoids blocking and deadlock risk.
-- If you must block and you want original exception types, use `GetAwaiter().GetResult()`. In WinForms applications, note the [Common pitfalls and deadlocks](~/desktop/winforms/forms/events#common-pitfalls-and-deadlocks) section of the article on event handlers.
+- If you must block and you want original exception types, use `GetAwaiter().GetResult()`. In WinForms applications, note the [Common pitfalls and deadlocks](/desktop/winforms/forms/events#common-pitfalls-and-deadlocks) section of the article on event handlers.
 - If your existing code expects <xref:System.AggregateException>, use `Result` or `Wait()` and inspect `InnerExceptions`.
 
 These rules affect exception shape only. Both APIs still block the current thread, so both can deadlock on single-threaded <xref:System.Threading.SynchronizationContext> environments. To understand how to properly complete tasks on all code paths, see [Complete your tasks](complete-your-tasks.md).

--- a/docs/standard/asynchronous-programming-patterns/task-exception-handling.md
+++ b/docs/standard/asynchronous-programming-patterns/task-exception-handling.md
@@ -37,12 +37,12 @@ For tasks that fault with multiple exceptions, `GetAwaiter().GetResult()` still 
 :::code language="csharp" source="./snippets/task-exception-handling/csharp/Program.cs" id="MultiException":::
 :::code language="vb" source="./snippets/task-exception-handling/vb/Program.vb" id="MultiException":::
 
-## FAQ: `Task.Result` vs `GetAwaiter().GetResult()`
+## `Task.Result` vs `GetAwaiter().GetResult()`
 
 Use this guidance when you choose between the two APIs:
 
 - Prefer `await` when you can. It avoids blocking and deadlock risk.
-- If you must block and you want original exception types, use `GetAwaiter().GetResult()`.
+- If you must block and you want original exception types, use `GetAwaiter().GetResult()`. In WinForms applications, note the [Common pitfalls and deadlocks](~/desktop/winforms/forms/events#common-pitfalls-and-deadlocks) section of the article on event handlers.
 - If your existing code expects <xref:System.AggregateException>, use `Result` or `Wait()` and inspect `InnerExceptions`.
 
 These rules affect exception shape only. Both APIs still block the current thread, so both can deadlock on single-threaded <xref:System.Threading.SynchronizationContext> environments. To understand how to properly complete tasks on all code paths, see [Complete your tasks](complete-your-tasks.md).


### PR DESCRIPTION
1. Create `task-exception-handling.md` — from "Task exception handling in .NET 4.5." Covers `GetAwaiter().GetResult()` vs `.Result` exception propagation, `AggregateException` unwrapping, unobserved task exceptions, `TaskScheduler.UnobservedTaskException`. **Update:** modern .NET default behavior (unobserved exceptions no longer crash the process).
1. Create `complete-your-tasks.md` — from "Don't forget to complete your tasks." Covers: always complete `TaskCompletionSource` on all paths, common bugs (forgetting `SetException` in catch, dropping `TaskCompletionSource` references during reset).
1. Incorporate FAQ content about `Task.Result` vs `GetAwaiter().GetResult()`.
1. Add both to TOC.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/navigate/advanced-programming/toc.yml](https://github.com/dotnet/docs/blob/0c713877a4aee2568792d770c9f5c9b6ca95d16e/docs/navigate/advanced-programming/toc.yml) | [docs/navigate/advanced-programming/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/advanced-programming/toc?branch=pr-en-us-53005) |
| [docs/standard/asynchronous-programming-patterns/complete-your-tasks.md](https://github.com/dotnet/docs/blob/0c713877a4aee2568792d770c9f5c9b6ca95d16e/docs/standard/asynchronous-programming-patterns/complete-your-tasks.md) | [Complete your tasks](https://review.learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/complete-your-tasks?branch=pr-en-us-53005) |
| [docs/standard/asynchronous-programming-patterns/task-exception-handling.md](https://github.com/dotnet/docs/blob/0c713877a4aee2568792d770c9f5c9b6ca95d16e/docs/standard/asynchronous-programming-patterns/task-exception-handling.md) | [Task exception handling](https://review.learn.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/task-exception-handling?branch=pr-en-us-53005) |


<!-- PREVIEW-TABLE-END -->