### PR TITLE
Document null binding to non-nullable value types

### DIFF
--- a/docs/core/compatibility/extensions/10.0/configuration-null-values-preserved.md
+++ b/docs/core/compatibility/extensions/10.0/configuration-null-values-preserved.md
@@ -1,7 +1,7 @@
 ---
 title: "Breaking change: Null values preserved in configuration"
 description: "Learn about the breaking change in .NET 10 where configuration providers now preserve null values instead of treating them as missing values."
-ms.date: 08/07/2025
+ms.date: 06/17/2026
 ai-usage: ai-assisted
 ms.custom: https://github.com/dotnet/docs/issues/46890
 ---
@@ -98,6 +98,20 @@ Array1: 'null', 'null'
 Array2:
 ```
 
+### Non-nullable value types
+
+The binder now also binds `null` to non-nullable value-type properties (for example, `int`, `bool`, or an enum) by setting them to the type's default value (`default(T)`).
+
+Previously, with the JSON configuration provider, binding a `null` to such a property threw an `InvalidOperationException` similar to the following, because the provider had converted the `null` into an empty string and an empty string can't be converted to the target value type:
+
+```txt
+Failed to convert configuration value at 'NullConfiguration:DayOfWeekProperty' to type 'System.DayOfWeek'.
+```
+
+Starting in .NET 10, the same binding succeeds and the property is set to its default value. For example, a `null` bound to a `DayOfWeek` property results in `DayOfWeek.Sunday` (`0`), and a `null` bound to an `int` property results in `0`. No exception is thrown.
+
+This was already the behavior for providers that store a real `null` value, such as the in-memory provider, even before .NET 10, and it matches the configuration source generator. The change makes the JSON provider and the reflection-based binder consistent with that behavior.
+
 ## Type of breaking change
 
 This is a [behavioral change](../../categories.md#behavioral-change).
@@ -112,6 +126,7 @@ If you prefer the previous behavior, you can adjust your configuration according
 
 - When using the JSON configuration provider, replace `null` values with empty strings (`""`) to restore the original behavior, where empty strings are bound instead of `null`.
 - For other providers that support `null` values, remove the `null` entries from the configuration to replicate the earlier behavior, where missing values are ignored and existing property values remain unchanged.
+- If you previously relied on an exception being thrown when a `null` value was bound to a non-nullable value-type property, be aware that the binder now sets the property to its default value instead. To distinguish a missing or `null` value from a real value, make the property nullable (for example, `int?` or `DayOfWeek?`) and check for `null` after binding, or validate the configuration explicitly.
 
 ## Affected APIs
 

--- a/docs/core/compatibility/extensions/10.0/configuration-null-values-preserved.md
+++ b/docs/core/compatibility/extensions/10.0/configuration-null-values-preserved.md
@@ -104,7 +104,9 @@ The binder now also binds `null` to non-nullable value-type properties (for exam
 
 Previously, with the JSON configuration provider, binding a `null` to such a property threw an `InvalidOperationException` similar to the following, because the provider had converted the `null` into an empty string and an empty string can't be converted to the target value type:
 
-    Failed to convert configuration value at 'SomeSection:DayOfWeekProperty' to type 'System.DayOfWeek'.
+```output
+Failed to convert configuration value at 'SomeSection:DayOfWeekProperty' to type 'System.DayOfWeek'.
+```
 
 Starting in .NET 10, the same binding succeeds and the property is set to its default value. For example, a `null` bound to a `DayOfWeek` property results in `DayOfWeek.Sunday` (`0`), and a `null` bound to an `int` property results in `0`. No exception is thrown.
 

--- a/docs/core/compatibility/extensions/10.0/configuration-null-values-preserved.md
+++ b/docs/core/compatibility/extensions/10.0/configuration-null-values-preserved.md
@@ -104,13 +104,11 @@ The binder now also binds `null` to non-nullable value-type properties (for exam
 
 Previously, with the JSON configuration provider, binding a `null` to such a property threw an `InvalidOperationException` similar to the following, because the provider had converted the `null` into an empty string and an empty string can't be converted to the target value type:
 
-```txt
-Failed to convert configuration value at 'NullConfiguration:DayOfWeekProperty' to type 'System.DayOfWeek'.
-```
+    Failed to convert configuration value at 'SomeSection:DayOfWeekProperty' to type 'System.DayOfWeek'.
 
 Starting in .NET 10, the same binding succeeds and the property is set to its default value. For example, a `null` bound to a `DayOfWeek` property results in `DayOfWeek.Sunday` (`0`), and a `null` bound to an `int` property results in `0`. No exception is thrown.
 
-This was already the behavior for providers that store a real `null` value, such as the in-memory provider, even before .NET 10, and it matches the configuration source generator. The change makes the JSON provider and the reflection-based binder consistent with that behavior.
+Providers that store a real `null` value, such as the in-memory provider, already bound `null` to non-nullable value-type properties by setting the default value, even before .NET 10, and the configuration source generator also matches this behavior. The change makes the JSON provider and the reflection-based binder consistent with that behavior.
 
 ## Type of breaking change
 
@@ -126,7 +124,7 @@ If you prefer the previous behavior, you can adjust your configuration according
 
 - When using the JSON configuration provider, replace `null` values with empty strings (`""`) to restore the original behavior, where empty strings are bound instead of `null`.
 - For other providers that support `null` values, remove the `null` entries from the configuration to replicate the earlier behavior, where missing values are ignored and existing property values remain unchanged.
-- If you previously relied on an exception being thrown when a `null` value was bound to a non-nullable value-type property, be aware that the binder now sets the property to its default value instead. To distinguish a missing or `null` value from a real value, make the property nullable (for example, `int?` or `DayOfWeek?`) and check for `null` after binding, or validate the configuration explicitly.
+- If you previously relied on an exception when a `null` value was bound to a non-nullable value-type property, note that the binder now sets the property to its default value instead. To distinguish a missing or `null` value from a real value, make the property nullable (for example, `int?` or `DayOfWeek?`) and check for `null` after binding, or validate the configuration explicitly.
 
 ## Affected APIs
 


### PR DESCRIPTION
Addresses dotnet/runtime#129478.

The breaking change doc for "Null values preserved in configuration" did not mention how a present `null` now binds to non-nullable value-type properties. Before .NET 10 the JSON provider converted `null` to an empty string, so binding such a value to a non-nullable value type (for example, an `enum` or `int`) threw an `InvalidOperationException`. Starting in .NET 10 the real `null` is bound and the property is set to its default value (`default(T)`), with no exception.

This adds:

- A "Non-nullable value types" subsection under "New behavior" explaining the previous throw, the new default-value behavior, and that this already matched the in-memory provider and the configuration source generator.
- A "Recommended action" bullet for users who relied on the previous exception.

Also bumps `ms.date`.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/compatibility/extensions/10.0/configuration-null-values-preserved.md](https://github.com/dotnet/docs/blob/8f0e4c6532c385807dc20279853a1a5af103b35f/docs/core/compatibility/extensions/10.0/configuration-null-values-preserved.md) | [Null values preserved in configuration](https://review.learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/10.0/configuration-null-values-preserved?branch=pr-en-us-54464) |


<!-- PREVIEW-TABLE-END -->