### PR TITLE
Fix variable name in program-structure typo example

### DIFF
--- a/docs/csharp/fundamentals/program-structure/index.md
+++ b/docs/csharp/fundamentals/program-structure/index.md
@@ -104,7 +104,7 @@ A *statement* performs an action. Statements control program flow, declare varia
 - `if (condition) { /* code */ }` (conditional statement)
 - `return result;` (return statement)
 
-Statements often contain expressions, and expressions can nest inside other expressions. For example, the following declaration statement assigns `f` to the result of an addition expression. That addition expression adds the results of two method call expressions:
+Statements often contain expressions, and expressions can nest inside other expressions. For example, the following declaration statement assigns `maxResult` to the result of an addition expression. That addition expression adds the results of two method call expressions:
 
 ```csharp
 var maxResult = Math.Max(a, b) + Math.Max(c, d);


### PR DESCRIPTION
## Summary

Fix the variable name in the prose example under "Statements" — the narration referred to a variable named `f`, but the accompanying code snippet declares `maxResult`. Update the narration to match the snippet.

Fixes #53696.

---

Prepared with AI assistance (Claude Sonnet 4.6 via Claude Code).


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/program-structure/index.md](https://github.com/dotnet/docs/blob/a3138da42cec5fdea7306ae6de4c7b2011d44053/docs/csharp/fundamentals/program-structure/index.md) | [General structure of a C# program](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/index?branch=pr-en-us-53697) |

<!-- PREVIEW-TABLE-END -->