### PR TITLE
Document testconfig.json platformOptions and environment variables

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-config.md
+++ b/docs/core/testing/microsoft-testing-platform-config.md
@@ -1,9 +1,9 @@
 ---
 title: Microsoft.Testing.Platform (MTP) config options
-description: Learn how to configure MTP using configuration settings.
+description: Learn how to configure MTP using testconfig.json configuration settings and environment variables.
 author: Evangelink
 ms.author: amauryleve
-ms.date: 08/15/2024
+ms.date: 05/13/2026
 ---
 
 # Microsoft.Testing.Platform (MTP) configuration settings
@@ -19,8 +19,7 @@ The *testconfig.json* file has the following structure:
 ```json
 {
     "platformOptions": {
-        "config-property-name1": "config-value1",
-        "config-property-name2": "config-value2"
+        "resultDirectory": "./TestResults"
     }
 }
 ```
@@ -34,6 +33,105 @@ Starting with MTP 1.5, you can use the command-line argument `--config-file` to 
 > [!NOTE]
 > The *[appname].testconfig.json* file will get overwritten on subsequent builds.
 
+### Use a centralized testconfig.json
+
+If you want a single *testconfig.json* shared across multiple test projects, you can place it in a central location and pass it via `--config-file`. When MSBuild is available (for example, `dotnet test` or `dotnet run`), you can use the `TestingPlatformCommandLineArguments` MSBuild property to automatically pass the argument. Adding this to a *Directory.Build.props* at the repository root ensures all test projects use the same configuration:
+
+```xml
+<PropertyGroup>
+  <TestingPlatformCommandLineArguments>
+    $(TestingPlatformCommandLineArguments) --config-file $(MSBuildThisFileDirectory)testconfig.json
+  </TestingPlatformCommandLineArguments>
+</PropertyGroup>
+```
+
+### Configuration precedence
+
+When the same setting can be specified in multiple ways, MTP resolves it in the following order (first match wins):
+
+1. Command-line arguments (for example, `--results-directory`)
+1. Environment variables
+1. *testconfig.json* settings
+1. Built-in defaults
+
+### Platform options
+
+The `platformOptions` section of the *testconfig.json* file configures the core behavior of the test platform. The following table lists all supported platform options:
+
+| Entry | Default | Description |
+|-------|---------|-------------|
+| `resultDirectory` | `TestResults` | The directory where the test results are placed. Can be a relative path (resolved from the current working directory) or an absolute path. The `--results-directory` command-line option takes precedence. |
+| `exitProcessOnUnhandledException` | `false` | When set to `true`, the test host process exits immediately on unhandled exceptions instead of allowing graceful shutdown. The `TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION` environment variable (values `1` or `0`) takes precedence. |
+
+> [!NOTE]
+> Additional internal platform options exist for advanced scenarios (such as named-pipe timeouts for test host controllers). These options are intended for infrastructure use and are not covered here.
+
+Example:
+
+```json
+{
+  "platformOptions": {
+    "resultDirectory": "../../TestResults",
+    "exitProcessOnUnhandledException": false
+  }
+}
+```
+
+### Extension options are CLI-only
+
+Extension features such as [crash dump](microsoft-testing-platform-crash-hang-dumps.md), [hang dump](microsoft-testing-platform-crash-hang-dumps.md), [retry](microsoft-testing-platform-retry.md), [TRX reports](microsoft-testing-platform-test-reports.md), and [code coverage](microsoft-testing-platform-code-coverage.md) are **not** configurable via *testconfig.json*. These features are configured exclusively through command-line arguments.
+
+For a complete reference of command-line options, see [MTP CLI options reference](microsoft-testing-platform-cli-options.md).
+
+### Test framework-specific settings
+
+Test frameworks can define their own configuration sections in the *testconfig.json* file. Refer to the documentation for your test framework:
+
+- **MSTest**: [Configure MSTest — testconfig.json](unit-testing-mstest-configure.md#testconfigjson)
+- **xUnit.net v3**: [xUnit.net testconfig.json](https://xunit.net/docs/config-testconfig-json)
+- **NUnit**: See NUnit documentation for the latest Microsoft.Testing.Platform support.
+- **TUnit**: See TUnit documentation for the latest Microsoft.Testing.Platform support.
+
+### Example testconfig.json
+
+The following example shows a *testconfig.json* file that configures platform options and MSTest settings:
+
+```json
+{
+  "platformOptions": {
+    "resultDirectory": "./TestResults"
+  },
+  "mstest": {
+    "parallelism": {
+      "enabled": true,
+      "workers": 4,
+      "scope": "method"
+    },
+    "timeout": {
+      "test": 30000
+    },
+    "execution": {
+      "considerFixturesAsSpecialTests": true
+    }
+  }
+}
+```
+
+### Migrating from .runsettings to testconfig.json
+
+If you're migrating from a *.runsettings* file, the following table maps common settings to their *testconfig.json* equivalents or alternatives:
+
+| .runsettings setting | testconfig.json equivalent | Notes |
+|---|---|---|
+| `RunConfiguration/ResultsDirectory` | `platformOptions.resultDirectory` | |
+| `RunConfiguration/MaxCpuCount` | No equivalent | Process-level parallelism is controlled by `dotnet test --max-parallel-test-modules` or MSBuild `/m` option. |
+| `MSTest/*` | `mstest.*` | See [Configure MSTest — testconfig.json](unit-testing-mstest-configure.md#testconfigjson). |
+| `xUnit/*` | `xUnit.*` | See [xUnit.net testconfig.json](https://xunit.net/docs/config-testconfig-json). |
+| `LoggerRunSettings/Loggers` | CLI only | Use `--report-trx` or similar CLI options. |
+| `DataCollectionRunSettings` (blame) | CLI only | Use `--crashdump` and `--hangdump` CLI options. See [Crash and hang dumps](microsoft-testing-platform-crash-hang-dumps.md). |
+| `DataCollectionRunSettings` (coverage) | CLI only | Use `--coverage` CLI option. See [Code coverage](microsoft-testing-platform-code-coverage.md). |
+| `TestRunParameters` | `--test-parameter` CLI | Use `--test-parameter key=value` on the command line. |
+
 ## Environment variables
 
 Environment variables can be used to supply some runtime configuration information.
@@ -41,6 +139,48 @@ Environment variables can be used to supply some runtime configuration informati
 > [!NOTE]
 > Environment variables take precedence over configuration settings in the *testconfig.json* file.
 
+### `TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION` environment variable
+
+When set to `1`, the test host process exits immediately on unhandled exceptions. When set to `0`, the platform allows graceful shutdown. This setting takes precedence over the `platformOptions:exitProcessOnUnhandledException` configuration.
+
+### `TESTINGPLATFORM_DEFAULT_HANG_TIMEOUT` environment variable
+
+Overrides the default timeout (300 seconds) used for named-pipe connections between the test host controller and test host. The value must be a `TimeSpan`-compatible string.
+
 ### `TESTINGPLATFORM_UI_LANGUAGE` environment variable
 
 Starting with MTP 1.5, this environment variable sets the language of the platform for displaying messages and logs using a locale value such as `en-us`. This language takes precedence over the Visual Studio and .NET SDK languages. The supported values are the same as for Visual Studio. For more information, see the section on changing the installer language in the [Visual Studio installation documentation](/visualstudio/install/install-visual-studio).
+
+### `TESTINGPLATFORM_DIAGNOSTIC` environment variable
+
+If set to `1`, enables the diagnostic logging.
+
+### `TESTINGPLATFORM_DIAGNOSTIC_VERBOSITY` environment variable
+
+Defines the verbosity level when diagnostics are enabled. The available values are `Trace`, `Debug`, `Information`, `Warning`, `Error`, or `Critical`.
+
+### `TESTINGPLATFORM_DIAGNOSTIC_OUTPUT_DIRECTORY` environment variable
+
+The output directory of the diagnostic logging. If not specified, the file is generated in the default *TestResults* directory.
+
+### `TESTINGPLATFORM_DIAGNOSTIC_OUTPUT_FILEPREFIX` environment variable
+
+The prefix for the log file name. Defaults to `"log_"`.
+
+### `TESTINGPLATFORM_DIAGNOSTIC_FILELOGGER_SYNCHRONOUSWRITE` environment variable
+
+Forces the built-in file logger to synchronously write logs. Useful for scenarios where you don't want to lose any log entries (if the process crashes). This does slow down the test execution.
+
+### `TESTINGPLATFORM_EXITCODE_IGNORE` environment variable
+
+A semicolon-separated list of exit codes to ignore. When an exit code is ignored, the process returns `0` instead. For example, `TESTINGPLATFORM_EXITCODE_IGNORE=2;8` ignores test failures and no-tests-ran scenarios.
+
+> [!NOTE]
+> Diagnostic-related environment variables take precedence over their corresponding `--diagnostic-*` command-line arguments.
+
+## See also
+
+- [MTP CLI options reference](microsoft-testing-platform-cli-options.md)
+- [MTP features](microsoft-testing-platform-features.md)
+- [Configure MSTest](unit-testing-mstest-configure.md)
+- [MTP troubleshooting](microsoft-testing-platform-troubleshooting.md)

--- a/docs/core/testing/unit-testing-mstest-configure.md
+++ b/docs/core/testing/unit-testing-mstest-configure.md
@@ -281,16 +281,17 @@ Each element of the file is optional because it has a default value.
 ```json
 {
   "platformOptions": {
+    "resultDirectory": "./TestResults"
   },
   "mstest": {
     "execution": {
-        "mapInconclusiveToFailed" : true,
+        "mapInconclusiveToFailed": true,
         "disableAppDomain": true,
-        "considerFixturesAsSpecialTests" : false,
+        "considerFixturesAsSpecialTests": false
     },
-    "parallelism" : {
+    "parallelism": {
         "enabled": true,
-        "scope": "method",
+        "scope": "method"
     },
     "output": {
         "captureTrace": false


### PR DESCRIPTION
## Summary

This PR addresses the documentation gaps reported in microsoft/testfx#6335 ("Document testconfig.json").

The `microsoft-testing-platform-config.md` page previously had generic placeholder values (`config-property-name1`, `config-value1`) that provided no actionable guidance to users. This PR replaces that with comprehensive documentation.

## Changes

### `microsoft-testing-platform-config.md` (major rewrite)

- **Platform options table**: Documents `resultDirectory` and `exitProcessOnUnhandledException` with types, defaults, and behavior notes
- **Configuration precedence**: Documents the resolution order (CLI > env vars > testconfig.json > defaults)
- **Centralized testconfig.json**: Guidance for sharing a single config across projects via `--config-file` and `TestingPlatformCommandLineArguments` MSBuild property
- **CLI-only extensions**: Clarifies that crash dump, hang dump, retry, TRX reports, and code coverage are **not** configurable via testconfig.json
- **Framework-specific links**: Links to MSTest, xUnit.net v3, NUnit, and TUnit testconfig.json docs
- **Complete example**: Real-world testconfig.json combining platform options and MSTest settings
- **Migration table**: Maps common `.runsettings` settings to their testconfig.json equivalents or CLI alternatives
- **Environment variables**: Documents `TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION`, `TESTINGPLATFORM_DEFAULT_HANG_TIMEOUT`, `TESTINGPLATFORM_DIAGNOSTIC*`, `TESTINGPLATFORM_EXITCODE_IGNORE`, and `TESTINGPLATFORM_UI_LANGUAGE`
- **See also**: Cross-references to CLI options, features, MSTest configuration, and troubleshooting pages

### `unit-testing-mstest-configure.md` (minor fix)

- Fixed invalid trailing commas in the example JSON block
- Replaced empty `platformOptions: {}` with a real example value

Fixes microsoft/testfx#6335

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-config.md](https://github.com/dotnet/docs/blob/4b318f8b199d840f32499291d9dc9a82cd2a90ca/docs/core/testing/microsoft-testing-platform-config.md) | [Microsoft.Testing.Platform (MTP) configuration settings](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-config?branch=pr-en-us-53842) |
| [docs/core/testing/unit-testing-mstest-configure.md](https://github.com/dotnet/docs/blob/4b318f8b199d840f32499291d9dc9a82cd2a90ca/docs/core/testing/unit-testing-mstest-configure.md) | [Configure MSTest](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-configure?branch=pr-en-us-53842) |

<!-- PREVIEW-TABLE-END -->