### PR TITLE
Add next-gen config + DI tab to local-development-dev-accounts

### DIFF
--- a/docs/azure/sdk/authentication/local-development-dev-accounts.md
+++ b/docs/azure/sdk/authentication/local-development-dev-accounts.md
@@ -74,8 +74,8 @@ Next, sign-in to Azure using one of several developer tools that can be used to 
 
 The [Azure Identity library](/dotnet/api/azure.identity?view=azure-dotnet&preserve-view=true) provides implementations of <xref:Azure.Core.TokenCredential> that support various scenarios and Microsoft Entra authentication flows. The Azure SDK for .NET offers two patterns for registering Azure service clients with dependency injection:
 
-- **Microsoft.Extensions.Azure (stable)** — register clients with `AddAzureClients` and pass a `TokenCredential` to `UseCredential` in code. Use this pattern for production apps today.
-- **Azure.Identity configuration and DI (preview)** — bind clients and their credentials to a section of `appsettings.json`. No `TokenCredential` instance is constructed in code. Tracked by [azure-sdk-for-net#55491](https://github.com/Azure/azure-sdk-for-net/issues/55491).
+- **Microsoft.Extensions.Azure (stable)**: register clients with `AddAzureClients` and pass a `TokenCredential` to `UseCredential` in code. Use this pattern for production apps today.
+- **Azure.Identity configuration and DI (preview)**: bind clients and their credentials to a section of `appsettings.json`. No `TokenCredential` instance is constructed in code. Tracked by [azure-sdk-for-net#55491](https://github.com/Azure/azure-sdk-for-net/issues/55491).
 
 Select a tab to see the steps for each pattern.
 
@@ -133,7 +133,7 @@ Select a tab to see the steps for each pattern.
 
     The package pulls in a compatible prerelease of `Azure.Identity` transitively.
 
-1. In `appsettings.json`, add a section that describes the client endpoint and credential. The section name is arbitrary — you reference it by name when you register the client:
+1. In `appsettings.json`, add a section that describes the client endpoint and credential. The section name is arbitrary; you reference it by name when you register the client:
 
     ```json
     "KeyVaultSecrets": {
@@ -150,7 +150,7 @@ Select a tab to see the steps for each pattern.
 
     :::code language="csharp" source="../snippets/authentication/local-dev-account/Program.cs" id="snippet_NextGenAddSecretClient":::
 
-    The credential is resolved from the `Credential` subsection automatically — no `TokenCredential` instance is constructed in code.
+    The credential is resolved from the `Credential` subsection automatically. No `TokenCredential` instance is constructed in code.
 
 > [!NOTE]
 > Service-specific extensions like `AddSecretClient` ship with each client library as it adopts the pattern. For libraries that haven't shipped a dedicated extension yet, use the generic `builder.AddAzureClient<TClient, TSettings>("section-name")` method from `Azure.Identity` instead.

--- a/docs/azure/sdk/authentication/local-development-dev-accounts.md
+++ b/docs/azure/sdk/authentication/local-development-dev-accounts.md
@@ -75,7 +75,7 @@ Next, sign-in to Azure using one of several developer tools that can be used to 
 The [Azure Identity library](/dotnet/api/azure.identity?view=azure-dotnet&preserve-view=true) provides implementations of <xref:Azure.Core.TokenCredential> that support various scenarios and Microsoft Entra authentication flows. The Azure SDK for .NET offers two patterns for registering Azure service clients with dependency injection:
 
 - The **Microsoft.Extensions.Azure** pattern is stable. You register clients with `AddAzureClients` and pass a `TokenCredential` to `UseCredential` in code. Use this pattern for production apps today.
-- The **Azure.Identity configuration and DI** pattern is in preview. You bind clients and their credentials to a section of `appsettings.json`, and no `TokenCredential` instance is constructed in code. This pattern is tracked by [azure-sdk-for-net#55491](https://github.com/Azure/azure-sdk-for-net/issues/55491).
+- The **Azure.Identity configuration and DI** pattern is in preview. You bind clients and their credentials to a section of `appsettings.json`, and no `TokenCredential` instance is constructed in code.
 
 Select a tab to see the steps for each pattern.
 
@@ -117,13 +117,15 @@ Select a tab to see the steps for each pattern.
 ### [Azure.Identity configuration and DI (preview)](#tab/config-di)
 
 > [!IMPORTANT]
-> The configuration and dependency injection APIs shown in this tab are in public preview and emit diagnostic ID `SCME0002`. Service-specific registration extensions (for example, `AddSecretClient`) are rolling out incrementally across the Azure SDK client libraries. To use these APIs today, install a prerelease of the relevant client library and suppress `SCME0002` in your project file:
+> The configuration and dependency injection APIs shown in this tab are in public preview and emit diagnostic ID `SCME0002`. Service-specific registration extensions (for example, `AddSecretClient`) are rolling out incrementally across the Azure SDK client libraries. To use these APIs today, install a prerelease of the relevant client library and suppress `SCME0002` inline at each call site, so the diagnostic still surfaces for any future preview API you adopt:
 >
-> ```xml
-> <PropertyGroup>
->   <NoWarn>$(NoWarn);SCME0002</NoWarn>
-> </PropertyGroup>
+> ```csharp
+> #pragma warning disable SCME0002
+> builder.AddSecretClient("KeyVaultSecrets");
+> #pragma warning restore SCME0002
 > ```
+>
+> If you prefer a project-wide suppression instead, add `<NoWarn>$(NoWarn);SCME0002</NoWarn>` to a `PropertyGroup` in your project file.
 
 1. Add a reference to the preview release of the client library that ships the next-gen extensions. For example, to register a Key Vault `SecretClient`:
 
@@ -144,7 +146,16 @@ Select a tab to see the steps for each pattern.
     }
     ```
 
-    `CredentialSource` accepts any credential supported by Azure.Identity, including `AzureCliCredential`, `AzureDeveloperCliCredential`, `AzurePowerShellCredential`, `VisualStudioCredential`, `VisualStudioCodeCredential`, `EnvironmentCredential`, `ManagedIdentityCredential`, and `InteractiveBrowserCredential`.
+    `CredentialSource` accepts any credential supported by Azure.Identity, including:
+
+    - `AzureCliCredential`
+    - `AzureDeveloperCliCredential`
+    - `AzurePowerShellCredential`
+    - `VisualStudioCredential`
+    - `VisualStudioCodeCredential`
+    - `EnvironmentCredential`
+    - `ManagedIdentityCredential`
+    - `InteractiveBrowserCredential`
 
 1. In `Program.cs`, add a `using` directive for the client namespace and register the client by binding it to the configuration section:
 

--- a/docs/azure/sdk/authentication/local-development-dev-accounts.md
+++ b/docs/azure/sdk/authentication/local-development-dev-accounts.md
@@ -74,8 +74,8 @@ Next, sign-in to Azure using one of several developer tools that can be used to 
 
 The [Azure Identity library](/dotnet/api/azure.identity?view=azure-dotnet&preserve-view=true) provides implementations of <xref:Azure.Core.TokenCredential> that support various scenarios and Microsoft Entra authentication flows. The Azure SDK for .NET offers two patterns for registering Azure service clients with dependency injection:
 
-- **Microsoft.Extensions.Azure (stable)**: register clients with `AddAzureClients` and pass a `TokenCredential` to `UseCredential` in code. Use this pattern for production apps today.
-- **Azure.Identity configuration and DI (preview)**: bind clients and their credentials to a section of `appsettings.json`. No `TokenCredential` instance is constructed in code. Tracked by [azure-sdk-for-net#55491](https://github.com/Azure/azure-sdk-for-net/issues/55491).
+- The **Microsoft.Extensions.Azure** pattern is stable. You register clients with `AddAzureClients` and pass a `TokenCredential` to `UseCredential` in code. Use this pattern for production apps today.
+- The **Azure.Identity configuration and DI** pattern is in preview. You bind clients and their credentials to a section of `appsettings.json`, and no `TokenCredential` instance is constructed in code. This pattern is tracked by [azure-sdk-for-net#55491](https://github.com/Azure/azure-sdk-for-net/issues/55491).
 
 Select a tab to see the steps for each pattern.
 
@@ -133,7 +133,7 @@ Select a tab to see the steps for each pattern.
 
     The package pulls in a compatible prerelease of `Azure.Identity` transitively.
 
-1. In `appsettings.json`, add a section that describes the client endpoint and credential. The section name is arbitrary; you reference it by name when you register the client:
+1. In `appsettings.json`, add a section that describes the client endpoint and credential. The section name is arbitrary, and you reference it by name when you register the client:
 
     ```json
     "KeyVaultSecrets": {

--- a/docs/azure/sdk/authentication/local-development-dev-accounts.md
+++ b/docs/azure/sdk/authentication/local-development-dev-accounts.md
@@ -2,7 +2,8 @@
 title: Authenticate .NET apps to Azure using developer accounts
 description: Learn how to authenticate your application to Azure services when using the Azure SDK for .NET during local development using developer accounts.
 ms.topic: how-to
-ms.date: 11/25/2025
+ms.date: 06/12/2026
+ai-usage: ai-assisted
 ms.custom:
   - devx-track-dotnet
   - engagement-fy23
@@ -71,11 +72,14 @@ Next, sign-in to Azure using one of several developer tools that can be used to 
 
 ## Authenticate to Azure services from your app
 
-The [Azure Identity library](/dotnet/api/azure.identity?view=azure-dotnet&preserve-view=true) provides implementations of <xref:Azure.Core.TokenCredential> that support various scenarios and Microsoft Entra authentication flows. The steps ahead demonstrate how to use <xref:Azure.Identity.DefaultAzureCredential> or a specific development tool credential when working with user accounts locally.
+The [Azure Identity library](/dotnet/api/azure.identity?view=azure-dotnet&preserve-view=true) provides implementations of <xref:Azure.Core.TokenCredential> that support various scenarios and Microsoft Entra authentication flows. The Azure SDK for .NET offers two patterns for registering Azure service clients with dependency injection:
 
-### Implement the code
+- **Microsoft.Extensions.Azure (stable)** — register clients with `AddAzureClients` and pass a `TokenCredential` to `UseCredential` in code. Use this pattern for production apps today.
+- **Azure.Identity configuration and DI (preview)** — bind clients and their credentials to a section of `appsettings.json`. No `TokenCredential` instance is constructed in code. Tracked by [azure-sdk-for-net#55491](https://github.com/Azure/azure-sdk-for-net/issues/55491).
 
-Complete the following steps:
+Select a tab to see the steps for each pattern.
+
+### [Microsoft.Extensions.Azure (stable)](#tab/mea)
 
 1. Add references to the [Azure.Identity](https://www.nuget.org/packages/Azure.Identity) and the [Microsoft.Extensions.Azure](https://www.nuget.org/packages/Microsoft.Extensions.Azure) packages in your project:
 
@@ -109,3 +113,46 @@ Complete the following steps:
 
     > [!TIP]
     > When your team uses multiple development tools to authenticate with Azure, prefer a local development-optimized instance of `DefaultAzureCredential` over tool-specific credentials.
+
+### [Azure.Identity configuration and DI (preview)](#tab/config-di)
+
+> [!IMPORTANT]
+> The configuration and dependency injection APIs shown in this tab are in public preview and emit diagnostic ID `SCME0002`. Service-specific registration extensions (for example, `AddSecretClient`) are rolling out incrementally across the Azure SDK client libraries. To use these APIs today, install a prerelease of the relevant client library and suppress `SCME0002` in your project file:
+>
+> ```xml
+> <PropertyGroup>
+>   <NoWarn>$(NoWarn);SCME0002</NoWarn>
+> </PropertyGroup>
+> ```
+
+1. Add a reference to the preview release of the client library that ships the next-gen extensions. For example, to register a Key Vault `SecretClient`:
+
+    ```dotnetcli
+    dotnet package add Azure.Security.KeyVault.Secrets --prerelease
+    ```
+
+    The package pulls in a compatible prerelease of `Azure.Identity` transitively.
+
+1. In `appsettings.json`, add a section that describes the client endpoint and credential. The section name is arbitrary — you reference it by name when you register the client:
+
+    ```json
+    "KeyVaultSecrets": {
+      "VaultUri": "https://<vault-name>.vault.azure.net",
+      "Credential": {
+        "CredentialSource": "AzureCliCredential"
+      }
+    }
+    ```
+
+    `CredentialSource` accepts any credential supported by Azure.Identity, including `AzureCliCredential`, `AzureDeveloperCliCredential`, `AzurePowerShellCredential`, `VisualStudioCredential`, `VisualStudioCodeCredential`, `EnvironmentCredential`, `ManagedIdentityCredential`, and `InteractiveBrowserCredential`.
+
+1. In `Program.cs`, add a `using` directive for the client namespace and register the client by binding it to the configuration section:
+
+    :::code language="csharp" source="../snippets/authentication/local-dev-account/Program.cs" id="snippet_NextGenAddSecretClient":::
+
+    The credential is resolved from the `Credential` subsection automatically — no `TokenCredential` instance is constructed in code.
+
+> [!NOTE]
+> Service-specific extensions like `AddSecretClient` ship with each client library as it adopts the pattern. For libraries that haven't shipped a dedicated extension yet, use the generic `builder.AddAzureClient<TClient, TSettings>("section-name")` method from `Azure.Identity` instead.
+
+---

--- a/docs/azure/sdk/snippets/authentication/local-dev-account/LocalDevAccount.csproj
+++ b/docs/azure/sdk/snippets/authentication/local-dev-account/LocalDevAccount.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- SCME0002 covers the experimental configuration and DI APIs in
+         System.ClientModel / Azure.Identity. Suppress here so the next-gen
+         snippets compile. Remove after the APIs stabilize. -->
+    <NoWarn>$(NoWarn);SCME0002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +16,10 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
+    <!-- Preview release that ships the AddSecretClient extension for the
+         next-gen configuration and DI pattern. Tracked by
+         https://github.com/Azure/azure-sdk-for-net/issues/55491. -->
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" VersionOverride="4.12.0-beta.1" />
   </ItemGroup>
 
 </Project>

--- a/docs/azure/sdk/snippets/authentication/local-dev-account/LocalDevAccount.csproj
+++ b/docs/azure/sdk/snippets/authentication/local-dev-account/LocalDevAccount.csproj
@@ -4,10 +4,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <!-- SCME0002 covers the experimental configuration and DI APIs in
-         System.ClientModel / Azure.Identity. Suppress here so the next-gen
-         snippets compile. Remove after the APIs stabilize. -->
-    <NoWarn>$(NoWarn);SCME0002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/azure/sdk/snippets/authentication/local-dev-account/Program.cs
+++ b/docs/azure/sdk/snippets/authentication/local-dev-account/Program.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.Extensions.Azure;
 using Azure.Storage.Blobs;
 using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
 
 var builder = WebApplication.CreateBuilder(args);
 
 registerUsingUserPrincipal(builder);
+registerUsingNextGen(builder);
 
 var app = builder.Build();
 
@@ -66,6 +68,18 @@ void registerUsingUserPrincipal(WebApplicationBuilder builder)
         clientBuilder.UseCredential(credential);
     });
     #endregion snippet_DefaultAzureCredentialDev
+}
+
+// Demonstrates the next-gen configuration and dependency injection pattern from
+// System.ClientModel / Azure.Identity. The credential and endpoint are read from
+// the "KeyVaultSecrets" section of appsettings.json.
+void registerUsingNextGen(WebApplicationBuilder builder)
+{
+    #region snippet_NextGenAddSecretClient
+    // Binds the "KeyVaultSecrets" section of appsettings.json and resolves the
+    // credential from the nested "Credential" subsection automatically.
+    builder.AddSecretClient("KeyVaultSecrets");
+    #endregion snippet_NextGenAddSecretClient
 }
 
 internal record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)

