### PR TITLE
docs: link Orleans ADO.NET migration scripts

### DIFF
--- a/docs/orleans/host/configuration-guide/adonet-configuration.md
+++ b/docs/orleans/host/configuration-guide/adonet-configuration.md
@@ -9,6 +9,12 @@ ms.topic: how-to
 
 The following sections contain links to SQL scripts for configuring your database and the corresponding ADO.NET invariant used to configure ADO.NET providers in Orleans. Customize these scripts as needed for your deployment. Before executing scripts for Clustering, Persistence, or Reminders, you need to create the main tables using the Main scripts.
 
+If you are upgrading an existing ADO.NET schema, also apply the appropriate migration scripts for the providers you use:
+
+- [Clustering migrations](https://github.com/dotnet/orleans/tree/main/src/AdoNet/Orleans.Clustering.AdoNet/Migrations)
+- [Persistence migrations](https://github.com/dotnet/orleans/tree/main/src/AdoNet/Orleans.Persistence.AdoNet/Migrations)
+- [Reminders migrations](https://github.com/dotnet/orleans/tree/main/src/AdoNet/Orleans.Reminders.AdoNet/Migrations)
+
 ## Main scripts
 
 | Database | Script | NuGet package| ADO.NET invariant |


### PR DESCRIPTION
﻿## Summary
- add links to Orleans ADO.NET migration script directories
- call out that existing schemas should apply the provider-specific migration scripts

Addresses #38870.

## Validation
- `git diff --check`

## AI assistance
This change was prepared with assistance from OpenAI Codex.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/orleans/host/configuration-guide/adonet-configuration.md](https://github.com/dotnet/docs/blob/0680678b0cf2904b18e9e084440887290cdf08e1/docs/orleans/host/configuration-guide/adonet-configuration.md) | [docs/orleans/host/configuration-guide/adonet-configuration](https://review.learn.microsoft.com/en-us/dotnet/orleans/host/configuration-guide/adonet-configuration?branch=pr-en-us-54410) |


<!-- PREVIEW-TABLE-END -->