### PR TITLE
Fix incorrect Product type reference in generics article

### DIFF
--- a/docs/csharp/fundamentals/types/generics.md
+++ b/docs/csharp/fundamentals/types/generics.md
@@ -18,7 +18,7 @@ You encounter generics constantly in everyday C#. Collections, async return type
 
 :::code language="csharp" source="snippets/generics/Program.cs" ID="EverydayGenerics":::
 
-In each case, the type argument in angle brackets (`<int>`, `<string>`, `<Product>`) tells the generic type what kind of data it holds or operates on. The compiler enforces type safety. You can't accidentally add a `string` to a `List<int>`.
+In each case, the type argument in angle brackets (`<int>`, `<string>`, `<decimal>`) tells the generic type what kind of data it holds or operates on. The compiler enforces type safety. You can't accidentally add a `string` to a `List<int>`.
 
 ## Consuming generic types
 


### PR DESCRIPTION
## Summary

Fixes #53989.

This PR updates the generics documentation to replace the `<Product>` type argument reference with `<decimal>`, which is one of the actual type arguments used in the example.

## Reason

The article currently mentions `<Product>`, but the example does not define or use a `Product` type. This could confuse readers who are new to generics.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/fundamentals/types/generics.md](https://github.com/dotnet/docs/blob/c54d7f270b0d4166717462c6e5e91942d45471bd/docs/csharp/fundamentals/types/generics.md) | [Generic types and methods](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/types/generics?branch=pr-en-us-54462) |

<!-- PREVIEW-TABLE-END -->