### PR TITLE
Update syslib0060.md to note how to handle code which previously passed a salt size

### DIFF
--- a/docs/fundamentals/syslib-diagnostics/syslib0060.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0060.md
@@ -1,7 +1,7 @@
 ---
 title: SYSLIB0060 warning - Rfc2898DeriveBytes constructors are obsolete
 description: Learn about the obsoletion of Rfc2898DeriveBytes constructors. Use of these constructors generates compile-time warning SYSLIB0060.
-ms.date: 01/30/2025
+ms.date: 04/24/2026
 ai-usage: ai-assisted
 f1_keywords:
   - SYSLIB0060
@@ -18,35 +18,31 @@ The instance-based implementation of PBKDF2, which <xref:System.Security.Cryptog
 
 Change instances of <xref:System.Security.Cryptography.Rfc2898DeriveBytes?displayProperty=nameWithType> and calls to `GetBytes` to use the <xref:System.Security.Cryptography.Rfc2898DeriveBytes.Pbkdf2*?displayProperty=nameWithType> one-shot static method instead.
 
-For example, change:
+For example, change this code:
 
 ```csharp
-using System.Security.Cryptography;
-
 Rfc2898DeriveBytes kdf = new Rfc2898DeriveBytes(password, salt, iterations, hashAlgorithm);
 byte[] derivedKey = kdf.GetBytes(64);
 ```
 
-to
+To this:
 
 ```csharp
 byte[] derivedKey = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, hashAlgorithm, 64);
 ```
 
-If you used an `Rfc2898DeriveBytes` constructor that took a salt size, you'll need to manually create the salt (<xref:System.Security.Cryptography.Rfc2898DeriveBytes.Pbkdf2*?displayProperty=nameWithType> does not have an overload that takes a salt size).
+If you used an `Rfc2898DeriveBytes` constructor that took a salt size, you'll need to manually create the salt (<xref:System.Security.Cryptography.Rfc2898DeriveBytes.Pbkdf2*?displayProperty=nameWithType> doesn't have an overload that takes a salt size).
 For consistency with the previous implementation, use <xref:System.Security.Cryptography.RandomNumberGenerator.Fill*?displayProperty=nameWithType> to fill an existing array with cryptographically secure bytes, or <xref:System.Security.Cryptography.RandomNumberGenerator.GetBytes*?displayProperty=nameWithType> to create a new array with cryptographically secure bytes.
 
-Example:
+For example, change this code:
 
 ```csharp
-using System.Security.Cryptography;
-
 Rfc2898DeriveBytes kdf = new Rfc2898DeriveBytes(password, saltSize, iterations, hashAlgorithm);
 byte[] salt = kdf.Salt;
 byte[] derivedKey = kdf.GetBytes(64);
 ```
 
-should change to
+To this:
 
 ```csharp
 byte[] salt = RandomNumberGenerator.GetBytes(saltSize);

--- a/docs/fundamentals/syslib-diagnostics/syslib0060.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0060.md
@@ -33,6 +33,26 @@ to
 byte[] derivedKey = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, hashAlgorithm, 64);
 ```
 
+Note that for constructors of `Rfc2898DeriveBytes` which took a salt size, the salt will need to be manually created (<xref:System.Security.Cryptography.Rfc2898DeriveBytes.Pbkdf2*?displayProperty=nameWithType> does not have an overload taking a salt size).
+For consistency with the previous implementation, use <xref:System.Security.Cryptography.RandomNumberGenerator.Fill*?displayProperty=nameWithType> to fill an existing array with cryptographically secure bytes, or <xref:System.Security.Cryptography.RandomNumberGenerator.GetBytes*?displayProperty=nameWithType> to create a new array with cryptographically secure bytes.
+
+Example:
+
+```csharp
+using System.Security.Cryptography;
+
+Rfc2898DeriveBytes kdf = new Rfc2898DeriveBytes(password, saltSize, iterations, hashAlgorithm);
+byte[] salt = kdf.Salt;
+byte[] derivedKey = kdf.GetBytes(64);
+```
+
+should change to
+
+```csharp
+byte[] salt = RandomNumberGenerator.GetBytes(saltSize);
+byte[] derivedKey = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, hashAlgorithm, 64);
+```
+
 ## Suppress a warning
 
 If you must use the obsolete API, you can suppress the warning in code or in your project file.

--- a/docs/fundamentals/syslib-diagnostics/syslib0060.md
+++ b/docs/fundamentals/syslib-diagnostics/syslib0060.md
@@ -33,7 +33,7 @@ to
 byte[] derivedKey = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, hashAlgorithm, 64);
 ```
 
-Note that for constructors of `Rfc2898DeriveBytes` which took a salt size, the salt will need to be manually created (<xref:System.Security.Cryptography.Rfc2898DeriveBytes.Pbkdf2*?displayProperty=nameWithType> does not have an overload taking a salt size).
+If you used an `Rfc2898DeriveBytes` constructor that took a salt size, you'll need to manually create the salt (<xref:System.Security.Cryptography.Rfc2898DeriveBytes.Pbkdf2*?displayProperty=nameWithType> does not have an overload that takes a salt size).
 For consistency with the previous implementation, use <xref:System.Security.Cryptography.RandomNumberGenerator.Fill*?displayProperty=nameWithType> to fill an existing array with cryptographically secure bytes, or <xref:System.Security.Cryptography.RandomNumberGenerator.GetBytes*?displayProperty=nameWithType> to create a new array with cryptographically secure bytes.
 
 Example:


### PR DESCRIPTION
When I came to migrate to .NET 10, I came across the SYSLIB0060 deprecation and was uncertain how to handle it. I have noted what I believe to be the correct way to handle migrating from use of https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.rfc2898derivebytes.-ctor?view=net-10.0#system-security-cryptography-rfc2898derivebytes-ctor(system-string-system-int32-system-int32-system-security-cryptography-hashalgorithmname)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/syslib-diagnostics/syslib0060.md](https://github.com/dotnet/docs/blob/baaa965b9d6b5ffe2ef341c00cdf22070270912a/docs/fundamentals/syslib-diagnostics/syslib0060.md) | [SYSLIB0060: Rfc2898DeriveBytes constructors are obsolete](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0060?branch=pr-en-us-53356) |


<!-- PREVIEW-TABLE-END -->