### PR TITLE
Update the GHCP modernization TOC in the migration area

### DIFF
--- a/docs/core/porting/github-copilot-app-modernization/toc.yml
+++ b/docs/core/porting/github-copilot-app-modernization/toc.yml
@@ -30,4 +30,4 @@ items:
         href: troubleshooting.md
 
   - name: Migrate .NET apps to Azure
-    href: ../../azure/migration/appmod/predefined-tasks.md
+    href: ../../../azure/migration/appmod/predefined-tasks.md

--- a/docs/core/porting/github-copilot-app-modernization/toc.yml
+++ b/docs/core/porting/github-copilot-app-modernization/toc.yml
@@ -30,13 +30,4 @@ items:
         href: troubleshooting.md
 
   - name: Migrate .NET apps to Azure
-    expanded: true
-    items:
-      - name: Migrate a .NET project
-        href: ../../../azure/migration/appmod/quickstart.md?toc=/dotnet/core/porting/github-copilot-app-modernization/toc.json&bc=/dotnet/breadcrumb/toc.json
-      - name: Migration sample
-        href: ../../../azure/migration/appmod/sample.md?toc=/dotnet/core/porting/github-copilot-app-modernization/toc.json&bc=/dotnet/breadcrumb/toc.json
-      - name: Copilot CLI Support
-        href: ../../../azure/migration/appmod/copilot-cli-support.md?toc=/dotnet/core/porting/github-copilot-app-modernization/toc.json&bc=/dotnet/breadcrumb/toc.json
-      - name: Coding Agent Support
-        href: ../../../azure/migration/appmod/coding-agent-support.md?toc=/dotnet/core/porting/github-copilot-app-modernization/toc.json&bc=/dotnet/breadcrumb/toc.json
+    href: ../../azure/migration/appmod/predefined-tasks.md

--- a/docs/navigate/migration-guide/toc.yml
+++ b/docs/navigate/migration-guide/toc.yml
@@ -9,6 +9,21 @@ items:
       - name: Overview
         href: ../../core/porting/github-copilot-app-modernization/overview.md?toc=/dotnet/navigate/migration-guide/toc.json&bc=/dotnet/breadcrumb/toc.json
         displayName: copilot, upgrade
+      - name: Install
+        href: ../../core/porting/github-copilot-app-modernization/install.md?toc=/dotnet/navigate/migration-guide/toc.json&bc=/dotnet/breadcrumb/toc.json
+        displayName: copilot, upgrade
+      - name: Core concepts
+        href: ../../core/porting/github-copilot-app-modernization/concepts.md?toc=/dotnet/navigate/migration-guide/toc.json&bc=/dotnet/breadcrumb/toc.json
+        displayName: copilot, upgrade
+      - name: Working with the agent
+        href: ../../core/porting/github-copilot-app-modernization/working-with-agent.md?toc=/dotnet/navigate/migration-guide/toc.json&bc=/dotnet/breadcrumb/toc.json
+        displayName: copilot, upgrade
+      - name: Scenarios and skills reference
+        href: ../../core/porting/github-copilot-app-modernization/scenarios-and-skills.md?toc=/dotnet/navigate/migration-guide/toc.json&bc=/dotnet/breadcrumb/toc.json
+        displayName: copilot, upgrade
+      - name: Customization
+        href: ../../core/porting/github-copilot-app-modernization/customization.md?toc=/dotnet/navigate/migration-guide/toc.json&bc=/dotnet/breadcrumb/toc.json
+        displayName: copilot, upgrade
       - name: FAQ
         href: ../../core/porting/github-copilot-app-modernization/faq.yml?toc=/dotnet/navigate/migration-guide/toc.json&bc=/dotnet/breadcrumb/toc.json
         displayName: copilot, upgrade
@@ -18,13 +33,17 @@ items:
           - name: How to upgrade with GitHub Copilot
             href: ../../core/porting/github-copilot-app-modernization/how-to-upgrade-with-github-copilot.md?toc=/dotnet/navigate/migration-guide/toc.json&bc=/dotnet/breadcrumb/toc.json
             displayName: copilot, upgrade
+          - name: How to apply custom upgrade instructions
+            href: ../../core/porting/github-copilot-app-modernization/how-to-custom-upgrade-instructions.md?toc=/dotnet/navigate/migration-guide/toc.json&bc=/dotnet/breadcrumb/toc.json
+            displayName: copilot, upgrade
+          - name: Best practices
+            href: ../../core/porting/github-copilot-app-modernization/best-practices.md?toc=/dotnet/navigate/migration-guide/toc.json&bc=/dotnet/breadcrumb/toc.json
+            displayName: copilot, upgrade
+          - name: Troubleshooting
+            href: ../../core/porting/github-copilot-app-modernization/troubleshooting.md?toc=/dotnet/navigate/migration-guide/toc.json&bc=/dotnet/breadcrumb/toc.json
+            displayName: copilot, upgrade
       - name: Migrate .NET apps to Azure
-        expanded: false
-        items:
-          - name: Migrate a .NET project
-            href: ../../azure/migration/appmod/quickstart.md?toc=/dotnet/navigate/migration-guide/toc.json&bc=/dotnet/breadcrumb/toc.json
-          - name: Migration sample
-            href: ../../azure/migration/appmod/sample.md?toc=/dotnet/navigate/migration-guide/toc.json&bc=/dotnet/breadcrumb/toc.json
+        href: ../../azure/migration/appmod/predefined-tasks.md
 
   - name: Plan an upgrade from .NET Framework
     items:


### PR DESCRIPTION
## Summary

- Update the TOC in the migration area with the latest articles
- Trim down the Azure TOC structure because that too has grown. Instead, link to the Azure side directly and let them control the experience.

Fixes #53655


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/github-copilot-app-modernization/toc.yml](https://github.com/dotnet/docs/blob/6fc712cc3b63c5df750294fc7232ff1d3a926c83/docs/core/porting/github-copilot-app-modernization/toc.yml) | [docs/core/porting/github-copilot-app-modernization/toc](https://review.learn.microsoft.com/en-us/dotnet/core/porting/github-copilot-app-modernization/toc?branch=pr-en-us-53866) |
| [docs/navigate/migration-guide/toc.yml](https://github.com/dotnet/docs/blob/6fc712cc3b63c5df750294fc7232ff1d3a926c83/docs/navigate/migration-guide/toc.yml) | [docs/navigate/migration-guide/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/migration-guide/toc?branch=pr-en-us-53866) |


<!-- PREVIEW-TABLE-END -->