### PR TITLE
Fix typo in C# Dev Kit reference

### DIFF
--- a/docs/csharp/tour-of-csharp/overview.md
+++ b/docs/csharp/tour-of-csharp/overview.md
@@ -118,7 +118,7 @@ Callers can iterate the collection by using an `await foreach` statement:
 
 :::code language="csharp" source="./snippets/shared/AsyncSamples.cs" id="UseReadSequence":::
 
-Finally, as part of the .NET ecosystem, you can use [Visual Studio](https://visualstudio.microsoft.com/vs), or [Visual Studio Code](https://code.visualstudio.com) with the [C# Dev Kit](https://code.visualstudio.com/docs/csharp/get-started). These tools provide rich understanding of C#, including the code you write. They also provide debugging capabilities.
+Finally, as part of the .NET ecosystem, you can use [Visual Studio](https://visualstudio.microsoft.com/vs) or [Visual Studio Code](https://code.visualstudio.com) with the [C# Dev Kit](https://code.visualstudio.com/docs/csharp/get-started). These tools provide a rich understanding of C#, including the code you write. They also provide debugging capabilities.
 
 > [!TIP]
 > To learn more about pattern matching, LINQ, and async programming, see the [functional techniques](../fundamentals/functional/pattern-matching.md), [LINQ overview](../linq/index.md), and [asynchronous programming](../asynchronous-programming/index.md) sections.

--- a/docs/csharp/tour-of-csharp/overview.md
+++ b/docs/csharp/tour-of-csharp/overview.md
@@ -118,7 +118,7 @@ Callers can iterate the collection by using an `await foreach` statement:
 
 :::code language="csharp" source="./snippets/shared/AsyncSamples.cs" id="UseReadSequence":::
 
-Finally, as part of the .NET ecosystem, you can use [Visual Studio](https://visualstudio.microsoft.com/vs), or [Visual Studio Code](https://code.visualstudio.com) with the [C# DevKit](https://code.visualstudio.com/docs/csharp/get-started). These tools provide rich understanding of C#, including the code you write. They also provide debugging capabilities.
+Finally, as part of the .NET ecosystem, you can use [Visual Studio](https://visualstudio.microsoft.com/vs), or [Visual Studio Code](https://code.visualstudio.com) with the [C# Dev Kit](https://code.visualstudio.com/docs/csharp/get-started). These tools provide rich understanding of C#, including the code you write. They also provide debugging capabilities.
 
 > [!TIP]
 > To learn more about pattern matching, LINQ, and async programming, see the [functional techniques](../fundamentals/functional/pattern-matching.md), [LINQ overview](../linq/index.md), and [asynchronous programming](../asynchronous-programming/index.md) sections.


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tour-of-csharp/overview.md](https://github.com/dotnet/docs/blob/ac02b48fb2c4a9e7b0bdc007bf52cbe0758709ee/docs/csharp/tour-of-csharp/overview.md) | [A tour of the C# language](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/overview?branch=pr-en-us-54469) |


<!-- PREVIEW-TABLE-END -->