### PR TITLE
fix(dotnet restore): missing artifacts-path option

### DIFF
--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -15,8 +15,8 @@ ms.date: 09/29/2025
 
 ```dotnetcli
 dotnet restore [<PROJECT>|<SOLUTION>|<FILE>]
-  [-a|--arch <ARCHITECTURE>] [--configfile <FILE>] [--disable-build-servers]
-  [--disable-parallel] [-f|--force] [--force-evaluate]
+  [-a|--arch <ARCHITECTURE>] [--artifacts-path <ARTIFACTS_DIR>] [--configfile <FILE>]
+  [--disable-build-servers] [--disable-parallel] [-f|--force] [--force-evaluate]
   [--ignore-failed-sources] [--interactive] [--lock-file-path <LOCK_FILE_PATH>]
   [--locked-mode] [--no-dependencies] [--no-http-cache]
   [--os <OS>] [--packages <PACKAGES_DIRECTORY>]
@@ -92,6 +92,8 @@ There are three specific settings that `dotnet restore` ignores:
 ## Options
 
 - [!INCLUDE [arch](includes/cli-arch.md)]
+
+- [!INCLUDE [artifacts-path](includes/cli-artifacts-path.md)]
 
 - [!INCLUDE [configfile](includes/cli-configfile.md)]
 

--- a/docs/core/tools/includes/cli-artifacts-path.md
+++ b/docs/core/tools/includes/cli-artifacts-path.md
@@ -4,4 +4,4 @@ ms.topic: include
 ---
 **`--artifacts-path <ARTIFACTS_DIR>`**
 
-All build output files from the executed command will go in subfolders under the specified path, separated by project. For more information see [Artifacts Output Layout](../../sdk/artifacts-output.md). Available since .NET 8 SDK.
+All build output files from the executed command will go in subfolders under the specified path, separated by project. For more information see [Artifacts Output Layout](../../sdk/artifacts-output.md). This option and the value provided must be explicitly cascaded in any `dotnet` command that depends on the output of another `dotnet` command, for example, when using `dotnet build --no-restore` and `dotnet publish --no-build`. Available since .NET 8 SDK.


### PR DESCRIPTION
## Summary

Add `--artifacts-path` option to `dotnet restore` documentation, which is required especially if using `--no-restore` on `dotnet build`.

Fixes #53170


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-restore.md](https://github.com/dotnet/docs/blob/23105cbb1602f920c8663f26ced9245a7fea692c/docs/core/tools/dotnet-restore.md) | [dotnet restore](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-restore?branch=pr-en-us-53169) |


<!-- PREVIEW-TABLE-END -->