### PR TITLE
Document discovery/execution phases and folded vs. unfolded test behavior

### DIFF
--- a/docs/core/testing/unit-testing-mstest-writing-tests-data-driven.md
+++ b/docs/core/testing/unit-testing-mstest-writing-tests-data-driven.md
@@ -31,7 +31,7 @@ MSTest also provides the following types to extend data-driven scenarios:
 
 ## `DataRowAttribute`
 
-The <xref:Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute> allows you to run the same test method with multiple different inputs. Apply one or multiple `DataRow` attributes to a test method, and combine it with the <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute>.
+The <xref:Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute> lets you run the same test method with multiple different inputs. Apply one or more `DataRow` attributes to a test method that's decorated with the <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute>.
 
 The number and types of arguments must exactly match the test method signature.
 
@@ -322,7 +322,7 @@ public class IgnoreDynamicDataExample
 > [!TIP]
 > To ignore individual test cases, use `TestDataRow<T>` with its `IgnoreMessage` property. See the [TestDataRow\<T>](#testdatarow) section.
 
-## TestDataRow
+## `TestDataRow`
 
 The <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestDataRow`1> class provides enhanced control over test data in data-driven tests. Use <xref:System.Collections.Generic.IEnumerable`1> of <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestDataRow`1> as your data source return type to specify:
 
@@ -492,21 +492,46 @@ public class CrossPlatformTests
 
 Data-driven test attributes support the <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestDataSourceUnfoldingStrategy> property, which controls how test cases appear in Test Explorer and TRX results. This property also determines whether you can run individual test cases independently.
 
+### Discovery and execution phases
+
+MSTest processes data-driven tests in two distinct phases:
+
+1. **Discovery phase**: MSTest evaluates all data source attributes (`DataRow`, `DynamicData`, `ITestDataSource`) to determine the list of test cases. This evaluation happens *before* any of the regular MSTest lifecycle hooks run—`AssemblyInitialize`, `ClassInitialize`, and other setup methods haven't executed yet.
+1. **Execution phase**: MSTest runs the normal lifecycle (assembly initialization, class initialization, test initialization, test method, cleanup) and executes each test case with its data.
+
+Because data sources are evaluated during discovery, your data-generation code can't rely on any state set up by `AssemblyInitialize` or `ClassInitialize`. If your data source depends on setup logic (for example, reading from a database connection initialized in `ClassInitialize`), the data source evaluation fails during discovery.
+
 ### Available strategies
 
 | Strategy | Behavior |
 |----------|----------|
-| `Auto` (default) | MSTest determines unfolding best strategy |
-| `Unfold` | All test cases are expanded and shown individually |
-| `Fold` | All test cases are collapsed into a single test node |
+| `Auto` (default) | MSTest determines the best unfolding strategy. |
+| `Unfold` | All test cases are expanded and shown individually. |
+| `Fold` | All test cases are collapsed into a single test node. |
+
+### Folded vs. unfolded tests
+
+The unfolding strategy affects how test results are reported in Test Explorer and TRX output:
+
+- **Unfolded tests**: Each data row appears as a separate, independent test entry in Test Explorer and TRX. You can run, debug, or filter individual test cases. Each entry has its own pass/fail status.
+- **Folded tests**: All data rows appear as a single test node in Test Explorer. One entry appears in TRX, with multiple results associated with that single test case. You can't run or filter individual data rows independently.
+
+### Exception during discovery causes folding
+
+When MSTest evaluates a data source during discovery and the evaluation throws an exception, the test falls back to a folded state regardless of the configured unfolding strategy. Because the framework can't enumerate the individual test cases, it registers the test method as a single (folded) entry.
+
+At execution time, MSTest evaluates the data source again as part of the normal lifecycle. If the exception was caused by missing setup state (for example, a dependency that `ClassInitialize` provides), the data source might succeed during execution because the lifecycle hooks have now run.
+
+> [!NOTE]
+> When debugging a test that throws during discovery, you might see an exception (for example, a `NullReferenceException`) before the test starts. This exception comes from the discovery-phase evaluation. Press **Continue** in the debugger—the test then executes normally because the execution phase runs the full MSTest lifecycle, including initialization methods. For more details, see [microsoft/testfx#7774](https://github.com/microsoft/testfx/issues/7774).
 
 ### When to change the strategy
 
-For most scenarios, the default `Auto` behavior provides the best balance. Consider changing this setting only when you have specific requirements:
+For most scenarios, the default `Auto` behavior provides the best balance. Consider changing the unfolding strategy when you have specific requirements:
 
-- Non-deterministic data sources
-- Known limitations or bugs in MSTest
-- Performance concerns with many test cases
+- Data sources that depend on runtime state or setup logic that isn't available during discovery
+- Non-deterministic data sources that return different values on each evaluation
+- Performance concerns with large numbers of test cases
 
 ### Example usage
 
@@ -536,15 +561,11 @@ public class UnfoldingExample
 
 ## Best practices
 
-1. **Choose the right attribute**: Use `DataRow` for simple, inline data. Use `DynamicData` for complex or computed data.
-
-1. **Name your test cases**: Use `DisplayName` to make test failures easier to identify.
-
-1. **Keep data sources close**: Define data sources in the same class when possible for better maintainability.
-
-1. **Use meaningful data**: Choose test data that exercises edge cases and boundary conditions.
-
-1. **Consider combinatorial testing**: For testing parameter combinations, use the [Combinatorial.MSTest](https://www.nuget.org/packages/Combinatorial.MSTest) package.
+- **Choose the right attribute**: Use `DataRow` for simple, inline data. Use `DynamicData` for complex or computed data.
+- **Name your test cases**: Use `DisplayName` to make test failures easier to identify.
+- **Keep data sources close**: Define data sources in the same class when possible for better maintainability.
+- **Use meaningful data**: Choose test data that exercises edge cases and boundary conditions.
+- **Consider combinatorial testing**: For testing parameter combinations, use the [Combinatorial.MSTest](https://www.nuget.org/packages/Combinatorial.MSTest) package.
 
 ## See also
 

--- a/docs/core/testing/unit-testing-mstest-writing-tests-data-driven.md
+++ b/docs/core/testing/unit-testing-mstest-writing-tests-data-driven.md
@@ -496,8 +496,8 @@ Data-driven test attributes support the <xref:Microsoft.VisualStudio.TestTools.U
 
 MSTest processes data-driven tests in two distinct phases:
 
-1. **Discovery phase**: MSTest evaluates all data source attributes (`DataRow`, `DynamicData`, `ITestDataSource`) to determine the list of test cases. This evaluation happens *before* any of the regular MSTest lifecycle hooks run—`AssemblyInitialize`, `ClassInitialize`, and other setup methods haven't executed yet.
-1. **Execution phase**: MSTest runs the normal lifecycle (assembly initialization, class initialization, test initialization, test method, cleanup) and executes each test case with its data.
+- **Discovery phase**: MSTest evaluates all data source attributes (`DataRow`, `DynamicData`, `ITestDataSource`) to determine the list of test cases. This evaluation happens *before* any of the regular MSTest lifecycle hooks run—`AssemblyInitialize`, `ClassInitialize`, and other setup methods haven't executed yet.
+- **Execution phase**: MSTest runs the normal lifecycle (assembly initialization, class initialization, test initialization, test method, cleanup) and executes each test case with its data.
 
 Because data sources are evaluated during discovery, your data-generation code can't rely on any state set up by `AssemblyInitialize` or `ClassInitialize`. If your data source depends on setup logic (for example, reading from a database connection initialized in `ClassInitialize`), the data source evaluation fails during discovery.
 
@@ -529,9 +529,9 @@ At execution time, MSTest evaluates the data source again as part of the normal 
 
 For most scenarios, the default `Auto` behavior provides the best balance. Consider changing the unfolding strategy when you have specific requirements:
 
-- Data sources that depend on runtime state or setup logic that isn't available during discovery
-- Non-deterministic data sources that return different values on each evaluation
-- Performance concerns with large numbers of test cases
+- Use `Fold` if your data sources depend on runtime state or setup logic that isn't available during discovery.
+- Use `Fold` for non-deterministic data sources that return different values on each evaluation.
+- Use `Fold` to reduce overhead when performance is a concern with large numbers of test cases.
 
 ### Example usage
 


### PR DESCRIPTION
## Summary

Expands the "Unfolding strategy" section in the data-driven testing article to document important behavioral details that were previously missing.

## Changes

- **Discovery and execution phases**: Explains that data sources are evaluated during discovery *before* any MSTest lifecycle hooks (`AssemblyInitialize`, `ClassInitialize`) run, and that data-generation code can't rely on state from those hooks.
- **Folded vs. unfolded tests**: Clarifies the concrete differences—unfolded tests appear as separate entries in Test Explorer and TRX with individual pass/fail status, while folded tests appear as a single node with multiple results.
- **Exception during discovery causes folding**: Documents that an exception during data source evaluation causes the test to fall back to folded, and that execution might succeed because lifecycle hooks have run by then. Includes a note about the debugging experience (seeing an exception, pressing Continue, test runs normally).
- **Style fixes**: "allows you to" → "lets you", "one or multiple" → "one or more", heading formatting consistency for `TestDataRow`, "associated to" → "associated with", numbered list → bullet list for non-procedural best practices.

Related to microsoft/testfx#7774

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-writing-tests-data-driven.md](https://github.com/dotnet/docs/blob/dfa8036d110195617f2bc70987d6ce0a0d69dc5b/docs/core/testing/unit-testing-mstest-writing-tests-data-driven.md) | [docs/core/testing/unit-testing-mstest-writing-tests-data-driven](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-writing-tests-data-driven?branch=pr-en-us-53360) |


<!-- PREVIEW-TABLE-END -->