### PR TITLE
Add link to extensions release notes

### DIFF
--- a/docs/core/whats-new/dotnet-11/overview.md
+++ b/docs/core/whats-new/dotnet-11/overview.md
@@ -71,6 +71,10 @@ For information about new C# features, see [What's new in C# 15](../../../csharp
 
 See [What's new in EF Core for .NET 11](/ef/core/what-is-new/ef-core-11.0/whatsnew).
 
+## Extensions libraries
+
+See [dotnet/extensions release notes](https://github.com/dotnet/extensions/releases).
+
 ## Windows Forms
 
 See [What's new in Windows Forms for .NET 11](/dotnet/desktop/winforms/whats-new/net110).


### PR DESCRIPTION
Packages that ship out of dotnet/extensions are not included in the general .NET release notes because of shipping out of band. Nothing from the dotnet/extensions repo gets pulled into the SDK (or dotnet/dotnet). The Microsoft.Extensions packages that are now part of the shared framework were already shipping out of dotnet/runtime & the SDK.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-11/overview.md](https://github.com/dotnet/docs/blob/dcb2be6d7493aa56d78e6502d020350065afc478/docs/core/whats-new/dotnet-11/overview.md) | [What's new in .NET 11](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-11/overview?branch=pr-en-us-53883) |

<!-- PREVIEW-TABLE-END -->