### PR TITLE
Replace all occurences of redundant spacing in if condition

### DIFF
--- a/docs/framework/unmanaged-api/fusion/identity-attribute-blob-structure.md
+++ b/docs/framework/unmanaged-api/fusion/identity-attribute-blob-structure.md
@@ -177,7 +177,7 @@ int _cdecl wmain(int argc, LPCWSTR argv[])
             goto Exit;  
         }  
   
-        if (! cbUsed) {  
+        if (!cbUsed) {  
             break;  
         }  
   

--- a/samples/snippets/csharp/VS_Snippets_CLR/Formatting.HowTo.NumericValue/cs/Telephone1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/Formatting.HowTo.NumericValue/cs/Telephone1.cs
@@ -15,7 +15,7 @@ public class TelephoneFormatter : IFormatProvider, ICustomFormatter
    public string Format(string format, object arg, IFormatProvider formatProvider)
    {
       // Check whether this is an appropriate callback
-      if (! this.Equals(formatProvider))
+      if (!this.Equals(formatProvider))
          return null;
 
       // Set default format specifier

--- a/samples/snippets/csharp/VS_Snippets_CLR/TimeZone2.Serialization/cs/SerializeTimeZoneData.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/TimeZone2.Serialization/cs/SerializeTimeZoneData.cs
@@ -33,7 +33,7 @@ class TimeZoneSerialization
          ResXResourceReader resReader = new ResXResourceReader(readStream);
          foreach (DictionaryEntry item in resReader)
          {
-            if (! (((string) item.Key) == "CentralStandardTime" ||
+            if (!(((string) item.Key) == "CentralStandardTime" ||
                    ((string) item.Key) == "PalmerStandardTime" ))
                resources.Add((string)item.Key, (string) item.Value);
          }
@@ -118,7 +118,7 @@ class TimeZoneSerialization
       {
          // Time zone not in system; retrieve from resource
          timeZoneString = resMgr.GetString("CentralStandardTime");
-         if (! String.IsNullOrEmpty(timeZoneString))
+         if (!String.IsNullOrEmpty(timeZoneString))
          {
             cst = TimeZoneInfo.FromSerializedString(timeZoneString);
          }

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.clscompliant/cs/indicator3.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.clscompliant/cs/indicator3.cs
@@ -50,7 +50,7 @@ public class CharacterUtilities
          throw new ArgumentException("The array has too many characters.");
 
       if (chars.Length == 2) {
-         if (! Char.IsSurrogatePair(chars[0], chars[1]))
+         if (!Char.IsSurrogatePair(chars[0], chars[1]))
             throw new ArgumentException("The array must contain a low and a high surrogate.");
          else
             return Char.ConvertToUtf32(chars[0], chars[1]);

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.encoding/cs/bestfit1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.encoding/cs/bestfit1.cs
@@ -28,7 +28,7 @@ public class Example
       // Decode the string.
       string str2 = cp1252.GetString(bytes);
       Console.WriteLine($"String round-tripped: {str.Equals(str2)}");
-      if (! str.Equals(str2)) {
+      if (!str.Equals(str2)) {
          Console.WriteLine(str2);
          foreach (var ch in str2)
             Console.Write("{0} ", Convert.ToUInt16(ch).ToString("X4"));

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.encoding/cs/bestfit1a.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.encoding/cs/bestfit1a.cs
@@ -20,7 +20,7 @@ public class Example
       byte[] bytes = cp1252r.GetBytes(str1);
       string str2 = cp1252r.GetString(bytes);
       Console.WriteLine($"Round-trip: {str1.Equals(str2)}");
-      if (! str1.Equals(str2)) {
+      if (!str1.Equals(str2)) {
          Console.WriteLine(str2);
          foreach (var ch in str2)
             Console.Write("{0} ", Convert.ToUInt16(ch).ToString("X4"));

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.encoding/cs/custom1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.encoding/cs/custom1.cs
@@ -29,7 +29,7 @@ class Program
       // Decode the ASCII bytes.
       string str2 = enc.GetString(bytes);
       Console.WriteLine($"Round-trip: {str1.Equals(str2)}");
-      if (! str1.Equals(str2)) {
+      if (!str1.Equals(str2)) {
          Console.WriteLine(str2);
          foreach (var ch in str2)
             Console.Write("{0} ", Convert.ToUInt16(ch).ToString("X4"));

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.encoding/cs/exceptionascii.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.encoding/cs/exceptionascii.cs
@@ -41,7 +41,7 @@ public class Example
       try {
          string str2 = enc.GetString(bytes);
          Console.WriteLine($"Round-trip: {str1.Equals(str2)}");
-         if (! str1.Equals(str2)) {
+         if (!str1.Equals(str2)) {
             Console.WriteLine(str2);
             foreach (var ch in str2)
                Console.Write("{0} ", Convert.ToUInt16(ch).ToString("X4"));

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.encoding/cs/replacementascii.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.encoding/cs/replacementascii.cs
@@ -25,7 +25,7 @@ public class Example
       // Decode the ASCII bytes.
       string str2 = enc.GetString(bytes);
       Console.WriteLine($"Round-trip: {str1.Equals(str2)}");
-      if (! str1.Equals(str2)) {
+      if (!str1.Equals(str2)) {
          Console.WriteLine(str2);
          foreach (var ch in str2)
             Console.Write("{0} ", Convert.ToUInt16(ch).ToString("X4"));

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.encoding/cs/stream1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.encoding/cs/stream1.cs
@@ -68,7 +68,7 @@ public class Example
    {
       bool result = original.Equals(decoded);
       Console.WriteLine($"original = decoded: {original.Equals(decoded, StringComparison.Ordinal)}");
-      if (! result) {
+      if (!result) {
          Console.WriteLine("Code points in original string:");
          foreach (var ch in original)
             Console.Write("{0} ", Convert.ToUInt16(ch).ToString("X4"));

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.parallel.for/cs/for1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.parallel.for/cs/for1.cs
@@ -14,7 +14,7 @@ public class Example
          Console.WriteLine("There are no command line arguments.");
          return;
       }
-      if (! Directory.Exists(args[0])) {
+      if (!Directory.Exists(args[0])) {
          Console.WriteLine("The directory does not exist.");
          return;
       }

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regularexpressions.bestpractices/cs/static1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regularexpressions.bestpractices/cs/static1.cs
@@ -62,7 +62,7 @@ public class CurrencyForm : Form
    // <Snippet2>
    public void OKButton_Click(object sender, EventArgs e)
    {
-      if (! String.IsNullOrEmpty(sourceCurrency.Text))
+      if (!String.IsNullOrEmpty(sourceCurrency.Text))
          if (RegexLib.IsValidCurrency(sourceCurrency.Text))
             PerformConversion();
          else

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regularexpressions.bestpractices/cs/static2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regularexpressions.bestpractices/cs/static2.cs
@@ -61,7 +61,7 @@ public class CurrencyForm2 : Form
 
    public void OKButton_Click(object sender, EventArgs e)
    {
-      if (! String.IsNullOrEmpty(sourceCurrency.Text))
+      if (!String.IsNullOrEmpty(sourceCurrency.Text))
          if (RegexLib2.IsValidCurrency(sourceCurrency.Text))
             PerformConversion();
          else

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regularexpressions.objectmodel/cs/split1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regularexpressions.objectmodel/cs/split1.cs
@@ -10,7 +10,7 @@ public class Example
       string pattern = @"\b\d{1,2}\.\s";
       foreach (string item in Regex.Split(input, pattern))
       {
-         if (! String.IsNullOrEmpty(item))
+         if (!String.IsNullOrEmpty(item))
             Console.WriteLine(item);
       }
    }

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.resources.retrieving/cs/example2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.resources.retrieving/cs/example2.cs
@@ -13,7 +13,7 @@ public class Example
       string title = rm.GetString("TableName");
       PersonTable tableInfo = (PersonTable) rm.GetObject("Employees");
 
-      if (! String.IsNullOrEmpty(title)) {
+      if (!String.IsNullOrEmpty(title)) {
          fmtString = "{0," + ((Console.WindowWidth + title.Length) / 2).ToString() + "}";
          Console.WriteLine(fmtString, title);
          Console.WriteLine();

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.resources.retrieving/cs/example3.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.resources.retrieving/cs/example3.cs
@@ -19,7 +19,7 @@ public class Example
          Console.WriteLine($"\n{greeting}!");
          Console.Write(rm.GetString("Prompt", CultureInfo.CurrentCulture));
          string name = Console.ReadLine();
-         if (! String.IsNullOrEmpty(name))
+         if (!String.IsNullOrEmpty(name))
             Console.WriteLine("{0}, {1}!", greeting, name);
       }
       Console.WriteLine();


### PR DESCRIPTION
This pull request fixes #54380 along with other cases where the same problem exists.
This commit replaces all (29 in total as per grep results count):
`if (! condition)`
with
`if (!condition)`
according to the general formatting in the code base.

From what I saw, this typo happens mostly in old (couple of years even) files, and was there when migrated from samples repository.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/framework/unmanaged-api/fusion/identity-attribute-blob-structure.md](https://github.com/dotnet/docs/blob/c877b597855b57f6f2f34344747f74d7436667e3/docs/framework/unmanaged-api/fusion/identity-attribute-blob-structure.md) | [IDENTITY_ATTRIBUTE_BLOB Structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/fusion/identity-attribute-blob-structure?branch=pr-en-us-54405) |


<!-- PREVIEW-TABLE-END -->