### PR TITLE
Document new EnvironmentVariablesConfigurationProvider connection string prefixes (.NET 10)

### DIFF
--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -209,9 +209,9 @@ For more information on host and app configuration, see [.NET Generic Host](gene
 
 ### Connection string prefixes
 
-The Configuration API has special processing rules for connection string environment variables. These connection strings are involved in configuring Azure connection strings for the app environment. Environment variables with the prefixes shown in the table are loaded into the app with the default configuration or when no prefix is supplied to `AddEnvironmentVariables`.
+The Configuration API has special processing rules for connection string environment variables. These connection strings are involved in configuring Azure connection strings for the app environment. Environment variables with the prefixes shown in the following tables are loaded into the app with the default configuration or when no prefix is supplied to `AddEnvironmentVariables`.
 
-In .NET 8 and .NET 9, four connection string prefixes are recognized:
+Before .NET 10, four connection string prefixes are recognized:
 
 | Connection string prefix | Provider                                                                |
 |--------------------------|-------------------------------------------------------------------------|

--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -211,7 +211,7 @@ For more information on host and app configuration, see [.NET Generic Host](gene
 
 The Configuration API has special processing rules for connection string environment variables. These connection strings are involved in configuring Azure connection strings for the app environment. Environment variables with the prefixes shown in the following tables are loaded into the app with the default configuration or when no prefix is supplied to `AddEnvironmentVariables`.
 
-Before .NET 10, four connection string prefixes are recognized:
+In .NET 9 and earlier versions, four connection string prefixes are recognized:
 
 | Connection string prefix | Provider                                                                |
 |--------------------------|-------------------------------------------------------------------------|
@@ -236,26 +236,26 @@ Starting in .NET 10, seven additional prefixes are recognized for a total of 11:
 | `SQLAZURECONNSTR_`        | [Azure SQL Database](https://azure.microsoft.com/services/sql-database)                 |
 | `SQLCONNSTR_`             | [SQL Server](https://www.microsoft.com/sql-server)                                      |
 
-When an environment variable is discovered and loaded into configuration with any of the prefixes shown above:
+When an environment variable is discovered and loaded into configuration with any of the recognized prefixes:
 
 - The configuration key is created by removing the environment variable prefix and adding a configuration key section (`ConnectionStrings`).
-- A new configuration key-value pair is created that represents the database connection provider, when a provider name is associated with the prefix.
+- A new configuration key-value pair is created that represents the database connection provider when a provider name is associated with the prefix.
 
 The following table shows the configuration entries produced for each prefix. Prefixes marked _.NET 10+_ are only processed when running on .NET 10 or later.
 
-| Environment variable key         | Converted configuration key | Provider configuration entry                                                    |
-|----------------------------------|-----------------------------|---------------------------------------------------------------------------------|
-| `CUSTOMCONNSTR_{KEY}`            | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
-| `MYSQLCONNSTR_{KEY}`             | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `MySql.Data.MySqlClient` |
-| `SQLAZURECONNSTR_{KEY}`          | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `System.Data.SqlClient`  |
-| `SQLCONNSTR_{KEY}`               | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `System.Data.SqlClient`  |
-| `POSTGRESQLCONNSTR_{KEY}` _(.NET 10+)_      | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `Npgsql`                 |
+| Environment variable key                    | Converted configuration key | Provider configuration entry                                                    |
+|---------------------------------------------|-----------------------------|---------------------------------------------------------------------------------|
 | `APIHUBCONNSTR_{KEY}` _(.NET 10+)_          | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
+| `CUSTOMCONNSTR_{KEY}`                       | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
 | `DOCDBCONNSTR_{KEY}` _(.NET 10+)_           | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
 | `EVENTHUBCONNSTR_{KEY}` _(.NET 10+)_        | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
+| `MYSQLCONNSTR_{KEY}`                        | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `MySql.Data.MySqlClient` |
 | `NOTIFICATIONHUBCONNSTR_{KEY}` _(.NET 10+)_ | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
+| `POSTGRESQLCONNSTR_{KEY}` _(.NET 10+)_      | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `Npgsql`                 |
 | `REDISCACHECONNSTR_{KEY}` _(.NET 10+)_      | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
 | `SERVICEBUSCONNSTR_{KEY}` _(.NET 10+)_      | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
+| `SQLAZURECONNSTR_{KEY}`                     | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `System.Data.SqlClient`  |
+| `SQLCONNSTR_{KEY}`                          | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `System.Data.SqlClient`  |
 
 [!INCLUDE [managed-identities](../../includes/managed-identities.md)]
 

--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -1,7 +1,8 @@
 ---
 title: Configuration providers
 description: Discover how to configure .NET apps using the configuration provider API and the available configuration providers.
-ms.date: 12/16/2024
+ms.date: 04/28/2026
+ai-usage: ai-assisted
 ---
 
 # Configuration providers in .NET
@@ -208,7 +209,9 @@ For more information on host and app configuration, see [.NET Generic Host](gene
 
 ### Connection string prefixes
 
-The Configuration API has special processing rules for four connection string environment variables. These connection strings are involved in configuring Azure connection strings for the app environment. Environment variables with the prefixes shown in the table are loaded into the app with the default configuration or when no prefix is supplied to `AddEnvironmentVariables`.
+The Configuration API has special processing rules for connection string environment variables. These connection strings are involved in configuring Azure connection strings for the app environment. Environment variables with the prefixes shown in the table are loaded into the app with the default configuration or when no prefix is supplied to `AddEnvironmentVariables`.
+
+In .NET 8 and .NET 9, four connection string prefixes are recognized:
 
 | Connection string prefix | Provider                                                                |
 |--------------------------|-------------------------------------------------------------------------|
@@ -217,17 +220,42 @@ The Configuration API has special processing rules for four connection string en
 | `SQLAZURECONNSTR_`       | [Azure SQL Database](https://azure.microsoft.com/services/sql-database) |
 | `SQLCONNSTR_`            | [SQL Server](https://www.microsoft.com/sql-server)                      |
 
-When an environment variable is discovered and loaded into configuration with any of the four prefixes shown in the table:
+Starting in .NET 10, seven additional prefixes are recognized for a total of 11:
+
+| Connection string prefix  | Provider                                                                                |
+|---------------------------|-----------------------------------------------------------------------------------------|
+| `APIHUBCONNSTR_`          | [Azure API hubs](/azure/connectors/apihubs)                                             |
+| `CUSTOMCONNSTR_`          | Custom provider                                                                         |
+| `DOCDBCONNSTR_`           | [Azure Cosmos DB](https://azure.microsoft.com/services/cosmos-db)                       |
+| `EVENTHUBCONNSTR_`        | [Azure Event Hubs](https://azure.microsoft.com/services/event-hubs)                     |
+| `MYSQLCONNSTR_`           | [MySQL](https://www.mysql.com)                                                          |
+| `NOTIFICATIONHUBCONNSTR_` | [Azure Notification Hubs](https://azure.microsoft.com/services/notification-hubs)       |
+| `POSTGRESQLCONNSTR_`      | [PostgreSQL](https://www.postgresql.org)                                                |
+| `REDISCACHECONNSTR_`      | [Azure Cache for Redis](https://azure.microsoft.com/services/cache)                     |
+| `SERVICEBUSCONNSTR_`      | [Azure Service Bus](https://azure.microsoft.com/services/service-bus)                   |
+| `SQLAZURECONNSTR_`        | [Azure SQL Database](https://azure.microsoft.com/services/sql-database)                 |
+| `SQLCONNSTR_`             | [SQL Server](https://www.microsoft.com/sql-server)                                      |
+
+When an environment variable is discovered and loaded into configuration with any of the prefixes shown above:
 
 - The configuration key is created by removing the environment variable prefix and adding a configuration key section (`ConnectionStrings`).
-- A new configuration key-value pair is created that represents the database connection provider (except for `CUSTOMCONNSTR_`, which has no stated provider).
+- A new configuration key-value pair is created that represents the database connection provider, when a provider name is associated with the prefix.
 
-| Environment variable key | Converted configuration key | Provider configuration entry                                                    |
-|--------------------------|-----------------------------|---------------------------------------------------------------------------------|
-| `CUSTOMCONNSTR_{KEY}`    | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
-| `MYSQLCONNSTR_{KEY}`     | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `MySql.Data.MySqlClient` |
-| `SQLAZURECONNSTR_{KEY}`  | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `System.Data.SqlClient`  |
-| `SQLCONNSTR_{KEY}`       | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `System.Data.SqlClient`  |
+The following table shows the configuration entries produced for each prefix. Prefixes marked _.NET 10+_ are only processed when running on .NET 10 or later.
+
+| Environment variable key         | Converted configuration key | Provider configuration entry                                                    |
+|----------------------------------|-----------------------------|---------------------------------------------------------------------------------|
+| `CUSTOMCONNSTR_{KEY}`            | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
+| `MYSQLCONNSTR_{KEY}`             | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `MySql.Data.MySqlClient` |
+| `SQLAZURECONNSTR_{KEY}`          | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `System.Data.SqlClient`  |
+| `SQLCONNSTR_{KEY}`               | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `System.Data.SqlClient`  |
+| `POSTGRESQLCONNSTR_{KEY}` _(.NET 10+)_      | `ConnectionStrings:{KEY}`   | Key: `ConnectionStrings:{KEY}_ProviderName`:<br>Value: `Npgsql`                 |
+| `APIHUBCONNSTR_{KEY}` _(.NET 10+)_          | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
+| `DOCDBCONNSTR_{KEY}` _(.NET 10+)_           | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
+| `EVENTHUBCONNSTR_{KEY}` _(.NET 10+)_        | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
+| `NOTIFICATIONHUBCONNSTR_{KEY}` _(.NET 10+)_ | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
+| `REDISCACHECONNSTR_{KEY}` _(.NET 10+)_      | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
+| `SERVICEBUSCONNSTR_{KEY}` _(.NET 10+)_      | `ConnectionStrings:{KEY}`   | Configuration entry not created.                                                |
 
 [!INCLUDE [managed-identities](../../includes/managed-identities.md)]
 

--- a/docs/core/extensions/configuration-providers.md
+++ b/docs/core/extensions/configuration-providers.md
@@ -224,7 +224,7 @@ Starting in .NET 10, seven additional prefixes are recognized for a total of 11:
 
 | Connection string prefix  | Provider                                                                                |
 |---------------------------|-----------------------------------------------------------------------------------------|
-| `APIHUBCONNSTR_`          | [Azure API hubs](/azure/connectors/apihubs)                                             |
+| `APIHUBCONNSTR_`          | Azure API hubs                                                                          |
 | `CUSTOMCONNSTR_`          | Custom provider                                                                         |
 | `DOCDBCONNSTR_`           | [Azure Cosmos DB](https://azure.microsoft.com/services/cosmos-db)                       |
 | `EVENTHUBCONNSTR_`        | [Azure Event Hubs](https://azure.microsoft.com/services/event-hubs)                     |


### PR DESCRIPTION
Documents the seven new connection string prefixes recognized by `EnvironmentVariablesConfigurationProvider` starting in .NET 10, added by [dotnet/runtime#116037](https://github.com/dotnet/runtime/pull/116037).

## Changes

- Split the **Connection string prefixes** table into two: one for .NET 8 / .NET 9 (4 prefixes) and one for .NET 10+ (11 prefixes).
- Added `_(.NET 10+)_` markers in the conversion table for the new entries:
  - `POSTGRESQLCONNSTR_` → `Npgsql`
  - `APIHUBCONNSTR_`, `DOCDBCONNSTR_`, `EVENTHUBCONNSTR_`, `NOTIFICATIONHUBCONNSTR_`, `REDISCACHECONNSTR_`, `SERVICEBUSCONNSTR_` (no `_ProviderName` entry)
- Bumped `ms.date` and added `ai-usage: ai-assisted` to front matter.

## Source

Verified against `src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs` on `release/8.0`, `release/9.0`, `release/10.0`, and `main` (.NET 11).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/extensions/configuration-providers.md](https://github.com/dotnet/docs/blob/bf621b038c9ae7e7b922326c0f9fe785dae4d544/docs/core/extensions/configuration-providers.md) | [docs/core/extensions/configuration-providers](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/configuration-providers?branch=pr-en-us-53400) |


<!-- PREVIEW-TABLE-END -->