### PR TITLE
Document versioned MTP telemetry item (2.1.0)

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-telemetry.md
+++ b/docs/core/testing/microsoft-testing-platform-telemetry.md
@@ -88,6 +88,7 @@ The telemetry feature collects the following data points:
 | All | Version of your test adapter. |
 | All | Guid to correlate events from a single runner. |
 | 1.0.3 | Guid to correlate events from a single test run. |
+| 2.1.0 | Count of tests discovered. |
 
 ## Continuous integration detection
 


### PR DESCRIPTION
Adds the versioned row we can map confidently from testfx release history:

- **2.1.0**: Count of tests discovered.

Source: docs/Changelog-Platform.md in microsoft/testfx includes "Report discovered telemetry events correctly for MTP" (#7219) under **2.1.0**.

This PR only includes items with an explicit released version. Unreleased (main) items are in a separate PR.
