### PR TITLE
Correct case for 'pi' in area calculation challenge

### DIFF
--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md
@@ -251,7 +251,7 @@ You saw the basic numeric types in C#: integers and doubles. There's one other t
 
 ***Challenge***
 
-Now that you know the different numeric types, write code that calculates the area of a circle whose radius is 2.50 centimeters. Remember that the area of a circle is the radius squared multiplied by PI. One hint: the runtime contains a constant for PI, <xref:System.Math.PI?displayProperty=nameWithType> that you can use for that value. <xref:System.Math.PI?displayProperty=nameWithType>, like all constants declared in the `System.Math` namespace, is a `double` value. For that reason, you should use `double` instead of `decimal` values for this challenge.
+Now that you know the different numeric types, write code that calculates the area of a circle whose radius is 2.50 centimeters. Remember that the area of a circle is the radius squared multiplied by pi. One hint: the runtime contains a constant for pi, <xref:System.Math.PI?displayProperty=nameWithType> that you can use for that value. <xref:System.Math.PI?displayProperty=nameWithType>, like all constants declared in the `System.Math` namespace, is a `double` value. For that reason, you should use `double` instead of `decimal` values for this challenge.
 
 You should get an answer between 19 and 20.
 

--- a/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md
+++ b/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md
@@ -251,7 +251,7 @@ You saw the basic numeric types in C#: integers and doubles. There's one other t
 
 ***Challenge***
 
-Now that you know the different numeric types, write code that calculates the area of a circle whose radius is 2.50 centimeters. Remember that the area of a circle is the radius squared multiplied by pi. One hint: the runtime contains a constant for pi, <xref:System.Math.PI?displayProperty=nameWithType> that you can use for that value. <xref:System.Math.PI?displayProperty=nameWithType>, like all constants declared in the `System.Math` namespace, is a `double` value. For that reason, you should use `double` instead of `decimal` values for this challenge.
+Now that you know the different numeric types, write code that calculates the area of a circle whose radius is 2.50 centimeters. Remember that the area of a circle is the radius squared multiplied by pi. One hint: the runtime contains a constant for pi: <xref:System.Math.PI?displayProperty=nameWithType>. Because `Math.PI` is a `double` value, you should use `double` instead of `decimal` values for this challenge.
 
 You should get an answer between 19 and 20.
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md](https://github.com/dotnet/docs/blob/cb2efa170a51446dd0bd62c94981f1cefcf9353e/docs/csharp/tour-of-csharp/tutorials/numbers-in-csharp.md) | [Tutorial: How to use integer and floating point numbers in C\#](https://review.learn.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/tutorials/numbers-in-csharp?branch=pr-en-us-54471) |


<!-- PREVIEW-TABLE-END -->