### PR TITLE
Document SDK vulnerability and EOL build warnings

### DIFF
--- a/docs/core/releases-and-support.md
+++ b/docs/core/releases-and-support.md
@@ -1,7 +1,7 @@
 ---
 title: .NET releases, patches, and support
 description: Learn about releases, patches, and support for .NET.
-ms.date: 11/18/2025
+ms.date: 05/15/2026
 ms.custom: updateeachrelease
 ms.topic: overview
 ai-usage: ai-assisted
@@ -108,6 +108,8 @@ For information about the latest servicing updates for each major and minor vers
 ## End of support
 
 End of support refers to the date after which Microsoft no longer provides fixes, updates, or technical assistance for a product version. Before this date, move to a supported version. Versions that are out of support no longer receive security updates that protect your applications and data. For the supported date ranges for each version of .NET, see the [Support Policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).
+
+To detect builds running on an unsupported SDK, set the `CheckSdkVulnerabilities` MSBuild property to `true` in your project. The build then emits warning [NETSDK1239](tools/sdk-errors/netsdk1239.md) when the resolved .NET SDK is end of life.
 
 ## Supported operating systems
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -1,7 +1,8 @@
 ---
 title: .NET environment variables
 description: Learn about the environment variables that you can use to configure the .NET SDK, .NET CLI, and .NET runtime.
-ms.date: 11/20/2025
+ms.date: 05/15/2026
+ai-usage: ai-assisted
 ---
 
 # .NET environment variables
