### PR TITLE
Correct dotnet clean command formatting

### DIFF
--- a/docs/core/sdk/file-based-apps.md
+++ b/docs/core/sdk/file-based-apps.md
@@ -420,9 +420,9 @@ Caching improves build performance but can cause confusion when:
 
 - Clear cache artifacts for file-based apps by using the following command:
 
-```dotnetcli
-dotnet clean file-based-apps
-```
+  ```dotnetcli
+  dotnet clean file-based-apps
+  ```
 
 - Force a clean build to bypass cache:
 


### PR DESCRIPTION
Fixed formatting for the dotnet clean command in documentation.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/sdk/file-based-apps.md](https://github.com/dotnet/docs/blob/c005185df1aed4cfdd3019eb5603ae14646f5876/docs/core/sdk/file-based-apps.md) | [docs/core/sdk/file-based-apps](https://review.learn.microsoft.com/en-us/dotnet/core/sdk/file-based-apps?branch=pr-en-us-54551) |

<!-- PREVIEW-TABLE-END -->