### PR TITLE
[Diagnostics] Update dotnet-trace collect-linux and perfmap enablement

### DIFF
--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -311,8 +311,8 @@ Collects diagnostic traces using perf_events, a Linux OS technology. `collect-li
 - .NET 10+
 
 > [!NOTE]
-> The `collect-linux` verb only runs on Linux x64 and Linux Arm64 environments that have glibc version 2.35 or later.
-> All of the [.NET 10 officially supported Linux distros](https://github.com/dotnet/core/blob/main/release-notes/10.0/supported-os.md#linux) support this requirement except Alpine 3.22, CentOS Stream 9, and any distros based off Red Hat Enterprise Linux 9.
+> The `collect-linux` verb only runs on Linux x64 and Linux Arm64 environments that have glibc version 2.27 or later.
+> All of the [.NET 10 officially supported Linux distros](https://github.com/dotnet/core/blob/main/release-notes/10.0/supported-os.md#linux) support this requirement except Alpine 3.22.
 > A quick way to check the version of a system's libc is with the command `ldd --version` or by executing the libc library directly.
 
 > [!TIP]

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet-trace diagnostic tool - .NET CLI
 description: Learn how to install and use the dotnet-trace CLI tool to collect .NET traces of a running process without the native profiler, by using the .NET EventPipe.
-ms.date: 03/19/2026
+ms.date: 06/10/2026
 ms.topic: reference
 ms.custom: sfi-ropc-nochange
 ---

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -81,7 +81,7 @@ The following table compares perf maps and jit maps.
 |------------------------|--------------|--------|
 | **runtimeconfig.json** | N/A          | N/A    |
 | **Environment variable** | `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - perf maps and jit dumps both enabled<br/>`2` - jit dumps enabled<br/>`3` - perf maps enabled |
