### PR TITLE
Add warning to only load trusted models

### DIFF
--- a/docs/machine-learning/how-to-guides/save-load-machine-learning-models-ml-net.md
+++ b/docs/machine-learning/how-to-guides/save-load-machine-learning-models-ml-net.md
@@ -91,6 +91,10 @@ mlContext.Model.ConvertToOnnx(trainedModel, data, stream);
 
 ## Load a model stored locally
 
+> [!IMPORTANT]
+>
+> Only load models from trusted sources. Loading models from untrusted sources is a security risk.
+
 Models stored locally can be used in other processes or applications like ASP.NET Core and serverless web apps. For more information, see [Use ML.NET in Web API](./serve-model-web-api-ml-net.md) and [Deploy ML.NET Serverless Web App](./serve-model-serverless-azure-functions-ml-net.md).
 
 In a separate application or process, use the [`Load`](xref:Microsoft.ML.ModelOperationsCatalog.Load%2A) method along with the file path to get the trained model into your application.

--- a/docs/machine-learning/how-to-guides/save-load-machine-learning-models-ml-net.md
+++ b/docs/machine-learning/how-to-guides/save-load-machine-learning-models-ml-net.md
@@ -92,7 +92,6 @@ mlContext.Model.ConvertToOnnx(trainedModel, data, stream);
 ## Load a model stored locally
 
 > [!IMPORTANT]
->
 > Only load models from trusted sources. Loading models from untrusted sources is a security risk.
 
 Models stored locally can be used in other processes or applications like ASP.NET Core and serverless web apps. For more information, see [Use ML.NET in Web API](./serve-model-web-api-ml-net.md) and [Deploy ML.NET Serverless Web App](./serve-model-serverless-azure-functions-ml-net.md).


### PR DESCRIPTION
ML.NET assumes that loaded models are trusted. We should explicitly document this assumption and warn users not to load untrusted models.

Companion PR to change API docs: https://github.com/dotnet/machinelearning/pull/7611

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/machine-learning/how-to-guides/save-load-machine-learning-models-ml-net.md](https://github.com/dotnet/docs/blob/3da7bc93f141c24c2c14c82a6ec5a9a20e430403/docs/machine-learning/how-to-guides/save-load-machine-learning-models-ml-net.md) | [Save and load trained models](https://review.learn.microsoft.com/en-us/dotnet/machine-learning/how-to-guides/save-load-machine-learning-models-ml-net?branch=pr-en-us-53999) |


<!-- PREVIEW-TABLE-END -->