### PR TITLE
Update ICorDebugProcess11 documentation

### DIFF
--- a/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-enumerateloaderheapmemoryregions-method.md
+++ b/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-enumerateloaderheapmemoryregions-method.md
@@ -16,7 +16,7 @@ topic_type:
 ---
 # ICorDebugProcess11::EnumerateLoaderHeapMemoryRegions Method
 
-[Supported in .NET 5 through .NET 10.]
+Deprecated.
 
 Enumerates ranges of native memory that are used by the .NET runtime to store internal data structures that describe .NET types and methods. The information returned is the same information that would be shown by using the SOS `eeheap-loader` command.
 
@@ -42,7 +42,7 @@ HRESULT EnumerateLoaderHeapMemoryRegions(
 
  **Library:** CorGuids.lib
 
- **.NET Versions:** Available since .NET Core 5.0
+ **.NET Versions:** Available from .NET 8 through .NET 10.
 
 ## See also
 

--- a/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-enumerateloaderheapmemoryregions-method.md
+++ b/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-enumerateloaderheapmemoryregions-method.md
@@ -16,7 +16,7 @@ topic_type:
 ---
 # ICorDebugProcess11::EnumerateLoaderHeapMemoryRegions Method
 
-[Supported in .NET 5 and later versions.]
+[Supported in .NET 5-.NET 10.]
 
 Enumerates ranges of native memory that are used by the .NET runtime to store internal data structures that describe .NET types and methods. The information returned is the same information that would be shown by using the SOS `eeheap-loader` command.
 

--- a/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-enumerateloaderheapmemoryregions-method.md
+++ b/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-enumerateloaderheapmemoryregions-method.md
@@ -16,7 +16,7 @@ topic_type:
 ---
 # ICorDebugProcess11::EnumerateLoaderHeapMemoryRegions Method
 
-[Supported in .NET 5-.NET 10.]
+[Supported in .NET 5 through .NET 10.]
 
 Enumerates ranges of native memory that are used by the .NET runtime to store internal data structures that describe .NET types and methods. The information returned is the same information that would be shown by using the SOS `eeheap-loader` command.
 

--- a/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-interface.md
+++ b/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-interface.md
@@ -13,15 +13,15 @@ topic_type:
 ---
 # ICorDebugProcess11 Interface
 
-[Supported in .NET 5 through .NET 10.]
+[Supported in .NET 8 through .NET 10.]
 
-Provides a method that enumerates ranges of native memory that are used by the .NET runtime to store internal data structures that describe .NET types and methods. The returned information is the same information that would be shown by using the SOS `eeheap -loader` command.
+Deprecated. Provides a method that enumerates ranges of native memory that are used by the .NET runtime to store internal data structures that describe .NET types and methods. The returned information is the same information that would be shown by using the SOS `eeheap -loader` command.
 
 ## Methods
 
 |Method|Description|
 |------------|-----------------|
-|[EnumerateLoaderHeapMemoryRegions Method](icordebugprocess11-enumerateloaderheapmemoryregions-method.md)|Enumerates ranges of native memory that are used by the .NET runtime to store internal data structures that describe .NET types and methods. The information returned is the same information that would be shown by using the SOS `eeheap -loader` command. |
+|[EnumerateLoaderHeapMemoryRegions Method](icordebugprocess11-enumerateloaderheapmemoryregions-method.md)|Deprecated. Enumerates ranges of native memory that are used by the .NET runtime to store internal data structures that describe .NET types and methods. The information returned is the same information that would be shown by using the SOS `eeheap -loader` command. |
 
 ## Remarks
 

--- a/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-interface.md
+++ b/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-interface.md
@@ -13,7 +13,7 @@ topic_type:
 ---
 # ICorDebugProcess11 Interface
 
-[Supported in .NET 5-.NET 10.]
+[Supported in .NET 5 through .NET 10.]
 
 Provides a method that enumerates ranges of native memory that are used by the .NET runtime to store internal data structures that describe .NET types and methods. The returned information is the same information that would be shown by using the SOS `eeheap -loader` command.
 

--- a/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-interface.md
+++ b/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-interface.md
@@ -13,7 +13,7 @@ topic_type:
 ---
 # ICorDebugProcess11 Interface
 
-[Supported in .NET 5 and later versions.]
+[Supported in .NET 5-.NET 10.]
 
 Provides a method that enumerates ranges of native memory that are used by the .NET runtime to store internal data structures that describe .NET types and methods. The returned information is the same information that would be shown by using the SOS `eeheap -loader` command.
 


### PR DESCRIPTION
## Summary

Updating docs to reflect removal of ICorDebugProcess11. Context: https://github.com/dotnet/runtime/pull/128042
Closes https://github.com/dotnet/docs/issues/53690

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-enumerateloaderheapmemoryregions-method.md](https://github.com/dotnet/docs/blob/995cfd758a754a1cc11d35f6762f321e8cd05239/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-enumerateloaderheapmemoryregions-method.md) | [ICorDebugProcess11::EnumerateLoaderHeapMemoryRegions Method](https://review.learn.microsoft.com/en-us/dotnet/core/unmanaged-api/debugging/icordebug/icordebugprocess11-enumerateloaderheapmemoryregions-method?branch=pr-en-us-53677) |
| [docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-interface.md](https://github.com/dotnet/docs/blob/995cfd758a754a1cc11d35f6762f321e8cd05239/docs/core/unmanaged-api/debugging/icordebug/icordebugprocess11-interface.md) | ["ICorDebugProcess11 Interface"](https://review.learn.microsoft.com/en-us/dotnet/core/unmanaged-api/debugging/icordebug/icordebugprocess11-interface?branch=pr-en-us-53677) |


<!-- PREVIEW-TABLE-END -->