-| [**Diagnostics IPC Command**](https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md) | N/A | N/A |
+| [**Diagnostics IPC Command**](https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md) | `EnablePerfMap`, `DisablePerfMap` | `EnablePerfMap(PerfMapType.All)` - perf maps and jit dumps<br/>`EnablePerfMap(PerfMapType.JitDump)` - jit dumps only<br/>`EnablePerfMap(PerfMapType.PerfMap)` - perf maps only<br/>`DisablePerfMap()` - disabled |
 
 For EventPipe-related environment variables, see [Trace using environment variables](../diagnostics/eventpipe.md#trace-using-environment-variables).
 

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -1,7 +1,7 @@
 ---
 title: Debugging profiling config settings
 description: Learn about runtime settings that configure debugging and profiling for .NET apps.
-ms.date: 11/27/2019
+ms.date: 06/10/2026
 ---
 # Runtime configuration options for debugging and profiling
 
@@ -65,6 +65,7 @@ When the `DOTNET_PROFILER_PATH*` [environment variables](#environment-variable-c
 
 - Enables or disables perf maps or jit dumps. These files allow third party tools, such as the Linux `perf` tool, to provide human readable names for dynamically generated code and precompiled ReadyToRun (R2R) modules.
 - If you omit this setting, writing perf map and jit dump files are both disabled. This is equivalent to setting the value to `0`.
+- On .NET 8 and later, the runtime can enable and disable perf maps and jit dump files on demand in response to a diagnostic IPC request. See [EnablePerfMap](https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md#enableperfmap), [DisablePerfMap](https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md#disableperfmap), and [DiagnosticsClient APIs](../diagnostics/microsoft-diagnostics-netcore-client.md#perfmap-methods).
 - When perf maps are disabled, not all managed callsites will be properly resolved.
 - Depending on the Linux kernel version, both formats are supported by the `perf` tool.
 - Enabling perf maps or jit dumps might cause up to a 20% overhead, though often it's much less. To minimize performance impact, it's recommended to selectively enable either perf maps or jit dumps, but not both. The impact only occurs while the application is JITing code. Often that occurs at startup, but it might occur later if the application is running a new code path for the first time.
@@ -80,6 +81,7 @@ The following table compares perf maps and jit maps.
 |------------------------|--------------|--------|
 | **runtimeconfig.json** | N/A          | N/A    |
 | **Environment variable** | `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - perf maps and jit dumps both enabled<br/>`2` - jit dumps enabled<br/>`3` - perf maps enabled |
+| [**Diagnostics IPC Command**](https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md) | N/A | N/A |
 
 For EventPipe-related environment variables, see [Trace using environment variables](../diagnostics/eventpipe.md#trace-using-environment-variables).
 

--- a/docs/core/runtime-config/debugging-profiling.md
+++ b/docs/core/runtime-config/debugging-profiling.md
@@ -65,7 +65,7 @@ When the `DOTNET_PROFILER_PATH*` [environment variables](#environment-variable-c
 
 - Enables or disables perf maps or jit dumps. These files allow third party tools, such as the Linux `perf` tool, to provide human readable names for dynamically generated code and precompiled ReadyToRun (R2R) modules.
 - If you omit this setting, writing perf map and jit dump files are both disabled. This is equivalent to setting the value to `0`.
-- On .NET 8 and later, the runtime can enable and disable perf maps and jit dump files on demand in response to a diagnostic IPC request. See [EnablePerfMap](https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md#enableperfmap), [DisablePerfMap](https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md#disableperfmap), and [DiagnosticsClient APIs](../diagnostics/microsoft-diagnostics-netcore-client.md#perfmap-methods).
+- On .NET 8 and later, profiling tools can enable perfmaps on demand without needing any environment variable configuration. However not every profiling tool implements this. Manually setting the environment is still required for at least the Linux 'perf' tool and 'perfcollect'.
 - When perf maps are disabled, not all managed callsites will be properly resolved.
 - Depending on the Linux kernel version, both formats are supported by the `perf` tool.
 - Enabling perf maps or jit dumps might cause up to a 20% overhead, though often it's much less. To minimize performance impact, it's recommended to selectively enable either perf maps or jit dumps, but not both. The impact only occurs while the application is JITing code. Often that occurs at startup, but it might occur later if the application is running a new code path for the first time.
@@ -81,7 +81,6 @@ The following table compares perf maps and jit maps.
 |------------------------|--------------|--------|
 | **runtimeconfig.json** | N/A          | N/A    |
 | **Environment variable** | `DOTNET_PerfMapEnabled` | `0` - disabled<br/>`1` - perf maps and jit dumps both enabled<br/>`2` - jit dumps enabled<br/>`3` - perf maps enabled |
-| [**Diagnostics IPC Command**](https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md) | `EnablePerfMap`, `DisablePerfMap` | `EnablePerfMap(PerfMapType.All)` - perf maps and jit dumps<br/>`EnablePerfMap(PerfMapType.JitDump)` - jit dumps only<br/>`EnablePerfMap(PerfMapType.PerfMap)` - perf maps only<br/>`DisablePerfMap()` - disabled |
 
 For EventPipe-related environment variables, see [Trace using environment variables](../diagnostics/eventpipe.md#trace-using-environment-variables).
 


### PR DESCRIPTION
## Summary

Lower dotnet-trace collect-linux glibc compatibility.
Clarify PerfMap on demand enable/disable through Diagnostic IPC Commands

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/diagnostics/dotnet-trace.md](https://github.com/dotnet/docs/blob/97a9eb033effde2f7fc397a95dce6c863f545ed2/docs/core/diagnostics/dotnet-trace.md) | [dotnet-trace performance analysis utility](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace?branch=pr-en-us-54354) |
| [docs/core/runtime-config/debugging-profiling.md](https://github.com/dotnet/docs/blob/97a9eb033effde2f7fc397a95dce6c863f545ed2/docs/core/runtime-config/debugging-profiling.md) | [Debugging profiling config settings](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/debugging-profiling?branch=pr-en-us-54354) |


<!-- PREVIEW-TABLE-END -->