### PR TITLE
Add SDK download link to version selection page

### DIFF
--- a/docs/core/versions/selection.md
+++ b/docs/core/versions/selection.md
@@ -14,6 +14,9 @@ This article explains the policies used by the .NET tools, SDK, and runtime for 
 - Easy and efficient deployment of .NET, including security and reliability updates.
 - Use the latest tools and commands independent of target runtime.
 
+> [!TIP]
+> If you reached this page from a "compatible .NET SDK was not found" build error, [download the .NET SDK](https://dotnet.microsoft.com/download/dotnet) to install the required version. Alternatively, update your *global.json* file to match a version that's already installed.
+
 Version selection occurs:
 
 - When you run an SDK command, [the SDK uses the latest installed version](#the-sdk-uses-the-latest-installed-version).


### PR DESCRIPTION
Fixes #54199

  The aka.ms/dotnet/sdk-not-found redirect lands on this article, which had
  no visible link to download the SDK. As discussed in the issue, this adds
  a tip near the top of the page linking to the .NET download page.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/versions/selection.md](https://github.com/dotnet/docs/blob/50c831ed731305abae0db2a3f24e309ccd859670/docs/core/versions/selection.md) | [Select the .NET version to use](https://review.learn.microsoft.com/en-us/dotnet/core/versions/selection?branch=pr-en-us-54207) |

<!-- PREVIEW-TABLE-END -->