### PR TITLE
Add C# 8 parameter shadowing history item

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/local-functions.md
+++ b/docs/csharp/programming-guide/classes-and-structs/local-functions.md
@@ -18,6 +18,8 @@ helpviewer_keywords:
 - Finalizers
 - Other local functions
 
+Beginning with C# 8.0, local function parameters can shadow local variables and parameters from an enclosing scope.
+
 However, local functions can't be declared inside an expression-bodied member.
 
 > [!NOTE]

--- a/docs/csharp/whats-new/csharp-version-history.md
+++ b/docs/csharp/whats-new/csharp-version-history.md
@@ -212,6 +212,7 @@ C# 8.0 is the first major C# release that specifically targets .NET Core. Some f
   - Positional patterns
 - [Using declarations](../language-reference/statements/using.md)
 - [Static local functions](../programming-guide/classes-and-structs/local-functions.md)
+- Lambda expressions, anonymous methods, and local functions can declare parameters that shadow local variables and parameters from an enclosing scope.
 - [Disposable ref structs](../language-reference/builtin-types/ref-struct.md)
 - [Nullable reference types](../language-reference/builtin-types/nullable-reference-types.md)
 - [Asynchronous streams](../language-reference/statements/iteration-statements.md#await-foreach)


### PR DESCRIPTION
Fixes #52972

Adds the missing C# 8 history item for lambda expressions, anonymous methods, and local functions allowing parameters to shadow local variables and parameters from an enclosing scope.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/local-functions.md](https://github.com/dotnet/docs/blob/a5c973cbec42d923fc72385cc31917520dc476a7/docs/csharp/programming-guide/classes-and-structs/local-functions.md) | [Local functions (C# Programming Guide)](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/local-functions?branch=pr-en-us-54372) |
| [docs/csharp/whats-new/csharp-version-history.md](https://github.com/dotnet/docs/blob/a5c973cbec42d923fc72385cc31917520dc476a7/docs/csharp/whats-new/csharp-version-history.md) | [The history of C#](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history?branch=pr-en-us-54372) |


<!-- PREVIEW-TABLE-END -->