### PR TITLE
Update OS; Update links in prompts to .NET 10 latest

### DIFF
--- a/.github/prompts/InstallGuide.UpdateDependencies.prompt.md
+++ b/.github/prompts/InstallGuide.UpdateDependencies.prompt.md
@@ -8,8 +8,8 @@ You are a support engineer documenting the .NET prerequisites for various Linux 
 
 The supported .NET versions are .NET 8, .NET 9, .NET 10, with .NET 11 in preview. .NET 11 shouldn't be documented as we don't document preview releases in the installation guide. The source of most up-to-date information is the `os-packages.json` file in the .NET GitHub repository. Use the GitHub MCP server to get the files.
 
-- **.NET 10**: `https://github.com/dotnet/core/blob/v10.0.3/release-notes/10.0/os-packages.json`
-- **.NET 9**: `https://github.com/dotnet/core/blob/v10.0.3/release-notes/9.0/os-packages.json`
+- **.NET 10**: `https://github.com/dotnet/core/blob/v10.0.8/release-notes/10.0/os-packages.json`
+- **.NET 9**: `https://github.com/dotnet/core/blob/v10.0.8/release-notes/9.0/os-packages.json`
 - **.NET 8**: Doesn't exist. For the most part, the packages are the same as .NET 9 except that zlib is required for .NET 8. Some packages may differ in name between .NET 8 and .NET 9.
 
 Cross-reference the distribution and find the required dependencies for that distribution. Then, update the dependencies section of the article to ensure it includes all required dependencies for that distribution. If there is no source material for the .NET version (like .NET 8), use the closest version available (like .NET 9) and make any necessary adjustments based on known differences. The article should already have dependencies that work for at least .NET 8.

--- a/.github/prompts/InstallGuide.UpdateSupportedOS.prompt.md
+++ b/.github/prompts/InstallGuide.UpdateSupportedOS.prompt.md
@@ -8,9 +8,9 @@ You are a support engineer documenting which operating systems are supported wit
 
 The supported .NET versions are .NET 8, .NET 9, .NET 10, with .NET 11 in preview. .NET 11 shouldn't be documented as we don't document preview releases in the installation guide. The source of most up-to-date information is the `supported-os.json` file in the .NET GitHub repository. Use the GitHub MCP server to get the files.
 
-- **.NET 10**: `https://github.com/dotnet/core/blob/v10.0.3/release-notes/10.0/supported-os.json`
-- **.NET 9**: `https://github.com/dotnet/core/blob/v10.0.3/release-notes/9.0/supported-os.json`
-- **.NET 8**: `https://github.com/dotnet/core/blob/v10.0.3/release-notes/8.0/supported-os.json`
+- **.NET 10**: `https://github.com/dotnet/core/blob/v10.0.8/release-notes/10.0/supported-os.json`
+- **.NET 9**: `https://github.com/dotnet/core/blob/v10.0.8/release-notes/9.0/supported-os.json`
+- **.NET 8**: `https://github.com/dotnet/core/blob/v10.0.8/release-notes/8.0/supported-os.json`
 
 ## Actions
 

--- a/docs/core/install/linux-fedora.md
+++ b/docs/core/install/linux-fedora.md
@@ -24,8 +24,8 @@ The following table is a list of currently supported .NET releases and the versi
 
 | Fedora | .NET     |
 |--------|----------|
+| 44     | 10, 9, 8 |
 | 43     | 10, 9, 8 |
-| 42     | 10, 9, 8 |
 
 [!INCLUDE [versions-not-supported](includes/versions-not-supported.md)]
 

--- a/docs/core/install/linux-opensuse.md
+++ b/docs/core/install/linux-opensuse.md
@@ -20,9 +20,6 @@ The following table is a list of currently supported .NET releases on openSUSE L
 | openSUSE Leap    | .NET     |
 |------------------|----------|
 | 16               | 10, 9, 8 |
