### PR TITLE
Add GHCP modernization tip to upgrade

### DIFF
--- a/docs/core/tools/sdk-errors/netsdk1138.md
+++ b/docs/core/tools/sdk-errors/netsdk1138.md
@@ -16,6 +16,9 @@ Out-of-support versions include 1.0, 1.1, 2.0, 2.1, 2.2, 3.0, 3.1, 5, 6, and 7.
 
 To resolve this error, change your project to target a supported version of .NET.
 
+> [!TIP]
+> You can use [GitHub Copilot modernization](https://aka.ms/ghcp-modernization/dotNET) to assess, plan, and upgrade your project to a supported version of .NET.
+
 If you want to suppress the message without targeting a later framework, set the MSBuild property `CheckEolTargetFramework` to `false`. You can set it in the project file or by passing `/p:CheckEolTargetFramework=false` to a .NET CLI command, such as `dotnet build`. Here's an example project file:
 
 ```xml

--- a/docs/core/tools/sdk-errors/netsdk1138.md
+++ b/docs/core/tools/sdk-errors/netsdk1138.md
@@ -17,7 +17,7 @@ Out-of-support versions include 1.0, 1.1, 2.0, 2.1, 2.2, 3.0, 3.1, 5, 6, and 7.
 To resolve this error, change your project to target a supported version of .NET.
 
 > [!TIP]
-> You can use [GitHub Copilot modernization](https://aka.ms/ghcp-modernization/dotNET) to assess, plan, and upgrade your project to a supported version of .NET.
+> You can use [GitHub Copilot modernization](../../porting/github-copilot-app-modernization/overview.md) to assess, plan, and upgrade your project to a supported version of .NET.
 
 If you want to suppress the message without targeting a later framework, set the MSBuild property `CheckEolTargetFramework` to `false`. You can set it in the project file or by passing `/p:CheckEolTargetFramework=false` to a .NET CLI command, such as `dotnet build`. Here's an example project file:
 


### PR DESCRIPTION
## Summary

Adds a call-to-action to the modernization tooling to act as a breadcrumb for users that are hitting deprecation warnings.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/sdk-errors/netsdk1138.md](https://github.com/dotnet/docs/blob/2ffa8bb109fcfeaddf2775ffad785f39d247d761/docs/core/tools/sdk-errors/netsdk1138.md) | [NETSDK1138: The target framework is out of support](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1138?branch=pr-en-us-53405) |


<!-- PREVIEW-TABLE-END -->