### PR TITLE
Remove awkward compiling the code section

### DIFF
--- a/docs/standard/datetime/create-time-zones-with-adjustment-rules.md
+++ b/docs/standard/datetime/create-time-zones-with-adjustment-rules.md
@@ -74,15 +74,6 @@ The example can be tested using code such as the following:
 [!code-csharp[System.TimeZone2.CreateTimeZone#7](../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.TimeZone2.CreateTimeZone/cs/System.TimeZone2.CreateTimeZone.cs#7)]
 [!code-vb[System.TimeZone2.CreateTimeZone#7](../../../samples/snippets/visualbasic/VS_Snippets_CLR_System/system.TimeZone2.CreateTimeZone/vb/System.TimeZone2.CreateTimeZone.vb#7)]
 
-## Compiling the code
-
-This example requires:
-
-- That the following namespaces be imported:
-
-  [!code-csharp[System.TimeZone2.CreateTimeZone#6](../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.TimeZone2.CreateTimeZone/cs/System.TimeZone2.CreateTimeZone.cs#6)]
-  [!code-vb[System.TimeZone2.CreateTimeZone#6](../../../samples/snippets/visualbasic/VS_Snippets_CLR_System/system.TimeZone2.CreateTimeZone/vb/System.TimeZone2.CreateTimeZone.vb#6)]
-
 ## See also
 
 - [Dates, times, and time zones](index.md)


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/standard/datetime/create-time-zones-with-adjustment-rules.md](https://github.com/dotnet/docs/blob/d01439990b200e38d0d3b4bc5e60b34b96f87be8/docs/standard/datetime/create-time-zones-with-adjustment-rules.md) | [How to: Create time zones with adjustment rules](https://review.learn.microsoft.com/en-us/dotnet/standard/datetime/create-time-zones-with-adjustment-rules?branch=pr-en-us-54500) |

<!-- PREVIEW-TABLE-END -->