### PR TITLE
Document dotnet test (MTP) argument forwarding caveat

### DIFF
--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -3,7 +3,8 @@ title: Testing with 'dotnet test'
 description: Learn more about how 'dotnet test' works and its support for VSTest and Microsoft.Testing.Platform (MTP)
 author: Youssef1313
 ms.author: ygerges
-ms.date: 03/26/2025
+ms.date: 06/05/2026
+ai-usage: ai-assisted
 ---
 
 # Testing with 'dotnet test'
@@ -159,7 +160,7 @@ For users of MTP that are using the VSTest mode of `dotnet test`, there are few 
 1. If passing a specific dll, for example, `dotnet test path/to/UnitTests.dll`, this should become `dotnet test --test-modules path/to/UnitTests.dll`. Note that `--test-modules` also supports globbing.
 
 > [!TIP]
-> Even though `--` is no longer required in MTP mode, you can still use it to mark where test application arguments begin. The separator avoids a parser quirk that can change the meaning of unrecognized arguments interleaved with options that `dotnet test` understands, and it also protects your scripts if `dotnet test` later starts recognizing one of those tokens. For more information, see [Pass arguments to the test application](../tools/dotnet-test-mtp.md#pass-arguments-to-the-test-application).
+> Even though `--` is no longer required in MTP mode, you can still use it to mark where test application arguments begin. The separator avoids a parser quirk where unrecognized arguments change meaning when interleaved with options that `dotnet test` understands. The separator also protects your scripts if `dotnet test` later starts recognizing one of those tokens. For more information, see [Forward arguments to the test application](../tools/dotnet-test-mtp.md#forward-arguments-to-the-test-application).
 
 ## Solutions with mixed test frameworks or extensions
 

--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -158,6 +158,9 @@ For users of MTP that are using the VSTest mode of `dotnet test`, there are few 
 1. If passing a specific project (or directory containing project), for example, `dotnet test MyProject.csproj`, this should become `dotnet test --project MyProject.csproj`.
 1. If passing a specific dll, for example, `dotnet test path/to/UnitTests.dll`, this should become `dotnet test --test-modules path/to/UnitTests.dll`. Note that `--test-modules` also supports globbing.
 
+> [!TIP]
+> Even though `--` is no longer required in MTP mode, you can still use it to mark where test application arguments begin. The separator avoids a parser quirk that can change the meaning of unrecognized arguments interleaved with options that `dotnet test` understands, and it also protects your scripts if `dotnet test` later starts recognizing one of those tokens. For more information, see [Pass arguments to the test application](../tools/dotnet-test-mtp.md#pass-arguments-to-the-test-application).
+
 ## Solutions with mixed test frameworks or extensions
 
 When a solution contains test projects that use different test frameworks (for example, MSTest and xUnit.net) or different sets of extensions, running `dotnet test` with framework-specific or extension-specific command-line options can fail. Options that are valid for one project are unrecognized by another, causing exit code 5 (invalid command-line arguments). For example:

--- a/docs/core/tools/dotnet-run.md
+++ b/docs/core/tools/dotnet-run.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet run command
 description: The dotnet run command provides a convenient option to run your application from the source code.
-ms.date: 09/29/2025
+ms.date: 06/05/2026
 ---
 # dotnet run
 
@@ -60,6 +60,29 @@ To run the application, the `dotnet run` command resolves the dependencies of th
   Arguments passed to the application that is being run.
   
   Any arguments that aren't recognized by `dotnet run` are passed to the application. To separate arguments for `dotnet run` from arguments for the application, use the `--` option.
+
+## Forward arguments to the application
+
+`dotnet run` forwards any token it doesn't recognize to the application. The forwarded tokens keep their original order, but `dotnet run` first removes the options it understands. When a recognized option appears between an unrecognized option name and its value, removing the recognized option can change the meaning of the leftover tokens.
+
+For example, the following command interleaves the recognized option `--project` between tokens the application is meant to receive:
+
+```dotnetcli
+dotnet run --app-flag --app-name --project ConsoleApp.csproj A.txt
+```
+
+After `dotnet run` consumes `--project ConsoleApp.csproj`, the application receives `--app-flag --app-name A.txt`. The application then treats `A.txt` as the value of `--app-name`, which doesn't match the original command line.
+
+To avoid this ambiguity, place application arguments after a literal `--`:
+
+```dotnetcli
+dotnet run --project ConsoleApp.csproj -- --app-flag --app-name A.txt
+```
+
+The `--` separator marks every following token as an application argument, so `dotnet run` doesn't reorder or reinterpret them. The separator also future-proofs scripts against new `dotnet run` options that might later match a token previously forwarded to the application.
+
+> [!NOTE]
+> The same behavior applies to `dotnet build` and to `dotnet test` in Microsoft.Testing.Platform (MTP) mode, which forward unrecognized tokens to MSBuild or to the test application respectively. For more information about `dotnet test`, see [Forward arguments to the test application](dotnet-test-mtp.md#forward-arguments-to-the-test-application).
 
 ## Options
 

--- a/docs/core/tools/dotnet-test-mtp.md
+++ b/docs/core/tools/dotnet-test-mtp.md
@@ -168,28 +168,15 @@ With MTP, `dotnet test` operates faster than with VSTest. The test-related argum
 > [!NOTE]
 > To enable trace logging to a file, use the environment variable `DOTNET_CLI_TEST_TRACEFILE` to provide the path to the trace file.
 
-## Pass arguments to the test application
+## Forward arguments to the test application
 
-`dotnet test` forwards any argument it doesn't recognize to the test application. The forwarded arguments keep their original order, but `dotnet test` first removes the options it understands. When a recognized option appears between an unrecognized option name and its value, removing the recognized option can change the meaning of the remaining arguments.
-
-For example, the following command interleaves the `dotnet test` option `--results-directory` between MTP options that the test app understands:
-
-```dotnetcli
-dotnet test --report-trx --report-trx-filename --results-directory TestResults A.trx
-```
-
-After `dotnet test` consumes `--results-directory TestResults`, the test application receives `--report-trx --report-trx-filename A.trx`. The test application then treats `A.trx` as the value of `--report-trx-filename`, which doesn't match what you typed on the command line.
-
-To avoid this ambiguity, place test application arguments after a literal `--`:
+`dotnet test` forwards any token it doesn't recognize to the test application. When a recognized option appears between an unrecognized option name and its value, removing the recognized option can change how the leftover tokens bind to options in the test application. To avoid this ambiguity, place test application arguments after a literal `--`:
 
 ```dotnetcli
 dotnet test --results-directory TestResults -- --report-trx --report-trx-filename A.trx
 ```
 
-The `--` separator marks every following token as a test application argument, so `dotnet test` doesn't reorder or reinterpret them. The separator also future-proofs scripts against new `dotnet test` options that might later match a token previously forwarded to the test application.
-
-> [!NOTE]
-> The same behavior applies to `dotnet run` and `dotnet build`, which also forward unrecognized tokens to the target application or MSBuild. For more details, see [dotnet/sdk#51990](https://github.com/dotnet/sdk/issues/51990).
+The same parser behavior applies to `dotnet run` and `dotnet build`. For a detailed example, see [Forward arguments to the application](dotnet-run.md#forward-arguments-to-the-application) in the `dotnet run` reference.
 
 ## Examples
 

--- a/docs/core/tools/dotnet-test-mtp.md
+++ b/docs/core/tools/dotnet-test-mtp.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet test command with Microsoft.Testing.Platform (MTP)
 description: The dotnet test command is used to execute unit tests in a given project using MTP.
-ms.date: 02/03/2026
+ms.date: 06/05/2026
 ai-usage: ai-assisted
 ---
 # dotnet test with Microsoft.Testing.Platform (MTP)
@@ -167,6 +167,29 @@ With MTP, `dotnet test` operates faster than with VSTest. The test-related argum
 
 > [!NOTE]
 > To enable trace logging to a file, use the environment variable `DOTNET_CLI_TEST_TRACEFILE` to provide the path to the trace file.
+
+## Pass arguments to the test application
+
+`dotnet test` forwards any argument it doesn't recognize to the test application. The forwarded arguments keep their original order, but `dotnet test` first removes the options it understands. When a recognized option appears between an unrecognized option name and its value, removing the recognized option can change the meaning of the remaining arguments.
+
+For example, the following command interleaves the `dotnet test` option `--results-directory` between MTP options that the test app understands:
+
+```dotnetcli
+dotnet test --report-trx --report-trx-filename --results-directory TestResults A.trx
+```
+
+After `dotnet test` consumes `--results-directory TestResults`, the test application receives `--report-trx --report-trx-filename A.trx`. The test application then treats `A.trx` as the value of `--report-trx-filename`, which doesn't match what you typed on the command line.
+
+To avoid this ambiguity, place test application arguments after a literal `--`:
+
+```dotnetcli
+dotnet test --results-directory TestResults -- --report-trx --report-trx-filename A.trx
+```
+
+The `--` separator marks every following token as a test application argument, so `dotnet test` doesn't reorder or reinterpret them. The separator also future-proofs scripts against new `dotnet test` options that might later match a token previously forwarded to the test application.
+
+> [!NOTE]
+> The same behavior applies to `dotnet run` and `dotnet build`, which also forward unrecognized tokens to the target application or MSBuild. For more details, see [dotnet/sdk#51990](https://github.com/dotnet/sdk/issues/51990).
 
 ## Examples
 


### PR DESCRIPTION
Documents the parser caveat from [dotnet/sdk#51990](https://github.com/dotnet/sdk/issues/51990) for dotnet test in Microsoft.Testing.Platform (MTP) mode.

When `dotnet test` consumes an option it recognizes (for example, `--results-directory TestResults`), the remaining tokens are forwarded to the test application. If a recognized option appears between an unrecognized option name and its value, removing the recognized option can change the meaning of the leftover arguments. For example:

```
dotnet test --report-trx --report-trx-filename --results-directory TestResults A.trx
```

becomes `--report-trx --report-trx-filename A.trx` for the test app, which then treats `A.trx` as the value of `--report-trx-filename`.

The same behavior exists in `dotnet run` and `dotnet build` (any unrecognized token is forwarded). The recommendation, as discussed in the issue, is to use a literal `--` to mark where test application arguments begin so that `dotnet test` doesn't reorder or reinterpret them.

## Changes

- `docs/core/tools/dotnet-test-mtp.md`: adds a new `Pass arguments to the test application` section that explains the behavior, shows a concrete repro, and recommends using `--`.
- `docs/core/testing/unit-testing-with-dotnet-test.md`: adds a tip in the *Migrate to MTP mode* section noting that even though `--` is no longer required, it's still useful to avoid this parser quirk and future-proof scripts.

## Internal previews

- [dotnet test with Microsoft.Testing.Platform (MTP)](https://review.learn.microsoft.com/dotnet/core/tools/dotnet-test-mtp?branch=pr-en-us-XXXXX#pass-arguments-to-the-test-application)
- [Testing with 'dotnet test'](https://review.learn.microsoft.com/dotnet/core/testing/unit-testing-with-dotnet-test?branch=pr-en-us-XXXXX#migrate-to-mtp-mode-of-dotnet-test)

Closes https://github.com/dotnet/sdk/issues/51990.

---

🤖 Generated with the assistance of GitHub Copilot CLI.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-with-dotnet-test.md](https://github.com/dotnet/docs/blob/b245dd23f85d565a4876ad12907bfce2458832e4/docs/core/testing/unit-testing-with-dotnet-test.md) | [Testing with 'dotnet test'](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-dotnet-test?branch=pr-en-us-54192) |
| [docs/core/tools/dotnet-run.md](https://github.com/dotnet/docs/blob/b245dd23f85d565a4876ad12907bfce2458832e4/docs/core/tools/dotnet-run.md) | [dotnet run command](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-run?branch=pr-en-us-54192) |
| [docs/core/tools/dotnet-test-mtp.md](https://github.com/dotnet/docs/blob/b245dd23f85d565a4876ad12907bfce2458832e4/docs/core/tools/dotnet-test-mtp.md) | [dotnet test with Microsoft.Testing.Platform (MTP)](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test-mtp?branch=pr-en-us-54192) |


<!-- PREVIEW-TABLE-END -->