### PR TITLE
Fixed typo in fsharp/language-reference/arrays.md

### DIFF
--- a/docs/fsharp/language-reference/arrays.md
+++ b/docs/fsharp/language-reference/arrays.md
@@ -91,7 +91,7 @@ The output is as follows.
 
 ```console
 Length of empty array: 0
-Area of floats set to 5.0: [|5.0; 5.0; 5.0; 5.0; 5.0; 5.0; 5.0; 5.0; 5.0; 5.0|]
+Array of floats set to 5.0: [|5.0; 5.0; 5.0; 5.0; 5.0; 5.0; 5.0; 5.0; 5.0; 5.0|]
 Array of squares: [|0; 1; 4; 9; 16; 25; 36; 49; 64; 81|]
 ```
 


### PR DESCRIPTION
Fixes a typo `area` -> `array`

The typo was already fixed in ~/samples/snippets/fsharp/arrays/snippet91.fs but not in the output shown in this page

Screenshot of the page currently (typo on second-to-last line)
<img width="724" height="721" alt="image" src="https://github.com/user-attachments/assets/c49a4677-97e7-40be-a745-14146e9a1827" />


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/fsharp/language-reference/arrays.md](https://github.com/dotnet/docs/blob/281f036c7c3ed0c9dcef99cbadd0c062fca8a1ae/docs/fsharp/language-reference/arrays.md) | [Arrays (F#)](https://review.learn.microsoft.com/en-us/dotnet/fsharp/language-reference/arrays?branch=pr-en-us-54549) |

<!-- PREVIEW-TABLE-END -->