### PR TITLE
[Metrics] Update Prometheus snippets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 docs/_build/
 .idea/
+*.tmp
 *.swp
 rebuild.cmd
 

--- a/docs/core/diagnostics/snippets/Metrics/Program.cs
+++ b/docs/core/diagnostics/snippets/Metrics/Program.cs
@@ -40,7 +40,7 @@ class Program
     {
         using MeterProvider meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter("HatCo.HatStore")
-                .AddPrometheusHttpListener(options => options.UriPrefixes = new string[] { "http://localhost:9184/" })
+                .AddPrometheusHttpListener(options => options.Port = 9184)
                 .Build();
 
         var rand = Random.Shared;

--- a/docs/core/diagnostics/snippets/Metrics/metric-instr.csproj
+++ b/docs/core/diagnostics/snippets/Metrics/metric-instr.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.6.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.16.0-beta.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.9" />
   </ItemGroup>
 

--- a/docs/core/diagnostics/snippets/OTel-Prometheus-Grafana-Jaeger/csharp/OTel-Prometheus-Grafana-Jaeger.csproj
+++ b/docs/core/diagnostics/snippets/OTel-Prometheus-Grafana-Jaeger/csharp/OTel-Prometheus-Grafana-Jaeger.csproj
@@ -13,11 +13,11 @@
 
   <!--<Snippet_References>-->
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.16.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
   </ItemGroup>
   <!--</Snippet_References>-->

--- a/docs/fundamentals/networking/telemetry/snippets/metrics/HelloBuiltinMetrics.csproj
+++ b/docs/fundamentals/networking/telemetry/snippets/metrics/HelloBuiltinMetrics.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.7.0-rc.1" />
-    <PackageReference Include = "Microsoft.Extensions.Http" Version = "9.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.16.0-beta.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.0.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Update snippets using the OpenTelemetry Prometheus exporters to the latest version and remove obsolete `UriPrefixes` property usage.

`UriPrefixes` was made obsolete by https://github.com/open-telemetry/opentelemetry-dotnet/pull/7114 and was superseded by `Host` and `Port`. The property itself will be removed by https://github.com/open-telemetry/opentelemetry-dotnet/pull/7435.

As the default value of `Host` is `localhost`, only `Port` needs to be set (its default is `9464`).

Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/7268.
