### PR TITLE
Categories for C# 8 diagnostics

### DIFF
--- a/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
+++ b/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
@@ -245,11 +245,11 @@ f1_keywords:
   ## Index and range
   - "CS8428"
   - "CS8429"
-  ## cant parse syntax
+  ## Can't parse syntax
   - "CS8635"
   - "CS8641"
   ## Default interface implementation
-  - "CS8646" 
+  - "CS8646"
   ## Patterns
   - "CS8650"
   - "CS8651"

--- a/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
+++ b/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
@@ -227,24 +227,33 @@ f1_keywords:
   - "CS8384"
   - "CS8385"
   # C# 8.0 diagnostics
+  ## Async enumerables
   - "CS8412"
   - "CS8413"
   - "CS8414"
   - "CS8415"
   - "CS8419"
   - "CS8420"
+  ## Static local functions
   - "CS8421"
+  ## Attributes
   - "CS8423"
+  ## More async enumerators
   - "CS8424"
   - "CS8425"
   - "CS8426"
+  ## Index and range
   - "CS8428"
   - "CS8429"
+  ## cant parse syntax
   - "CS8635"
   - "CS8641"
-  - "CS8646"
+  ## Default interface implementation
+  - "CS8646" 
+  ## Patterns
   - "CS8650"
   - "CS8651"
+  ## Readonly struct members
   - "CS8656"
   - "CS8662"
   - "CS8669"
@@ -293,6 +302,10 @@ f1_keywords:
   - "CS9382"
   - "CS9383"
   - "CS9384"
+# More unions:
+  - "CS9385"
+  - "CS9386"
+  - "CS9387"
 helpviewer_keywords:
   - "errors [C#], additional information"
 ---

--- a/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
+++ b/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
@@ -302,7 +302,7 @@ f1_keywords:
   - "CS9382"
   - "CS9383"
   - "CS9384"
-# More unions:
+  # More unions:
   - "CS9385"
   - "CS9386"
   - "CS9387"


### PR DESCRIPTION
No visible changes. Capture the groups of errors in the C# 8 range, for undocumented errors are warnings.

Also, add the latest C# 15 preview errors (most of which will be documented in the next sprint.)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md](https://github.com/dotnet/docs/blob/09c3943bf223ccd20ec8a9a9de5c308961c16527/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md) | [Coming in C# 15](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error?branch=pr-en-us-54100) |


<!-- PREVIEW-TABLE-END -->