### PR TITLE
Fix formatting of F# syntax keywords in documentation

### DIFF
--- a/docs/fsharp/language-reference/verbose-syntax.md
+++ b/docs/fsharp/language-reference/verbose-syntax.md
@@ -38,7 +38,7 @@ compound expressions
 </tr>
 <tr><td>
 
-nested `let` bindings
+nested let bindings
 
 </td><td>
 
@@ -83,7 +83,7 @@ end
 </td>
 </tr>
 <tr><td>
-`for...do`
+for...do
 </td><td>
 
 ```fsharp
@@ -102,7 +102,7 @@ done
 </td>
 </tr>
 <tr><td>
-`while...do`
+while...do
 </td><td>
 
 ```fsharp
@@ -121,7 +121,7 @@ done
 </td>
 </tr>
 <tr><td>
-`for...in`
+for...in
 </td><td>
 
 ```fsharp
@@ -140,7 +140,7 @@ done
 </td>
 </tr>
 <tr><td>
-`do`
+do
 </td><td>
 
 ```fsharp


### PR DESCRIPTION

This change fixes a rendering issue that presumably happens only with the updated theme/font.

The source puts superfluous backticks to some of the entries, I removed them.

See current rendering: 
https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/verbose-syntax


<img width="233" height="1380" alt="Screenshot_2026-06-20-17-44-55-010_com brave browser-edit" src="https://github.com/user-attachments/assets/c08ad8fa-ce34-4873-9e82-3259439a0d9e" />


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/verbose-syntax.md](https://github.com/dotnet/docs/blob/ef5d06857ae8d6736345dda6f2df6894307fd3b5/docs/fsharp/language-reference/verbose-syntax.md) | [docs/fsharp/language-reference/verbose-syntax](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/verbose-syntax?branch=pr-en-us-54479) |

<!-- PREVIEW-TABLE-END -->