-| 15.6<sup>*</sup> | 10, 9, 8 |
-
-<sup>* Support ends April 30, 2026.</sup>
 
 [!INCLUDE [versions-not-supported](includes/versions-not-supported.md)]
 
@@ -42,41 +39,6 @@ The following table is a list of currently supported .NET releases on openSUSE L
 sudo zypper install libicu
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
 wget https://packages.microsoft.com/config/opensuse/16/prod.repo
-sudo mv prod.repo /etc/zypp/repos.d/microsoft-prod.repo
-sudo chown root:root /etc/zypp/repos.d/microsoft-prod.repo
-```
-
-# [.NET 10](#tab/dotnet10)
-
-[!INCLUDE [linux-install-package-manager-x64-arm64](includes/linux-install-package-manager-x64-arm64.md)]
-
-[!INCLUDE [linux-zyp-install-100](includes/linux-install-100-zyp.md)]
-
-# [.NET 9](#tab/dotnet9)
-
-[!INCLUDE [linux-install-package-manager-x64-only](includes/linux-install-package-manager-x64-only.md)]
-
-[!INCLUDE [linux-zyp-install-90](includes/linux-install-90-zyp.md)]
-
-# [.NET 8](#tab/dotnet8)
-
-[!INCLUDE [linux-install-package-manager-x64-only](includes/linux-install-package-manager-x64-only.md)]
-
-[!INCLUDE [linux-zyp-install-80](includes/linux-install-80-zyp.md)]
-
----
-
-## openSUSE Leap 15
-
-> [!IMPORTANT]
-> Support ends April 30, 2026.
-
-[!INCLUDE [linux-prep-intro-generic](includes/linux-prep-intro-generic.md)]
-
-```bash
-sudo zypper install libicu
-sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-wget https://packages.microsoft.com/config/opensuse/15/prod.repo
 sudo mv prod.repo /etc/zypp/repos.d/microsoft-prod.repo
 sudo chown root:root /etc/zypp/repos.d/microsoft-prod.repo
 ```


### PR DESCRIPTION
## Summary

- Dropped out of support
- Added in support
- Updated instructions


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/prompts/InstallGuide.UpdateDependencies.prompt.md](https://github.com/dotnet/docs/blob/d77281f8b426e4e7c03e39699ab0860c3606fee3/.github/prompts/InstallGuide.UpdateDependencies.prompt.md) | [.github/prompts/InstallGuide.UpdateDependencies.prompt](https://review.learn.microsoft.com/en-us/dotnet/.github/prompts/InstallGuide.UpdateDependencies.prompt?branch=pr-en-us-53855) |
| [.github/prompts/InstallGuide.UpdateSupportedOS.prompt.md](https://github.com/dotnet/docs/blob/d77281f8b426e4e7c03e39699ab0860c3606fee3/.github/prompts/InstallGuide.UpdateSupportedOS.prompt.md) | [.github/prompts/InstallGuide.UpdateSupportedOS.prompt](https://review.learn.microsoft.com/en-us/dotnet/.github/prompts/InstallGuide.UpdateSupportedOS.prompt?branch=pr-en-us-53855) |
| [docs/core/install/linux-fedora.md](https://github.com/dotnet/docs/blob/d77281f8b426e4e7c03e39699ab0860c3606fee3/docs/core/install/linux-fedora.md) | [Install the .NET SDK or the .NET Runtime on Fedora](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-fedora?branch=pr-en-us-53855) |
| [docs/core/install/linux-opensuse.md](https://github.com/dotnet/docs/blob/d77281f8b426e4e7c03e39699ab0860c3606fee3/docs/core/install/linux-opensuse.md) | [[.NET 10](#tab/dotnet10)](https://review.learn.microsoft.com/en-us/dotnet/core/install/linux-opensuse?branch=pr-en-us-53855) |

<!-- PREVIEW-TABLE-END -->