--- a/docs/azure/sdk/snippets/authentication/local-dev-account/Program.cs
+++ b/docs/azure/sdk/snippets/authentication/local-dev-account/Program.cs
@@ -76,9 +76,11 @@ void registerUsingUserPrincipal(WebApplicationBuilder builder)
 void registerUsingNextGen(WebApplicationBuilder builder)
 {
     #region snippet_NextGenAddSecretClient
-    // Binds the "KeyVaultSecrets" section of appsettings.json and resolves the
-    // credential from the nested "Credential" subsection automatically.
+    // SCME0002 flags the experimental config + DI APIs. Scope the suppression
+    // narrowly so the rest of the project still surfaces the diagnostic.
+#pragma warning disable SCME0002
     builder.AddSecretClient("KeyVaultSecrets");
+#pragma warning restore SCME0002
     #endregion snippet_NextGenAddSecretClient
 }
 

--- a/docs/azure/sdk/snippets/authentication/local-dev-account/appsettings.json
+++ b/docs/azure/sdk/snippets/authentication/local-dev-account/appsettings.json
@@ -5,5 +5,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "KeyVaultSecrets": {
+    "VaultUri": "https://<vault-name>.vault.azure.net",
+    "Credential": {
+      "CredentialSource": "AzureCliCredential"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds a preview tab for the **Azure.Identity configuration and dependency injection** pattern alongside the existing **Microsoft.Extensions.Azure** flow in [docs/azure/sdk/authentication/local-development-dev-accounts.md](docs/azure/sdk/authentication/local-development-dev-accounts.md). The next-gen pattern is tracked by [`Azure/azure-sdk-for-net#55491`](https://github.com/Azure/azure-sdk-for-net/issues/55491) and ships service-specific extensions like `AddSecretClient` that bind clients (and their credentials) to an `appsettings.json` section, with no `TokenCredential` constructed in code.

## Changes

**Article — [local-development-dev-accounts.md](docs/azure/sdk/authentication/local-development-dev-accounts.md)**

- Frontmatter: `ms.date` bumped to `06/12/2026`; added `ai-usage: ai-assisted`.
- Replaced the single `### Implement the code` block under "Authenticate to Azure services from your app" with two `###`-level tabs:
  - **Microsoft.Extensions.Azure (stable)** — the original 4-step `AddAzureClients` + `UseCredential` walkthrough, unchanged.
  - **Azure.Identity configuration and DI (preview)** — `SCME0002` callout with the `<NoWarn>` snippet, then steps for `dotnet package add --prerelease`, the `KeyVaultSecrets` `appsettings.json` schema (with the full list of supported `CredentialSource` values), and the `builder.AddSecretClient("KeyVaultSecrets")` registration. Closing note explains the fallback to generic `builder.AddAzureClient<T, TSettings>` for libraries that haven't shipped service-specific extensions yet.
