### PR TITLE
make member sample in new "Union Types" page slightly less confusing

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/unions/BodyMembers.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/unions/BodyMembers.cs
@@ -1,11 +1,10 @@
 // <BodyMembers>
-public union OneOrMore<T>(T, IEnumerable<T>)
+public union OneOrMore<T>(T, IEnumerable<T>) where T : notnull
 {
-    public IEnumerable<T> AsEnumerable() => Value switch
+    public IEnumerable<T> AsEnumerable() => this switch
     {
         T single => [single],
-        IEnumerable<T> multiple => multiple,
-        _ => []
+        IEnumerable<T> multiple => multiple
     };
 }
 // </BodyMembers>


### PR DESCRIPTION
at first, the presence of a fallback case seems counter to the fact that unions are supposed to help with exhaustiveness. by switching on `this` instead of `Value`, we can already gain the exhaustiveness of the union, but since T is a totally generic parameter, it could still be nullable, which still requires the switch to handle `null`.

since the union is named `OneOrMore`, imo `null` is a confusing value for T in general, so we can just make T non-nullable, and make the switch fully exhaustive with just the first two cases. (an alternative could be to still matching on `null` but return `[null]`, but... that doesn't make much sense imo, and at the end of the day it's a demo sample, not a one-size-fits-all solution.) returning an empty array for a class named `OneOrMore` feels really wrong in any case (just looking  at the class name, i'd expect `oneormore.AsEnumerable().First()` to  never fail).
