### PR TITLE
Add runtime model differences between C# and JavaScript

### DIFF
--- a/docs/csharp/tour-of-csharp/tips-for-javascript-developers.md
+++ b/docs/csharp/tour-of-csharp/tips-for-javascript-developers.md
@@ -85,6 +85,13 @@ if (value is string s) { /* use s */ }
 
 To learn more, see [Pattern matching](../fundamentals/functional/pattern-matching.md).
 
+## Runtime model differences
+
+Even though C# and JavaScript look similar in syntax, they run very differently:
+
+- JavaScript runs on a runtime like V8 and uses an event loop to handle asynchronous work.
+- C# runs on the .NET runtime (CLR), where code is compiled into Intermediate Language (IL) and then executed using JIT or AOT compilation.
+
 ## What's new for you in C\#
 
 As you learn C#, you encounter concepts that aren't part of JavaScript. Some of these concepts might be familiar to you if you use TypeScript:


### PR DESCRIPTION
Adds a small section explaining the difference between how C# and JavaScript run.

This helps developers coming from JavaScript or TypeScript understand the basic runtime difference:
- JavaScript runs on an event loop (like V8)
- C# runs on the .NET CLR with IL compilation and JIT/AOT execution

No existing content was changed. This is just an extra explanatory section added for clarity.

## Summary

This update improves the onboarding experience for JavaScript/TypeScript developers learning C# by filling a small but important gap about how the two languages actually execute code.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tour-of-csharp/tips-for-javascript-developers.md](https://github.com/dotnet/docs/blob/fa973493c36c0805cefc52c170c3242e3d246f17/docs/csharp/tour-of-csharp/tips-for-javascript-developers.md) | [Roadmap for JavaScript and TypeScript developers learning C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tips-for-javascript-developers?branch=pr-en-us-54004) |

<!-- PREVIEW-TABLE-END -->