### PR TITLE
Fix WorkWithIntegers typo

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md
@@ -99,7 +99,7 @@ void WorkWithIntegers()
 
 ## Explore order of operations
 
-1. Comment out the call to `WorkingWithIntegers()`. This change makes the output less cluttered as you work in this section:
+1. Comment out the call to `WorkWithIntegers()`. This change makes the output less cluttered as you work in this section:
 
    ```csharp
    //WorkWithIntegers();


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md](https://github.com/dotnet/docs/blob/46e5b2971e82692eb7c2f09f26acdf241bc06788/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md) | [docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tutorials/numbers-in-csharp?branch=pr-en-us-54470) |

<!-- PREVIEW-TABLE-END -->