### PR TITLE
Clarify exit code descriptions in signtool-exe.md

### DIFF
--- a/docs/framework/tools/signtool-exe.md
+++ b/docs/framework/tools/signtool-exe.md
@@ -151,9 +151,9 @@ signtool [command] [options] [file_name | ...]
 |Exit code|Description|  
 |---------------|-----------------|  
 |0|Execution was successful.|  
-|1|Execution has failed.|  
-|2|Execution has completed with warnings.|  
-|3|Execution failed with RuntimeException.|
+|1|Execution failed.|  
+|2|Execution completed with warnings.|  
+|3|Execution failed with an exception.|
 
 ## Examples  
 


### PR DESCRIPTION
There is no `RuntimeException`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/tools/signtool-exe.md](https://github.com/dotnet/docs/blob/8a08cf05df946de0d03831b1f8e93971922409d8/docs/framework/tools/signtool-exe.md) | [SignTool.exe (Sign Tool)](https://review.learn.microsoft.com/en-us/dotnet/framework/tools/signtool-exe?branch=pr-en-us-53848) |

<!-- PREVIEW-TABLE-END -->