### PR TITLE
Clarify range comment in array slicing

### DIFF
--- a/docs/csharp/tour-of-csharp/snippets/shared/CollectionExpressions.cs
+++ b/docs/csharp/tour-of-csharp/snippets/shared/CollectionExpressions.cs
@@ -15,7 +15,7 @@
             // <RangeAndIndex>
             string second = names[1]; // 0-based index
             string last = names[^1]; // ^1 is the last element
-            int[] smallNumbers = numbers[0..5]; // 0 to 4
+            int[] smallNumbers = numbers[0..5]; // elements at indexes 0 to 4
             // </RangeAndIndex>
         }
     }


### PR DESCRIPTION
## Summary

Clarifies that the `0..5` range expression comment refers to array indexes rather than values, improving readability for readers learning C# range syntax.

Fixes #53871
