### PR TITLE
Document sizeof behavior for enum types

### DIFF
--- a/docs/csharp/language-reference/operators/sizeof.md
+++ b/docs/csharp/language-reference/operators/sizeof.md
@@ -34,6 +34,8 @@ The expressions presented in the following table are evaluated at compile time t
 
 The size of the types in the preceding table is a compile-time constant.
 
+For an enum type, the result of the `sizeof` operator is the size of the enum's underlying integral type. The result is computed at compile time.
+
 In [unsafe](../keywords/unsafe.md) code, you can use `sizeof` on any non-`void` type, including types constructed from type parameters.
 
 > [!NOTE]


### PR DESCRIPTION
## Summary

Adds a short note explaining that `sizeof` on an enum returns the size of its underlying integral type and that the result is computed at compile time.

Fixes #54499.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/operators/sizeof.md](https://github.com/dotnet/docs/blob/d20d844d23198f9659a9c5f1bce67df08b8a39f1/docs/csharp/language-reference/operators/sizeof.md) | [sizeof operator - determine the memory needs for a given type](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/sizeof?branch=pr-en-us-54567) |

<!-- PREVIEW-TABLE-END -->