@@ -210,6 +211,8 @@ This section describes the following environment variables:
 - [`DOTNET_CLI_CONTEXT_*`](#dotnet_cli_context_)
 - [`DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE`](#dotnet_cli_workload_update_notify_disable)
 - [`DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_INTERVAL_HOURS`](#dotnet_cli_workload_update_notify_interval_hours)
+- [`DOTNET_SDK_VULNERABILITY_CHECK_DISABLE`](#dotnet_sdk_vulnerability_check_disable)
+- [`DOTNET_SDK_VULNERABILITY_CHECK_INTERVAL_HOURS`](#dotnet_sdk_vulnerability_check_interval_hours)
 - [`DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK`](#dotnet_skip_workload_integrity_check)
 - [`DOTNET_TOOLS_ALLOW_MANIFEST_IN_ROOT`](#dotnet_tools_allow_manifest_in_root)
 - [`DOTNET_HOST_TRACE`](#dotnet_host_trace)
@@ -412,6 +415,14 @@ Disables background download of advertising manifests for workloads. Default is 
 ### `DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_INTERVAL_HOURS`
 
 Specifies the minimum number of hours between background downloads of advertising manifests for workloads. The default is `24`, which is no more frequently than once a day. For more information, see [Advertising manifests](dotnet-workload-install.md#advertising-manifests).
+
+### `DOTNET_SDK_VULNERABILITY_CHECK_DISABLE`
+
+Disables the opt-in SDK vulnerability and end-of-life check. When set to `true`, the .NET CLI doesn't refresh the local SDK release metadata cache in the background, and the MSBuild check doesn't emit [NETSDK1238](sdk-errors/netsdk1238.md), [NETSDK1239](sdk-errors/netsdk1239.md), or [NETSDK1240](sdk-errors/netsdk1240.md). The default is `false`. The check is also opt-in at the project level through the `CheckSdkVulnerabilities` MSBuild property.
+
+### `DOTNET_SDK_VULNERABILITY_CHECK_INTERVAL_HOURS`
+
+Specifies the minimum number of hours between background refreshes of the SDK release metadata cache used by the SDK vulnerability and end-of-life check. The default is `24`.
 
 ### `DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -418,11 +418,11 @@ Specifies the minimum number of hours between background downloads of advertisin
 
 ### `DOTNET_SDK_VULNERABILITY_CHECK_DISABLE`
 
-Disables the opt-in SDK vulnerability and end-of-life check. When set to `true`, the .NET CLI doesn't refresh the local SDK release metadata cache in the background, and the MSBuild check doesn't emit [NETSDK1238](sdk-errors/netsdk1238.md), [NETSDK1239](sdk-errors/netsdk1239.md), or [NETSDK1240](sdk-errors/netsdk1240.md). The default is `false`. The check is also opt-in at the project level through the `CheckSdkVulnerabilities` MSBuild property.
+Disables the opt-in SDK vulnerability, end-of-life, and feature-band discontinuation check. When set to `true`, the .NET CLI doesn't refresh the local SDK release metadata cache in the background, and the MSBuild check doesn't emit [NETSDK1238](sdk-errors/netsdk1238.md), [NETSDK1239](sdk-errors/netsdk1239.md), or [NETSDK1240](sdk-errors/netsdk1240.md). The default is `false`. The check is also opt-in at the project level through the `CheckSdkVulnerabilities` MSBuild property.
 
 ### `DOTNET_SDK_VULNERABILITY_CHECK_INTERVAL_HOURS`
 
-Specifies the minimum number of hours between background refreshes of the SDK release metadata cache used by the SDK vulnerability and end-of-life check. The default is `24`.
+Specifies the minimum number of hours between background refreshes of the SDK release metadata cache used by the SDK vulnerability, end-of-life, and feature-band discontinuation check. The default is `24`.
 
 ### `DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK`
 

--- a/docs/core/tools/dotnet-sdk-check.md
+++ b/docs/core/tools/dotnet-sdk-check.md
@@ -67,4 +67,4 @@ The latest versions of .NET can be installed from https://aka.ms/dotnet-core-dow
 
 ## See also
 
-To get the same information as a build warning, set the `CheckSdkVulnerabilities` MSBuild property to `true` in your project. See [NETSDK1238](sdk-errors/netsdk1238.md), [NETSDK1239](sdk-errors/netsdk1239.md), and [NETSDK1240](sdk-errors/netsdk1240.md).
+To get similar SDK status information as a build warning for the SDK that your build resolves, set the `CheckSdkVulnerabilities` MSBuild property to `true` in your project. See [NETSDK1238](sdk-errors/netsdk1238.md), [NETSDK1239](sdk-errors/netsdk1239.md), and [NETSDK1240](sdk-errors/netsdk1240.md).

--- a/docs/core/tools/dotnet-sdk-check.md
+++ b/docs/core/tools/dotnet-sdk-check.md
@@ -1,7 +1,8 @@
 ---
 title: dotnet sdk check command
 description: The 'dotnet sdk check' command tells you what is the latest available version of the .NET SDK and .NET Runtime.
-ms.date: 06/30/2021
+ms.date: 05/15/2026
+ai-usage: ai-assisted
 ---
 # dotnet sdk check
 
@@ -63,3 +64,7 @@ The latest versions of .NET can be installed from https://aka.ms/dotnet-core-dow
   ```dotnetcli
   dotnet sdk check
   ```
+
+## See also
+
+To get the same information as a build warning, set the `CheckSdkVulnerabilities` MSBuild property to `true` in your project. See [NETSDK1238](sdk-errors/netsdk1238.md), [NETSDK1239](sdk-errors/netsdk1239.md), and [NETSDK1240](sdk-errors/netsdk1240.md).

--- a/docs/core/tools/sdk-errors/index.md
+++ b/docs/core/tools/sdk-errors/index.md
@@ -2,7 +2,8 @@
 title: ".NET SDK error list"
 description: A complete list of NETSDKxxxx errors, with links to more info where more info is available.
 ms.topic: error-reference
-ms.date: 12/11/2023
+ms.date: 05/15/2026
+ai-usage: ai-assisted
 f1_keywords:
 - NETSDK1001
 - NETSDK1002
@@ -168,6 +169,9 @@ f1_keywords:
 - NETSDK1211
 - NETSDK1212
 - NETSDK1213
+- NETSDK1238
+- NETSDK1239
+- NETSDK1240
 ---
 # .NET SDK error list
 
@@ -375,3 +379,6 @@ This list is a complete list of the errors that you might get from the .NET SDK 
 |NETSDK1212|IsTrimmable and EnableTrimAnalyzer are not supported for the target framework. Consider multi-targeting to a supported framework to enable trimming, and set IsTrimmable only for the supported frameworks. For example:<br>`<IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>`|
 |NETSDK1213|Targeting .NET 8.0 or higher in Visual Studio 2022 17.7 is not supported.|
 |[NETSDK1237](netsdk1237.md)|Assembly '{0}' was listed in PublishReadyToRunPartialAssemblies but is being compiled into a composite image. Partial compilation is only supported for assemblies compiled separately. The assembly will be compiled fully into the composite image.|
+|[NETSDK1238](netsdk1238.md)|The current .NET SDK ({0}) has known vulnerabilities ({1}).{2} See <https://dotnet.microsoft.com/download>|
+|[NETSDK1239](netsdk1239.md)|The current .NET SDK ({0}) is end of life as of {1}. It will receive no further security updates: <https://dotnet.microsoft.com/download>|
+|[NETSDK1240](netsdk1240.md)|The current .NET SDK ({0}) has no newer release in its feature band. Update to version {1}: <https://dotnet.microsoft.com/download>|

--- a/docs/core/tools/sdk-errors/netsdk1238.md
+++ b/docs/core/tools/sdk-errors/netsdk1238.md
@@ -29,7 +29,7 @@ The check is opt-in and only runs when the MSBuild property `CheckSdkVulnerabili
 
 You can also pass `/p:CheckSdkVulnerabilities=true` to a .NET CLI command, such as `dotnet build`.
 
-The .NET CLI refreshes a local cache of SDK release metadata in the background (at most once every 24 hours) under `~/.dotnet/sdk-vulnerability-cache/`. The MSBuild check reads only that cache; it does not make network calls during the build. On machines that have never had network access, no warning is emitted.
+By default, the .NET CLI refreshes a local cache of SDK release metadata in the background at most once every 24 hours under `~/.dotnet/sdk-vulnerability-cache/`. To change that interval, set [`DOTNET_SDK_VULNERABILITY_CHECK_INTERVAL_HOURS`](../dotnet-environment-variables.md#dotnet_sdk_vulnerability_check_interval_hours). The MSBuild check reads only that cache; it does not make network calls during the build. On machines that have never had network access, no warning is emitted.
 
 ## Suppress the warning
 

--- a/docs/core/tools/sdk-errors/netsdk1238.md
+++ b/docs/core/tools/sdk-errors/netsdk1238.md
@@ -1,0 +1,51 @@
+---
+title: "NETSDK1238: The current .NET SDK has known vulnerabilities"
+description: Learn how to resolve build warning NETSDK1238, which reports known CVEs against the .NET SDK that built your project.
+ms.topic: error-reference
+ms.date: 05/15/2026
+ai-usage: ai-assisted
+f1_keywords:
+- NETSDK1238
+---
+# NETSDK1238: The current .NET SDK has known vulnerabilities
+
+This warning indicates that the .NET SDK used to build your project has one or more known Common Vulnerabilities and Exposures (CVEs). The full warning message is similar to the following example:
+
+> NETSDK1238: The current .NET SDK (\<version>) has known vulnerabilities (\<CVE list>). Update to version \<version>. See <https://dotnet.microsoft.com/download>
+
+To resolve the warning, install a patched .NET SDK from <https://dotnet.microsoft.com/download> and update your `global.json` (if present) to select the new version.
+
+## How the check works
+
+The check is opt-in and only runs when the MSBuild property `CheckSdkVulnerabilities` is set to `true`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CheckSdkVulnerabilities>true</CheckSdkVulnerabilities>
+  </PropertyGroup>
+</Project>
+```
+
+You can also pass `/p:CheckSdkVulnerabilities=true` to a .NET CLI command, such as `dotnet build`.
+
+The .NET CLI refreshes a local cache of SDK release metadata in the background (at most once every 24 hours) under `~/.dotnet/sdk-vulnerability-cache/`. The MSBuild check reads only that cache; it does not make network calls during the build. On machines that have never had network access, no warning is emitted.
+
+## Suppress the warning
+
+To suppress the warning without updating the SDK:
+
+- Add `NETSDK1238` to `NoWarn`:
+
+  ```xml
+  <NoWarn>$(NoWarn);NETSDK1238</NoWarn>
+  ```
+
+- Set `CheckSdkVulnerabilities` to `false` (the default) to turn off NETSDK1238, NETSDK1239, and NETSDK1240.
+- Set the [`DOTNET_SDK_VULNERABILITY_CHECK_DISABLE`](../dotnet-environment-variables.md#dotnet_sdk_vulnerability_check_disable) environment variable to `true` to disable both the cache refresh and the build-time check.
+
+## See also
+
+- [NETSDK1239: The current .NET SDK is end of life](netsdk1239.md)
+- [NETSDK1240: The current .NET SDK feature band is discontinued](netsdk1240.md)
+- [.NET releases and support](../../releases-and-support.md)

--- a/docs/core/tools/sdk-errors/netsdk1239.md
+++ b/docs/core/tools/sdk-errors/netsdk1239.md
@@ -31,7 +31,7 @@ The check is opt-in and only runs when the MSBuild property `CheckSdkVulnerabili
 
 You can also pass `/p:CheckSdkVulnerabilities=true` to a .NET CLI command, such as `dotnet build`.
 
-The .NET CLI refreshes a local cache of SDK release metadata in the background (at most once every 24 hours) under `~/.dotnet/sdk-vulnerability-cache/`. The MSBuild check reads only that cache; it does not make network calls during the build.
+By default, the .NET CLI refreshes a local cache of SDK release metadata in the background at most once every 24 hours under `~/.dotnet/sdk-vulnerability-cache/`. Set [`DOTNET_SDK_VULNERABILITY_CHECK_INTERVAL_HOURS`](../dotnet-environment-variables.md#dotnet_sdk_vulnerability_check_interval_hours) to change the refresh interval. The MSBuild check reads only that cache; it doesn't make network calls during the build.
 
 ## Suppress the warning
 

--- a/docs/core/tools/sdk-errors/netsdk1239.md
+++ b/docs/core/tools/sdk-errors/netsdk1239.md
@@ -1,0 +1,53 @@
+---
+title: "NETSDK1239: The current .NET SDK is end of life"
+description: Learn how to resolve build warning NETSDK1239, which reports that the .NET SDK that built your project is end of life.
+ms.topic: error-reference
+ms.date: 05/15/2026
+ai-usage: ai-assisted
+f1_keywords:
+- NETSDK1239
+---
+# NETSDK1239: The current .NET SDK is end of life
+
+This warning indicates that the .NET SDK used to build your project is end of life (EOL) and no longer receives security updates. The full warning message is similar to the following example:
+
+> NETSDK1239: The current .NET SDK (\<version>) is end of life as of \<date>. It will receive no further security updates: <https://dotnet.microsoft.com/download>
+
+To resolve the warning, install a supported .NET SDK from <https://dotnet.microsoft.com/download> and update your `global.json` (if present) to select the new version. For the current support timeline, see [.NET releases and support](../../releases-and-support.md).
+
+This warning is distinct from [NETSDK1138](netsdk1138.md), which is raised when your project's *target framework* is out of support. NETSDK1239 is raised when the *SDK that runs the build* is out of support, regardless of which framework you target.
+
+## How the check works
+
+The check is opt-in and only runs when the MSBuild property `CheckSdkVulnerabilities` is set to `true`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CheckSdkVulnerabilities>true</CheckSdkVulnerabilities>
+  </PropertyGroup>
+</Project>
+```
+
+You can also pass `/p:CheckSdkVulnerabilities=true` to a .NET CLI command, such as `dotnet build`.
+
+The .NET CLI refreshes a local cache of SDK release metadata in the background (at most once every 24 hours) under `~/.dotnet/sdk-vulnerability-cache/`. The MSBuild check reads only that cache; it does not make network calls during the build.
+
+## Suppress the warning
+
+To suppress the warning without updating the SDK:
+
+- Add `NETSDK1239` to `NoWarn`:
+
+  ```xml
+  <NoWarn>$(NoWarn);NETSDK1239</NoWarn>
+  ```
+
+- Set `CheckSdkVulnerabilities` to `false` (the default) to turn off NETSDK1238, NETSDK1239, and NETSDK1240.
+- Set the [`DOTNET_SDK_VULNERABILITY_CHECK_DISABLE`](../dotnet-environment-variables.md#dotnet_sdk_vulnerability_check_disable) environment variable to `true`.
+
+## See also
+
+- [NETSDK1238: The current .NET SDK has known vulnerabilities](netsdk1238.md)
+- [NETSDK1240: The current .NET SDK feature band is discontinued](netsdk1240.md)
+- [.NET releases and support](../../releases-and-support.md)

--- a/docs/core/tools/sdk-errors/netsdk1240.md
+++ b/docs/core/tools/sdk-errors/netsdk1240.md
@@ -1,0 +1,51 @@
+---
+title: "NETSDK1240: The current .NET SDK feature band is discontinued"
+description: Learn how to resolve build warning NETSDK1240, which reports that the feature band of the .NET SDK that built your project has no newer release.
+ms.topic: error-reference
+ms.date: 05/15/2026
+ai-usage: ai-assisted
+f1_keywords:
+- NETSDK1240
+---
+# NETSDK1240: The current .NET SDK feature band is discontinued
+
+This warning indicates that the feature band of the .NET SDK used to build your project has no newer release, even though a newer SDK exists in a different feature band on the same major version. The full warning message is similar to the following example:
+
+> NETSDK1240: The current .NET SDK (\<version>) has no newer release in its feature band. Update to version \<version>: <https://dotnet.microsoft.com/download>
+
+A .NET SDK version has the form `<major>.<minor>.<feature-band><patch>` (for example, `8.0.404`, where `4xx` is the feature band). When the recommended servicing path moves to a different feature band, the older band stops receiving updates. To resolve the warning, install the recommended .NET SDK version from <https://dotnet.microsoft.com/download> and update your `global.json` (if present) to select it.
+
+## How the check works
+
+The check is opt-in and only runs when the MSBuild property `CheckSdkVulnerabilities` is set to `true`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CheckSdkVulnerabilities>true</CheckSdkVulnerabilities>
+  </PropertyGroup>
+</Project>
+```
+
+You can also pass `/p:CheckSdkVulnerabilities=true` to a .NET CLI command, such as `dotnet build`.
+
+The .NET CLI refreshes a local cache of SDK release metadata in the background (at most once every 24 hours) under `~/.dotnet/sdk-vulnerability-cache/`. The MSBuild check reads only that cache; it does not make network calls during the build.
+
+## Suppress the warning
+
+To suppress the warning without updating the SDK:
+
+- Add `NETSDK1240` to `NoWarn`:
+
+  ```xml
+  <NoWarn>$(NoWarn);NETSDK1240</NoWarn>
+  ```
+
+- Set `CheckSdkVulnerabilities` to `false` (the default) to turn off NETSDK1238, NETSDK1239, and NETSDK1240.
+- Set the [`DOTNET_SDK_VULNERABILITY_CHECK_DISABLE`](../dotnet-environment-variables.md#dotnet_sdk_vulnerability_check_disable) environment variable to `true`.
+
+## See also
+
+- [NETSDK1238: The current .NET SDK has known vulnerabilities](netsdk1238.md)
+- [NETSDK1239: The current .NET SDK is end of life](netsdk1239.md)
+- [.NET SDK versioning](../../versions/index.md)

--- a/docs/core/tools/sdk-errors/netsdk1240.md
+++ b/docs/core/tools/sdk-errors/netsdk1240.md
@@ -29,7 +29,7 @@ The check is opt-in and only runs when the MSBuild property `CheckSdkVulnerabili
 
 You can also pass `/p:CheckSdkVulnerabilities=true` to a .NET CLI command, such as `dotnet build`.
 
-The .NET CLI refreshes a local cache of SDK release metadata in the background (at most once every 24 hours) under `~/.dotnet/sdk-vulnerability-cache/`. The MSBuild check reads only that cache; it does not make network calls during the build.
+The .NET CLI refreshes a local cache of SDK release metadata in the background under `~/.dotnet/sdk-vulnerability-cache/`. By default, it refreshes the cache at most once every 24 hours. To change that interval, set [`DOTNET_SDK_VULNERABILITY_CHECK_INTERVAL_HOURS`](../dotnet-environment-variables.md#dotnet_sdk_vulnerability_check_interval_hours). The MSBuild check reads only that cache; it does not make network calls during the build.
 
 ## Suppress the warning
 

--- a/docs/core/versions/selection.md
+++ b/docs/core/versions/selection.md
@@ -3,7 +3,7 @@ title: Select which .NET version to use
 description: Learn how .NET automatically finds and chooses runtime versions for your program. Additionally, this article teaches you how to force a specific version.
 author: adegeo
 ms.author: adegeo
-ms.date: 10/22/2025
+ms.date: 05/15/2026
 ai-usage: ai-assisted
 ---
 
@@ -57,6 +57,8 @@ For more information about SDK version selection, see the [Matching rules](../to
 ### Updating the SDK version
 
 It's important to update to the latest version of the SDK regularly to adopt the latest features, performance improvements, and bug fixes. To easily check for updates to the SDK, use the `dotnet sdk check` [command](../tools/dotnet-sdk-check.md). Additionally, if you select a specific version using *global.json*, consider a tool such as Dependabot to automatically update the pinned SDK version as new versions become available.
+
+To get the same information at build time, set the `CheckSdkVulnerabilities` MSBuild property to `true`. The build then warns if the resolved .NET SDK has known vulnerabilities ([NETSDK1238](../tools/sdk-errors/netsdk1238.md)), is end of life ([NETSDK1239](../tools/sdk-errors/netsdk1239.md)), or is on a feature band that has no newer release ([NETSDK1240](../tools/sdk-errors/netsdk1240.md)).
 
 ## Target framework monikers define build time APIs
 

--- a/docs/core/versions/selection.md
+++ b/docs/core/versions/selection.md
@@ -58,7 +58,7 @@ For more information about SDK version selection, see the [Matching rules](../to
 
 It's important to update to the latest version of the SDK regularly to adopt the latest features, performance improvements, and bug fixes. To easily check for updates to the SDK, use the `dotnet sdk check` [command](../tools/dotnet-sdk-check.md). Additionally, if you select a specific version using *global.json*, consider a tool such as Dependabot to automatically update the pinned SDK version as new versions become available.
 
-To get the same information at build time, set the `CheckSdkVulnerabilities` MSBuild property to `true`. The build then warns if the resolved .NET SDK has known vulnerabilities ([NETSDK1238](../tools/sdk-errors/netsdk1238.md)), is end of life ([NETSDK1239](../tools/sdk-errors/netsdk1239.md)), or is on a feature band that has no newer release ([NETSDK1240](../tools/sdk-errors/netsdk1240.md)).
+To surface related warnings at build time for the resolved SDK, set the `CheckSdkVulnerabilities` MSBuild property to `true`. The build then warns if the resolved .NET SDK has known vulnerabilities ([NETSDK1238](../tools/sdk-errors/netsdk1238.md)), is end of life ([NETSDK1239](../tools/sdk-errors/netsdk1239.md)), or is on a feature band that has no newer release ([NETSDK1240](../tools/sdk-errors/netsdk1240.md)).
 
 ## Target framework monikers define build time APIs
 

--- a/docs/navigate/tools-diagnostics/toc.yml
+++ b/docs/navigate/tools-diagnostics/toc.yml
@@ -93,6 +93,12 @@ items:
                 href: ../../core/tools/sdk-errors/netsdk1206.md
               - name: NETSDK1237
                 href: ../../core/tools/sdk-errors/netsdk1237.md
+              - name: NETSDK1238
+                href: ../../core/tools/sdk-errors/netsdk1238.md
+              - name: NETSDK1239
+                href: ../../core/tools/sdk-errors/netsdk1239.md
+              - name: NETSDK1240
+                href: ../../core/tools/sdk-errors/netsdk1240.md
           - name: BuildCheck rules
             items:
               - name: Index of rules


### PR DESCRIPTION
## Summary

Adds reference pages for the three new build warnings introduced by dotnet/sdk#53557:

- NETSDK1238 - current SDK has known vulnerabilities
- NETSDK1239 - current SDK is end of life
- NETSDK1240 - current SDK feature band is discontinued

The warnings are opt-in via the `CheckSdkVulnerabilities` MSBuild property. Also documents the new `DOTNET_SDK_VULNERABILITY_CHECK_DISABLE` and `DOTNET_SDK_VULNERABILITY_CHECK_INTERVAL_HOURS` environment variables, adds entries to the SDK errors index and TOC, and cross-links from `dotnet sdk check`, version selection, and releases-and-support.

Pairs with dotnet/sdk#53557.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/releases-and-support.md](https://github.com/dotnet/docs/blob/0938f607f9a4523412a975bea07a101f041a3472/docs/core/releases-and-support.md) | [Releases and support for .NET](https://review.learn.microsoft.com/en-us/dotnet/core/releases-and-support?branch=pr-en-us-53870) |
| [docs/core/tools/dotnet-environment-variables.md](https://github.com/dotnet/docs/blob/0938f607f9a4523412a975bea07a101f041a3472/docs/core/tools/dotnet-environment-variables.md) | [.NET environment variables](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables?branch=pr-en-us-53870) |
| [docs/core/tools/dotnet-sdk-check.md](https://github.com/dotnet/docs/blob/0938f607f9a4523412a975bea07a101f041a3472/docs/core/tools/dotnet-sdk-check.md) | [dotnet sdk check](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-sdk-check?branch=pr-en-us-53870) |
| [docs/core/tools/sdk-errors/index.md](https://github.com/dotnet/docs/blob/0938f607f9a4523412a975bea07a101f041a3472/docs/core/tools/sdk-errors/index.md) | [.NET SDK error list](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/index?branch=pr-en-us-53870) |
| [docs/core/tools/sdk-errors/netsdk1238.md](https://github.com/dotnet/docs/blob/0938f607f9a4523412a975bea07a101f041a3472/docs/core/tools/sdk-errors/netsdk1238.md) | [docs/core/tools/sdk-errors/netsdk1238](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1238?branch=pr-en-us-53870) |
| [docs/core/tools/sdk-errors/netsdk1239.md](https://github.com/dotnet/docs/blob/0938f607f9a4523412a975bea07a101f041a3472/docs/core/tools/sdk-errors/netsdk1239.md) | [NETSDK1239: The current .NET SDK is end of life](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1239?branch=pr-en-us-53870) |
| [docs/core/tools/sdk-errors/netsdk1240.md](https://github.com/dotnet/docs/blob/0938f607f9a4523412a975bea07a101f041a3472/docs/core/tools/sdk-errors/netsdk1240.md) | ["NETSDK1240: The current .NET SDK feature band is discontinued"](https://review.learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1240?branch=pr-en-us-53870) |
| [docs/core/versions/selection.md](https://github.com/dotnet/docs/blob/0938f607f9a4523412a975bea07a101f041a3472/docs/core/versions/selection.md) | [Select the .NET version to use](https://review.learn.microsoft.com/en-us/dotnet/core/versions/selection?branch=pr-en-us-53870) |
| [docs/navigate/tools-diagnostics/toc.yml](https://github.com/dotnet/docs/blob/0938f607f9a4523412a975bea07a101f041a3472/docs/navigate/tools-diagnostics/toc.yml) | [docs/navigate/tools-diagnostics/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/tools-diagnostics/toc?branch=pr-en-us-53870) |


<!-- PREVIEW-TABLE-END -->