### PR TITLE
Update Azure SDK CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -85,7 +85,7 @@
 /docs/azure/sdk/azure-sdk-configure-proxy.md @JoshLove-msft @jsquire @alexwolfmsft @dotnet/docs
 /docs/azure/sdk/azure-sdk-for-net.md @jsquire @alexwolfmsft @dotnet/docs
 /docs/azure/sdk/dependency-injection.md @JoshLove-msft @jsquire @alexwolfmsft @m-nash @dotnet/docs
-/docs/azure/sdk/logging.md @JoshLove-msft @jsquire @alexwolfmsft
+/docs/azure/sdk/logging.md @JoshLove-msft @jsquire @alexwolfmsft @dotnet/docs
 /docs/azure/sdk/packages.md @jsquire @alexwolfmsft @dotnet/docs
 /docs/azure/sdk/pagination.md @JoshLove-msft @jsquire @alexwolfmsft @dotnet/docs
 /docs/azure/sdk/protocol-convenience-methods.md @jsquire @alexwolfmsft @dotnet/docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,22 +76,22 @@
 /docs/azure/includes/ @dotnet/docs
 
 # Azure SDK catch-all entry
-/docs/azure/sdk/ @jsquire @alexwolfmsft @scottaddie @dotnet/docs
+/docs/azure/sdk/ @jsquire @alexwolfmsft @dotnet/docs
 
 # Azure SDK authentication topics
-/docs/azure/sdk/authentication/ @JonathanCrd @christothes @dotnet/docs @alexwolfmsft @scottaddie
+/docs/azure/sdk/authentication/ @JonathanCrd @dotnet/docs @alexwolfmsft
 
 # Azure SDK miscellaneous topics
-/docs/azure/sdk/azure-sdk-configure-proxy.md @christothes @JoshLove-msft @KrzysztofCwalina @jsquire @alexwolfmsft @scottaddie @dotnet/docs
-/docs/azure/sdk/azure-sdk-for-net.md @jsquire @alexwolfmsft @scottaddie @dotnet/docs
-/docs/azure/sdk/dependency-injection.md @JoshLove-msft @jsquire @alexwolfmsft @scottaddie @dotnet/docs
-/docs/azure/sdk/logging.md @christothes @JoshLove-msft @KrzysztofCwalina @jsquire @alexwolfmsft
-/docs/azure/sdk/packages.md @jsquire @alexwolfmsft @scottaddie @dotnet/docs
-/docs/azure/sdk/pagination.md @christothes @JoshLove-msft @KrzysztofCwalina @jsquire @alexwolfmsft @scottaddie @dotnet/docs
-/docs/azure/sdk/protocol-convenience-methods.md @jsquire @alexwolfmsft @scottaddie @dotnet/docs
-/docs/azure/sdk/resource-management.md @ArthurMa1978 @m-nash @alexwolfmsft @scottaddie @dotnet/docs
-/docs/azure/sdk/thread-safety.md @christothes @JoshLove-msft @KrzysztofCwalina @jsquire @alexwolfmsft @scottaddie @dotnet/docs
-/docs/azure/sdk/unit-testing-mocking.md @christothes @JoshLove-msft @KrzysztofCwalina @jsquire @alexwolfmsft @scottaddie @dotnet/docs
+/docs/azure/sdk/azure-sdk-configure-proxy.md @JoshLove-msft @jsquire @alexwolfmsft @dotnet/docs
+/docs/azure/sdk/azure-sdk-for-net.md @jsquire @alexwolfmsft @dotnet/docs
+/docs/azure/sdk/dependency-injection.md @JoshLove-msft @jsquire @alexwolfmsft @m-nash @dotnet/docs
+/docs/azure/sdk/logging.md @JoshLove-msft @jsquire @alexwolfmsft
+/docs/azure/sdk/packages.md @jsquire @alexwolfmsft @dotnet/docs
+/docs/azure/sdk/pagination.md @JoshLove-msft @jsquire @alexwolfmsft @dotnet/docs
+/docs/azure/sdk/protocol-convenience-methods.md @jsquire @alexwolfmsft @dotnet/docs
+/docs/azure/sdk/resource-management.md @ArthurMa1978 @m-nash @alexwolfmsft @dotnet/docs
+/docs/azure/sdk/thread-safety.md @JoshLove-msft @jsquire @alexwolfmsft @dotnet/docs
+/docs/azure/sdk/unit-testing-mocking.md @JoshLove-msft @jsquire @alexwolfmsft @dotnet/docs
 
 ############### Fundamentals ################
 


### PR DESCRIPTION
## Summary

Refreshes the Azure SDK ownership entries in `.github/CODEOWNERS` to reflect current team membership.

- Removes `@scottaddie`, `@christothes`, and `@KrzysztofCwalina` from all `/docs/azure/sdk/*` entries.
- Adds `@m-nash` as an owner for `/docs/azure/sdk/dependency-injection.md`.

All affected lines retain at least one other owner, so no entries were dropped.