### PR TITLE
Change title "Objected oriented programming" to "Object oriented programming"

### DIFF
--- a/docs/csharp/fundamentals/object-oriented/inheritance.md
+++ b/docs/csharp/fundamentals/object-oriented/inheritance.md
@@ -1,5 +1,5 @@
 ---
-title: "Object oriented programming - inheritance"
+title: "Object-oriented programming - inheritance"
 description: Inheritance in C# enables you to create new classes that reuse, extend, and modify the behavior defined in other classes.
 ms.date: 05/14/2021
 helpviewer_keywords:

--- a/docs/csharp/fundamentals/object-oriented/inheritance.md
+++ b/docs/csharp/fundamentals/object-oriented/inheritance.md
@@ -1,5 +1,5 @@
 ---
-title: "Objected oriented programming - inheritance"
+title: "Object oriented programming - inheritance"
 description: Inheritance in C# enables you to create new classes that reuse, extend, and modify the behavior defined in other classes.
 ms.date: 05/14/2021
 helpviewer_keywords:


### PR DESCRIPTION
It seems like this was most likely what the title was intended to be.

See also the live version of the page: https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/object-oriented/inheritance


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/object-oriented/inheritance.md](https://github.com/dotnet/docs/blob/e699a0e62c9bdab526477f5f43bfc8be3bfbb987/docs/csharp/fundamentals/object-oriented/inheritance.md) | [Inheritance - derive types to create more specialized behavior](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/object-oriented/inheritance?branch=pr-en-us-54191) |


<!-- PREVIEW-TABLE-END -->