### PR TITLE
Document sizeof behavior on enum types

### DIFF
--- a/docs/csharp/language-reference/operators/sizeof.md
+++ b/docs/csharp/language-reference/operators/sizeof.md
@@ -10,7 +10,7 @@ helpviewer_keywords:
 ---
 # sizeof operator - determine the memory needs for a given type
 
-The `sizeof` operator returns the number of bytes occupied by a variable of a given type. In safe code, the argument to the `sizeof` operator must be the name of a built-in [unmanaged type](../builtin-types/unmanaged-types.md) whose size isn't platform-dependent, or an [enumeration type](../builtin-types/enum.md). The size of these types is a compile-time constant, so `sizeof` doesn't require an unsafe context.
+The `sizeof` operator returns the number of bytes occupied by a variable of a given type. In safe code, the argument to the `sizeof` operator must be the name of a built-in [unmanaged type](../builtin-types/unmanaged-types.md) whose size isn't platform-dependent, or an [enumeration type](../builtin-types/enum.md).
 
 [!INCLUDE[csharp-version-note](../includes/initial-version.md)]
 

--- a/docs/csharp/language-reference/operators/sizeof.md
+++ b/docs/csharp/language-reference/operators/sizeof.md
@@ -1,7 +1,7 @@
 ---
 title: "sizeof operator - determine the storage needs for a type"
 description: "Learn about the C# `sizeof` operator that returns the memory amount occupied by a variable of a given type."
-ms.date: 06/16/2026
+ms.date: 06/29/2026
 f1_keywords:
   - "sizeof_CSharpKeyword"
   - "sizeof"
@@ -41,6 +41,7 @@ In [unsafe](../keywords/unsafe.md) code, you can use `sizeof` on any non-`void` 
 
 - The size of a reference or pointer type is the size of a reference or pointer, not the size of the object it might refer to.
 - The size of a value type, unmanaged or not, is the size of such a value.
+- The size of an [enumeration type](../builtin-types/enum.md) is the size of its underlying integral type. This size is a compile-time constant. If the underlying type of an enum defined in a referenced assembly later changes, code that applied `sizeof` to that enum must be recompiled to observe the new size.
 - The size of a `ref struct` type is the size of the value. The size of every `ref` field is the size of a reference or pointer, not the size of the value it refers to.
 
 The following example demonstrates the usage of the `sizeof` operator:

--- a/docs/csharp/language-reference/operators/sizeof.md
+++ b/docs/csharp/language-reference/operators/sizeof.md
@@ -10,7 +10,7 @@ helpviewer_keywords:
 ---
 # sizeof operator - determine the memory needs for a given type
 
-The `sizeof` operator returns the number of bytes occupied by a variable of a given type. In safe code, the argument to the `sizeof` operator must be the name of a built-in [unmanaged type](../builtin-types/unmanaged-types.md) whose size isn't platform-dependent.
+The `sizeof` operator returns the number of bytes occupied by a variable of a given type. In safe code, the argument to the `sizeof` operator must be the name of a built-in [unmanaged type](../builtin-types/unmanaged-types.md) whose size isn't platform-dependent, or an [enumeration type](../builtin-types/enum.md). The size of these types is a compile-time constant, so `sizeof` doesn't require an unsafe context.
 
 [!INCLUDE[csharp-version-note](../includes/initial-version.md)]
 
@@ -41,7 +41,7 @@ In [unsafe](../keywords/unsafe.md) code, you can use `sizeof` on any non-`void` 
 
 - The size of a reference or pointer type is the size of a reference or pointer, not the size of the object it might refer to.
 - The size of a value type, unmanaged or not, is the size of such a value.
-- The size of an [enumeration type](../builtin-types/enum.md) is the size of its underlying integral type. This size is a compile-time constant. If the underlying type of an enum defined in a referenced assembly later changes, code that applied `sizeof` to that enum must be recompiled to observe the new size.
+- The size of an enumeration type is the size of its underlying integral type. This size is a compile-time constant. If the underlying type of an enum defined in a referenced assembly later changes, code that applied `sizeof` to that enum must be recompiled to observe the new size.
 - The size of a `ref struct` type is the size of the value. The size of every `ref` field is the size of a reference or pointer, not the size of the value it refers to.
 
 The following example demonstrates the usage of the `sizeof` operator:


### PR DESCRIPTION
Fixes #54499

   Adds a bullet to the `sizeof` operator reference noting that `sizeof` applied to an enum type returns the size of its underlying integral type, that the size is evaluated at compile time, and that changing the underlying type of an enum in a referenced assembly requires recompiling consuming code to observe the new size.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/sizeof.md](https://github.com/dotnet/docs/blob/ec3c1df8e9134643fa0a63c94248cf932eef4038/docs/csharp/language-reference/operators/sizeof.md) | [sizeof operator - determine the memory needs for a given type](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/sizeof?branch=pr-en-us-54560) |


<!-- PREVIEW-TABLE-END -->