### PR TITLE
Clarify targets for primary constructor

### DIFF
--- a/docs/csharp/advanced-topics/reflection-and-attributes/index.md
+++ b/docs/csharp/advanced-topics/reflection-and-attributes/index.md
@@ -133,7 +133,7 @@ The following table shows the list of possible `target` values.
 | `module`     | Current assembly module                                                |
 | `field`      | Field in a class or a struct                                           |
 | `event`      | Event                                                                  |
-| `method`     | Method, constructor (including a primary constructor), or `get` and `set` property accessors              |
+| `method`     | Method, constructor (including a primary constructor), or `get` and `set` property accessors |
 | `param`      | Method parameters or `set` property accessor parameters                |
 | `property`   | Property                                                               |
 | `return`     | Return value of a method, property indexer, or `get` property accessor |

--- a/docs/csharp/advanced-topics/reflection-and-attributes/index.md
+++ b/docs/csharp/advanced-topics/reflection-and-attributes/index.md
@@ -133,7 +133,7 @@ The following table shows the list of possible `target` values.
 | `module`     | Current assembly module                                                |
 | `field`      | Field in a class or a struct                                           |
 | `event`      | Event                                                                  |
-| `method`     | Method, constructor or `get` and `set` property accessors              |
+| `method`     | Method, constructor (including a primary constructor), or `get` and `set` property accessors              |
 | `param`      | Method parameters or `set` property accessor parameters                |
 | `property`   | Property                                                               |
 | `return`     | Return value of a method, property indexer, or `get` property accessor |

--- a/docs/csharp/advanced-topics/reflection-and-attributes/index.md
+++ b/docs/csharp/advanced-topics/reflection-and-attributes/index.md
@@ -133,7 +133,7 @@ The following table shows the list of possible `target` values.
 | `module`     | Current assembly module                                                |
 | `field`      | Field in a class or a struct                                           |
 | `event`      | Event                                                                  |
-| `method`     | Method or `get` and `set` property accessors                           |
+| `method`     | Method, constructor or `get` and `set` property accessors              |
 | `param`      | Method parameters or `set` property accessor parameters                |
 | `property`   | Property                                                               |
 | `return`     | Return value of a method, property indexer, or `get` property accessor |

--- a/docs/csharp/language-reference/attributes/general.md
+++ b/docs/csharp/language-reference/attributes/general.md
@@ -94,6 +94,7 @@ The `AttributeUsage` attribute determines how a custom attribute class can be us
   - Module
   - Field
   - Event
+  - Constructor
   - Method
   - Parameter
   - Property

--- a/docs/csharp/language-reference/attributes/general.md
+++ b/docs/csharp/language-reference/attributes/general.md
@@ -135,7 +135,7 @@ In this case, `NonInheritedAttribute` isn't applied to `DClass` via inheritance.
 
 You can also use these keywords to specify where an attribute should be applied. For example, you can use the `field:` specifier to add an attribute to the backing field of an [automatically implemented property](../../programming-guide/classes-and-structs/properties.md#automatically-implemented-properties). Or you can use the `field:`, `property:` or `param:` specifier to apply an attribute to any of the elements generated from a positional record. For an example, see [Positional syntax for property definition](../builtin-types/record.md#positional-syntax-for-property-and-field-definition).
 
-When you apply an attribute to a type with a [primary constructor](../../programming-guide/classes-and-structs/instance-constructors.md#primary-constructors), the attribute is applied to the class. You can specify that it is applied to the constructor by choosing the `method` target, which matches the *Constructor* attribute target.
+When you apply an attribute to a type with a [primary constructor](../../programming-guide/classes-and-structs/instance-constructors.md#primary-constructors), the attribute is applied to the class. You can specify that it's applied to the constructor by choosing the `method` target, which matches the *Constructor* attribute target.
 
 ## `AsyncMethodBuilder` attribute
 

--- a/docs/csharp/language-reference/attributes/general.md
+++ b/docs/csharp/language-reference/attributes/general.md
@@ -135,6 +135,8 @@ In this case, `NonInheritedAttribute` isn't applied to `DClass` via inheritance.
 
 You can also use these keywords to specify where an attribute should be applied. For example, you can use the `field:` specifier to add an attribute to the backing field of an [automatically implemented property](../../programming-guide/classes-and-structs/properties.md#automatically-implemented-properties). Or you can use the `field:`, `property:` or `param:` specifier to apply an attribute to any of the elements generated from a positional record. For an example, see [Positional syntax for property definition](../builtin-types/record.md#positional-syntax-for-property-and-field-definition).
 
+When you apply an attribute to a type with a [primary constructor](../../programming-guide/classes-and-structs/instance-constructors.md#primary-constructors), the attribute is applied to the class. You can specify that it is applied to the constructor by choosing the `method` target, which matches the *Constructor* attribute target.
+
 ## `AsyncMethodBuilder` attribute
 
 You add the <xref:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute?displayProperty=nameWithType> attribute to a type that can be an async return type. The attribute specifies the type that builds the async method implementation when the specified type is returned from an async method. The `AsyncMethodBuilder` attribute can be applied to a type that:


### PR DESCRIPTION
Fixes #53684 

Clarify that `AttributeTargets` elment on an attribute must use `Constructor` for the target on a constructor. Note that the article on [instance constructors](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/instance-constructors#primary-constructors) already had that information.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/advanced-topics/reflection-and-attributes/index.md](https://github.com/dotnet/docs/blob/c7ab962e436e786b7d1662bb08e044d472a478e4/docs/csharp/advanced-topics/reflection-and-attributes/index.md) | [Attributes](https://review.learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/reflection-and-attributes/index?branch=pr-en-us-54629) |
| [docs/csharp/language-reference/attributes/general.md](https://github.com/dotnet/docs/blob/c7ab962e436e786b7d1662bb08e044d472a478e4/docs/csharp/language-reference/attributes/general.md) | [Miscellaneous attributes interpreted by the C# compiler](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/general?branch=pr-en-us-54629) |


<!-- PREVIEW-TABLE-END -->