### PR TITLE
docs: align namespace sample with using directive text

### DIFF
--- a/docs/csharp/fundamentals/program-structure/snippets/namespaces/Basics.cs
+++ b/docs/csharp/fundamentals/program-structure/snippets/namespaces/Basics.cs
@@ -1,4 +1,5 @@
 // <NamespaceBasics>
+using System;
 using System.Globalization;
 
 namespace MyApp.Services;


### PR DESCRIPTION
## Summary
- add `using System;` to the namespace basics snippet
- align the sample with the surrounding article text that explicitly references `using System;`

## Why
The article says the sample uses `using System;`, but the snippet didn't show that directive. This small change makes the code and explanation consistent for beginners.

Closes #50089
