### PR TITLE
Update code-generation.md to change the only instance of "Optimize+" …

### DIFF
--- a/docs/csharp/language-reference/compiler-options/code-generation.md
+++ b/docs/csharp/language-reference/compiler-options/code-generation.md
@@ -77,7 +77,7 @@ The **Optimize** option enables or disables optimizations performed by the compi
 
 You set the **Optimize** option from **Build** properties page for your project in Visual Studio.
 
-**Optimize** also tells the common language runtime to optimize code at run time. By default, optimizations are disabled. Specify **Optimize+** to enable optimizations. When building a module to be used by an assembly, use the same **Optimize** settings as used by the assembly. It's possible to combine the **Optimize** and [**Debug**](#debugtype) options.
+**Optimize** also tells the common language runtime to optimize code at run time. By default, optimizations are disabled. Specify **Optimize** to enable optimizations. When building a module to be used by an assembly, use the same **Optimize** settings as used by the assembly. It's possible to combine the **Optimize** and [**Debug**](#debugtype) options.
 
 ## Deterministic
 


### PR DESCRIPTION
…to just "Optimize"

Changing "Optimize+" to "Optimize" (the former is not mentioned anywhere else in this doc, so I assume that it was a typo?)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-options/code-generation.md](https://github.com/dotnet/docs/blob/0d7c7627d1186a85c1408c1a95dcb6f40ec42f9d/docs/csharp/language-reference/compiler-options/code-generation.md) | [C# Compiler Options that control code generation](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/code-generation?branch=pr-en-us-54351) |

<!-- PREVIEW-TABLE-END -->