### PR TITLE
Add error code 3 - RuntimeException to singtool return codes

### DIFF
--- a/docs/framework/tools/signtool-exe.md
+++ b/docs/framework/tools/signtool-exe.md
@@ -153,6 +153,7 @@ signtool [command] [options] [file_name | ...]
 |0|Execution was successful.|  
 |1|Execution has failed.|  
 |2|Execution has completed with warnings.|  
+|3|Execution failed with RuntimeException.|
 
 ## Examples  
 


### PR DESCRIPTION
This pull request fixes #47639 
It adds the error code `3` to the return codes of SignTool page as the `RuntimeException` error code.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/tools/signtool-exe.md](https://github.com/dotnet/docs/blob/99a3f2bb1f6ab982d85f4c35cde1bda221bbcd78/docs/framework/tools/signtool-exe.md) | [SignTool.exe (Sign Tool)](https://review.learn.microsoft.com/en-us/dotnet/framework/tools/signtool-exe?branch=pr-en-us-53664) |

<!-- PREVIEW-TABLE-END -->