### PR TITLE
Add example fix to CS0409 compiler error

### DIFF
--- a/docs/csharp/misc/cs0409.md
+++ b/docs/csharp/misc/cs0409.md
@@ -1,7 +1,7 @@
 ---
 description: "Compiler Error CS0409"
 title: "Compiler Error CS0409"
-ms.date: 07/20/2015
+ms.date: 04/17/2026
 f1_keywords: 
   - "CS0409"
 helpviewer_keywords: 
@@ -12,15 +12,26 @@ ms.assetid: 23d86c13-7978-41b7-a087-ffcea52476fa
 
 A constraint clause has already been specified for type parameter 'type parameter'. All of the constraints for a type parameter must be specified in a single where clause.  
   
- Multiple constraint clauses (where clauses) were found for a single type parameter. Remove the extraneous where clause, or correct the where clauses so that a unique type parameter in each clause.  
+Multiple constraint clauses (where clauses) were found for a single type parameter. Remove the extraneous where clause, or correct the where clauses so that a unique type parameter in each clause.  
   
-```csharp  
-// CS0409.cs  
-interface I  
-{  
-}  
-  
-class C<T1, T2> where T1 : I where T1 : I  // CS0409 – T1 used twice  
-{  
-}  
+```csharp
+// CS0409.cs
+interface I
+{
+}
+
+// Compiler error CS0409 is reported on the following line because T is specified in multiple where clauses.
+class Example<T> where T : I where T : new()
+{
+}
+
+// To resolve the error, combine the constraints for the same type parameter into a single clause.
+class Example<T> where T : I, new()
+{
+}
+
+// Using multiple where clauses is only valid when targeting different type parameters.
+class Example<T1, T2> where T1 : I where T2 : new()
+{
+}
 ```


### PR DESCRIPTION
## Summary

- This PR adds the missing example fix to the `CS0409` compiler error.

Fixes #52955


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/cs0409.md](https://github.com/dotnet/docs/blob/fad10c3265166bad39527a66eba4151e9eaf9010/docs/csharp/misc/cs0409.md) | [docs/csharp/misc/cs0409](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/cs0409?branch=pr-en-us-53179) |

<!-- PREVIEW-TABLE-END -->