### PR TITLE
Fix CA1716 docs: add missing Parameter value in analyzed_symbol_kinds…

### DIFF
--- a/docs/fundamentals/code-analysis/quality-rules/ca1716.md
+++ b/docs/fundamentals/code-analysis/quality-rules/ca1716.md
@@ -98,5 +98,5 @@ You can configure the kinds of symbols that will be analyzed by this rule. The a
 Separate multiple values with a comma (`,`). The default value includes all of the symbol kinds in the previous list.
 
 ```ini
-dotnet_code_quality.CA1716.analyzed_symbol_kinds = Namespace, NamedType, Method, Property, Event
+dotnet_code_quality.CA1716.analyzed_symbol_kinds = Namespace, NamedType, Method, Property, Event, Parameter
 ```


### PR DESCRIPTION
The `Analyzed symbol kinds` section lists `Parameter` as a valid value,
but the example code was missing it. Added `Parameter` to the example
to match the documented list.

Fixes #53868

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fundamentals/code-analysis/quality-rules/ca1716.md](https://github.com/dotnet/docs/blob/9e1709dfd37f0ccfe788da0f7bd8d593b6813a38/docs/fundamentals/code-analysis/quality-rules/ca1716.md) | [CA1716: Identifiers should not match keywords](https://review.learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1716?branch=pr-en-us-53884) |

<!-- PREVIEW-TABLE-END -->