### PR TITLE
Fix ASP.NET workload typo in Docker app workflow

### DIFF
--- a/docs/architecture/microservices/docker-application-development-process/docker-app-development-workflow.md
+++ b/docs/architecture/microservices/docker-application-development-process/docker-app-development-workflow.md
@@ -48,7 +48,7 @@ To begin, make sure you have [Docker Desktop for Windows](https://docs.docker.co
 
 [Get started with Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/)
 
-In addition, you need Visual Studio 2022 or later with the **.ASP.NET and web development** workload installed, as shown in Figure 5-2.
+In addition, you need Visual Studio 2022 or later with the **ASP.NET and web development** workload installed, as shown in Figure 5-2.
 
 ![Screenshot of the .NET Core cross-platform development selection.](./media/docker-app-development-workflow/dotnet-core-cross-platform-development.png)
 


### PR DESCRIPTION
Fix ASP.NET workload typo

## Summary
Fixes a small typo by removing the extra dot before ASP.NET in the Visual Studio workload name.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/architecture/microservices/docker-application-development-process/docker-app-development-workflow.md](https://github.com/dotnet/docs/blob/e56b98c064c325a93b1032c0703c4f062dfc3066/docs/architecture/microservices/docker-application-development-process/docker-app-development-workflow.md) | [Development workflow for Docker apps](https://review.learn.microsoft.com/en-us/dotnet/architecture/microservices/docker-application-development-process/docker-app-development-workflow?branch=pr-en-us-54559) |

<!-- PREVIEW-TABLE-END -->