### PR TITLE
Revert "Update dotnet nuget verify docs for CRL and OCSP URL verbosity output"

### DIFF
--- a/docs/core/tools/dotnet-nuget-verify.md
+++ b/docs/core/tools/dotnet-nuget-verify.md
@@ -64,15 +64,11 @@ In .NET 10 and later versions, the command also outputs the package's content ha
   `Hashing algorithm used for signature`        | ❌       | ❌          | ✔️         | ✔️         | ✔️
   `Author/Repository Certificate -> SHA1 hash`| ❌       | ❌          | ✔️         | ✔️         | ✔️
   `Author/Repository Certificate -> Issued By`| ❌       | ❌          | ✔️         | ✔️         | ✔️
-  `Author/Repository Certificate -> CRL URL`¹| ❌       | ❌          | ✔️         | ✔️         | ✔️
-  `Author/Repository Certificate -> OCSP URL`¹| ❌       | ❌          | ✔️         | ✔️         | ✔️
   `Timestamp Certificate -> Issued By`| ❌       | ❌          | ✔️         | ✔️         | ✔️
   `Timestamp Certificate -> SHA-256 hash`| ❌       | ❌          | ✔️         | ✔️         | ✔️
   `Timestamp Certificate -> Validity period`| ❌       | ❌          | ✔️         | ✔️         | ✔️
   `Timestamp Certificate -> SHA1 hash`| ❌       | ❌          | ✔️         | ✔️         | ✔️
   `Timestamp Certificate -> Subject name`| ❌       | ❌          | ✔️         | ✔️         | ✔️
-  `Timestamp Certificate -> CRL URL`¹| ❌       | ❌          | ✔️         | ✔️         | ✔️
-  `Timestamp Certificate -> OCSP URL`¹| ❌       | ❌          | ✔️         | ✔️         | ✔️
   `Author/Repository Certificate -> Subject name`| ❌       | ✔️          | ✔️         | ✔️         | ✔️
   `Author/Repository Certificate -> SHA-256 hash`| ❌       | ✔️          | ✔️         | ✔️         | ✔️
   `Author/Repository Certificate -> Validity period`| ❌       | ✔️          | ✔️         | ✔️         | ✔️
@@ -81,8 +77,6 @@ In .NET 10 and later versions, the command also outputs the package's content ha
   `Type of signature (author or repository)`| ❌       | ✔️          | ✔️         | ✔️         | ✔️
 
   ❌ indicates details that are **not** displayed. ✔️ indicates details that are displayed.
-
-  ¹ Requires .NET SDK 10.0.300 or later.
 
 - [!INCLUDE [configfile](includes/cli-configfile.md)]
 


### PR DESCRIPTION
Reverts dotnet/docs#53404

Sorry, I didn't realize the implementation was actually reverted before the release.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-nuget-verify.md](https://github.com/dotnet/docs/blob/284549a338db8b9e16930316d788286a85741e4e/docs/core/tools/dotnet-nuget-verify.md) | [docs/core/tools/dotnet-nuget-verify](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-verify?branch=pr-en-us-53408) |

<!-- PREVIEW-TABLE-END -->