### PR TITLE
Remove stale Orleans cache validation metric

### DIFF
--- a/docs/orleans/host/monitoring/index.md
+++ b/docs/orleans/host/monitoring/index.md
@@ -171,7 +171,6 @@ The following table shows a collection of directory meters used to monitor the O
 | `orleans-directory-lookups-local-directory-successes` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of local directory successful lookups. |
 | `orleans-directory-lookups-cache-issued` | <xref:System.Diagnostics.Metrics.Counter`1> | A count cached lookups issued. |
 | `orleans-directory-lookups-cache-successes` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of cached successful lookups. |
-| `orleans-directory-validations-cache-sent` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory cache validations sent.  |
 | `orleans-directory-validations-cache-received` | <xref:System.Diagnostics.Metrics.Counter`1> | A count of directory cache validations received. |
 | `orleans-directory-partition-size` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the directory partition size. |
 | `orleans-directory-cache-size` | <xref:System.Diagnostics.Metrics.ObservableGauge`1> | An observable gauge representing the directory cache size. |


### PR DESCRIPTION
## Problem
The Orleans grain directory cache validation sent metric is no longer exposed by the runtime.

## Solution
Remove `orleans-directory-validations-cache-sent` from the Orleans monitoring metrics table so the docs match the available runtime metrics.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/orleans/host/monitoring/index.md](https://github.com/dotnet/docs/blob/a81ff391ae920de48ecd6949376c6632bce1f5e3/docs/orleans/host/monitoring/index.md) | [Orleans observability](https://review.learn.microsoft.com/en-us/dotnet/orleans/host/monitoring/index?branch=pr-en-us-53901) |

<!-- PREVIEW-TABLE-END -->