### PR TITLE
document DOTNET_EventPipeThreadSamplingRate

### DIFF
--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -233,6 +233,9 @@ dotnet-trace collect
   |--------------|----------------------------------------------------------|
   | `dotnet-common` | Lightweight .NET runtime diagnostics designed to stay low overhead.<br>Includes GC, AssemblyLoader, Loader, JIT, Exceptions, Threading, JittedMethodILToNativeMap, and Compilation events<br>Equivalent to `--providers "Microsoft-Windows-DotNETRuntime:0x100003801D:4"`. |
   | `dotnet-sampled-thread-time` | Samples .NET thread stacks (~100 Hz) to identify hotspots over time. Uses the runtime sample profiler with managed stacks. |
+
+  > [!TIP]
+  > The sampling rate used by `dotnet-sampled-thread-time` can be changed with the `DOTNET_EventPipeThreadSamplingRate` environment variable (value in milliseconds). This setting is process-global and affects all EventPipe sessions. See [EventPipe thread sampling rate](../runtime-config/debugging-profiling.md#eventpipe-thread-sampling-rate) for details.
   | `gc-verbose` | Tracks GC collections and samples object allocations.    |
   | `gc-collect` | Tracks GC collections only at very low overhead.         |
   | `database`   | Captures ADO.NET and Entity Framework database commands. |

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -235,7 +235,7 @@ dotnet-trace collect
   | `dotnet-sampled-thread-time` | Samples .NET thread stacks (~100 Hz) to identify hotspots over time. Uses the runtime sample profiler with managed stacks. |
 
   > [!TIP]
-  > The sampling rate used by `dotnet-sampled-thread-time` can be changed with the `DOTNET_EventPipeThreadSamplingRate` environment variable (value in milliseconds). This setting is process-global and affects all EventPipe sessions. See [EventPipe thread sampling rate](../runtime-config/debugging-profiling.md#eventpipe-thread-sampling-rate) for details.
+  > The sampling rate used by `dotnet-sampled-thread-time` can be changed with the `DOTNET_EventPipeThreadSamplingRate` environment variable (value in milliseconds). This setting is process-global and affects all EventPipe sessions. See [Trace using environment variables](./eventpipe.md#trace-using-environment-variables) for details.
   | `gc-verbose` | Tracks GC collections and samples object allocations.    |
   | `gc-collect` | Tracks GC collections only at very low overhead.         |
   | `database`   | Captures ADO.NET and Entity Framework database commands. |

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -233,12 +233,12 @@ dotnet-trace collect
   |--------------|----------------------------------------------------------|
   | `dotnet-common` | Lightweight .NET runtime diagnostics designed to stay low overhead.<br>Includes GC, AssemblyLoader, Loader, JIT, Exceptions, Threading, JittedMethodILToNativeMap, and Compilation events<br>Equivalent to `--providers "Microsoft-Windows-DotNETRuntime:0x100003801D:4"`. |
   | `dotnet-sampled-thread-time` | Samples .NET thread stacks (~100 Hz) to identify hotspots over time. Uses the runtime sample profiler with managed stacks. |
-
-  > [!TIP]
-  > The sampling rate used by `dotnet-sampled-thread-time` can be changed with the `DOTNET_EventPipeThreadSamplingRate` environment variable (value in milliseconds). This setting is process-global and affects all EventPipe sessions. See [Trace using environment variables](./eventpipe.md#trace-using-environment-variables) for details.
   | `gc-verbose` | Tracks GC collections and samples object allocations.    |
   | `gc-collect` | Tracks GC collections only at very low overhead.         |
   | `database`   | Captures ADO.NET and Entity Framework database commands. |
+
+  > [!TIP]
+  > The sampling rate used by `dotnet-sampled-thread-time` can be changed with the `DOTNET_EventPipeThreadSamplingRate` environment variable (value in milliseconds). This setting is process-global and affects all EventPipe sessions. See [Trace using environment variables](./eventpipe.md#trace-using-environment-variables) for details.
 
   > [!NOTE]
   > In past versions of the dotnet-trace tool, the collect verb supported a profile called `cpu-sampling`. This profile was removed because the name was misleading. It sampled all threads regardless of their CPU usage. You can achieve a similar result now using `--profile dotnet-sampled-thread-time,dotnet-common`. If you need to match the former `cpu-sampling` behavior exactly, use `--profile dotnet-sampled-thread-time --providers "Microsoft-Windows-DotNETRuntime:0x14C14FCCBD:4"`.

--- a/docs/core/diagnostics/eventpipe.md
+++ b/docs/core/diagnostics/eventpipe.md
@@ -84,7 +84,7 @@ However, you can use the following environment variables to set up an EventPipe 
 
 * `DOTNET_EventPipeProcNumbers`: Set this to `1` to enable capturing processor numbers in EventPipe event headers. The default value is `0`.
 
-* `DOTNET_EventPipeThreadSamplingRate`: Sets the interval, in milliseconds, for the EventPipe thread time sampling profiler. When set to `0` or omitted, the runtime uses its built-in default (1 ms on most platforms, 5 ms on WebAssembly). This setting is process-global and affects all EventPipe sessions, including on-demand traces started by tools such as [dotnet-trace](./dotnet-trace.md). Setting a large value reduces sampling overhead but also reduces the resolution of any trace collected during the process lifetime.
+* `DOTNET_EventPipeThreadSamplingRate`: Available in .NET 11+. Sets the interval, in milliseconds, for the EventPipe thread time sampling profiler. When set to `0` or omitted, the runtime uses its built-in default of 10 ms (~100 Hz). This setting is process-global and affects all EventPipe sessions, including on-demand traces started by tools such as [dotnet-trace](./dotnet-trace.md). Setting a large value reduces sampling overhead but also reduces the resolution of any trace collected during the process lifetime.
 
 * `DOTNET_EventPipeConfig`: Sets up the EventPipe session configuration when starting an EventPipe session with `DOTNET_EnableEventPipe`.
   The syntax is as follows:

--- a/docs/core/diagnostics/eventpipe.md
+++ b/docs/core/diagnostics/eventpipe.md
@@ -84,7 +84,7 @@ However, you can use the following environment variables to set up an EventPipe 
 
 * `DOTNET_EventPipeProcNumbers`: Set this to `1` to enable capturing processor numbers in EventPipe event headers. The default value is `0`.
 
-* `DOTNET_EventPipeThreadSamplingRate`: Available in .NET 11+. Sets the interval, in milliseconds, for the EventPipe thread time sampling profiler. When set to `0` or omitted, the runtime uses its built-in default of 10 ms (~100 Hz). This setting is process-global and affects all EventPipe sessions, including on-demand traces started by tools such as [dotnet-trace](./dotnet-trace.md). Setting a large value reduces sampling overhead but also reduces the resolution of any trace collected during the process lifetime.
+* `DOTNET_EventPipeThreadSamplingRate`: Available in .NET 11 and later. Sets the interval, in milliseconds, for the EventPipe thread time sampling profiler. When set to `0` or omitted, the runtime uses its built-in default of 10 ms (~100 Hz). This setting is process-global and affects all EventPipe sessions, including on-demand traces started by tools such as [dotnet-trace](./dotnet-trace.md). Setting a large value reduces sampling overhead but also reduces the resolution of any trace collected during the process lifetime.
 
 * `DOTNET_EventPipeConfig`: Sets up the EventPipe session configuration when starting an EventPipe session with `DOTNET_EnableEventPipe`.
   The syntax is as follows:

--- a/docs/core/diagnostics/eventpipe.md
+++ b/docs/core/diagnostics/eventpipe.md
@@ -84,6 +84,8 @@ However, you can use the following environment variables to set up an EventPipe 
 
 * `DOTNET_EventPipeProcNumbers`: Set this to `1` to enable capturing processor numbers in EventPipe event headers. The default value is `0`.
 
+* `DOTNET_EventPipeThreadSamplingRate`: Sets the interval, in milliseconds, for the EventPipe thread time sampling profiler. When set to `0` or omitted, the runtime uses its built-in default (1 ms on most platforms, 5 ms on WebAssembly). This setting is process-global and affects all EventPipe sessions, including on-demand traces started by tools such as [dotnet-trace](./dotnet-trace.md). Setting a large value reduces sampling overhead but also reduces the resolution of any trace collected during the process lifetime.
+
 * `DOTNET_EventPipeConfig`: Sets up the EventPipe session configuration when starting an EventPipe session with `DOTNET_EnableEventPipe`.
   The syntax is as follows:
 

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -81,6 +81,17 @@ The following table compares perf maps and jit maps.
 | **runtimeconfig.json** | N/A          | N/A    |
 | **Environment variable** | `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - perf maps and jit dumps both enabled<br/>`2` - jit dumps enabled<br/>`3` - perf maps enabled |
 
+## EventPipe thread sampling rate
+
+- Overrides the default interval for the EventPipe thread time sampling profiler. The value is specified in milliseconds.
+- When set to `0` (or omitted), the runtime uses its built-in default (1 ms on most platforms, 5 ms on WebAssembly).
+- This setting is process-global: it affects **all** EventPipe sessions in the process, including on-demand traces collected by tools such as [dotnet-trace](../diagnostics/dotnet-trace.md). There is currently no way to configure a per-session sampling rate. Setting a very large interval will reduce the resolution of any `dotnet-trace` session started later.
+
+|                          | Setting name                            | Values                                        |
+|--------------------------|-----------------------------------------|-----------------------------------------------|
+| **runtimeconfig.json**   | N/A                                     | N/A                                           |
+| **Environment variable** | `DOTNET_EventPipeThreadSamplingRate`    | Interval in milliseconds. `0` = use default.  |
+
 ## Perf log markers
 
 - Enables or disables the specified signal to be accepted and ignored as a marker in the perf logs.

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -81,7 +81,7 @@ The following table compares perf maps and jit maps.
 | **runtimeconfig.json** | N/A          | N/A    |
 | **Environment variable** | `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - perf maps and jit dumps both enabled<br/>`2` - jit dumps enabled<br/>`3` - perf maps enabled |
 
-For EventPipe-related environment variables (including `DOTNET_EventPipeThreadSamplingRate`), see [Trace using environment variables](../diagnostics/eventpipe.md#trace-using-environment-variables).
+For EventPipe-related environment variables, see [Trace using environment variables](../diagnostics/eventpipe.md#trace-using-environment-variables).
 
 ## Perf log markers
 

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -81,16 +81,7 @@ The following table compares perf maps and jit maps.
 | **runtimeconfig.json** | N/A          | N/A    |
 | **Environment variable** | `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - perf maps and jit dumps both enabled<br/>`2` - jit dumps enabled<br/>`3` - perf maps enabled |
 
-## EventPipe thread sampling rate
-
-- Overrides the default interval for the EventPipe thread time sampling profiler. The value is specified in milliseconds.
-- When set to `0` (or omitted), the runtime uses its built-in default (1 ms on most platforms, 5 ms on WebAssembly).
-- This setting is process-global: it affects **all** EventPipe sessions in the process, including on-demand traces collected by tools such as [dotnet-trace](../diagnostics/dotnet-trace.md). There is currently no way to configure a per-session sampling rate. Setting a very large interval will reduce the resolution of any `dotnet-trace` session started later.
-
-|                          | Setting name                            | Values                                        |
-|--------------------------|-----------------------------------------|-----------------------------------------------|
-| **runtimeconfig.json**   | N/A                                     | N/A                                           |
-| **Environment variable** | `DOTNET_EventPipeThreadSamplingRate`    | Interval in milliseconds. `0` = use default.  |
+For EventPipe-related environment variables (including `DOTNET_EventPipeThreadSamplingRate`), see [Trace using environment variables](../diagnostics/eventpipe.md#trace-using-environment-variables).
 
 ## Perf log markers
 


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/pull/127292

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/dotnet-trace.md](https://github.com/dotnet/docs/blob/e6981cdd73cb50b327eeb59dafc18171a96b09bb/docs/core/diagnostics/dotnet-trace.md) | [dotnet-trace performance analysis utility](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace?branch=pr-en-us-53393) |
| [docs/core/diagnostics/eventpipe.md](https://github.com/dotnet/docs/blob/e6981cdd73cb50b327eeb59dafc18171a96b09bb/docs/core/diagnostics/eventpipe.md) | [EventPipe Overview](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/eventpipe?branch=pr-en-us-53393) |
| [docs/core/runtime-config/debugging-profiling.md](https://github.com/dotnet/docs/blob/e6981cdd73cb50b327eeb59dafc18171a96b09bb/docs/core/runtime-config/debugging-profiling.md) | [Runtime configuration options for debugging and profiling](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/debugging-profiling?branch=pr-en-us-53393) |


<!-- PREVIEW-TABLE-END -->