### PR TITLE
Reorganize MTP features by functionality and document GitHub Actions report

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-features.md
+++ b/docs/core/testing/microsoft-testing-platform-features.md
@@ -31,7 +31,7 @@ Use the following path based on your goal:
 
 - Need to customize terminal output: [Terminal output](./microsoft-testing-platform-terminal-output.md) (built-in)
 - Need TRX or Azure DevOps reports: [Test reports](./microsoft-testing-platform-test-reports.md) (extension)
-- Need GitHub Actions-native output (log groups, annotations, job summary): [GitHub Actions report](https://www.nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport) (extension, experimental)
+- Need GitHub Actions-native output (log groups, annotations, and job summary): [GitHub Actions report](https://www.nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport) (extension, experimental)
 - Need coverage data: [Code coverage](./microsoft-testing-platform-code-coverage.md) (extension)
 - Need crash or hang diagnostics: [Crash and hang dumps](./microsoft-testing-platform-crash-hang-dumps.md) (extension)
 - Need to retry failed tests: [Retry](./microsoft-testing-platform-retry.md#retry) (extension)
@@ -58,7 +58,7 @@ Generate test report files (TRX, Azure DevOps).
 
 **[GitHub Actions report](https://www.nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport)** (experimental, introduced in MTP 2.3.0)
 
-Emit GitHub Actions-native workflow commands so test runs produce a first-class experience: per-assembly log groups, failure annotations (surfaced in the workflow **Annotations** tab and, when the source location resolves, on the pull request's **Files changed** diff), a markdown job summary appended to `GITHUB_STEP_SUMMARY`, and slow-test notices. The extension activates automatically when the `GITHUB_ACTIONS` environment variable is `true`, or elsewhere with the `--report-gh` switch. Each feature is individually toggleable through the `--report-gh-groups`, `--report-gh-annotations`, `--report-gh-step-summary`, `--report-gh-slow-test-notices`, and `--report-gh-slow-test-threshold` options. Register it manually with `builder.AddGitHubActionsProvider()`.
+Emit GitHub Actions-native workflow commands so test runs produce a first-class experience: per-assembly log groups, failure annotations (surfaced in the workflow **Annotations** tab and, when the source location resolves, on the pull request's **Files changed** diff), a Markdown job summary appended to `GITHUB_STEP_SUMMARY`, and slow-test notices. The extension activates automatically when the `GITHUB_ACTIONS` environment variable is `true`, or elsewhere with the `--report-gh` switch. Each feature can be turned on or off individually with the `--report-gh-groups`, `--report-gh-annotations`, `--report-gh-step-summary`, and `--report-gh-slow-test-notices` options, and the slow-test threshold is set with `--report-gh-slow-test-threshold`. Register it manually with `builder.AddGitHubActionsProvider()`.
 
 **[Code coverage](./microsoft-testing-platform-code-coverage.md)**
 

--- a/docs/core/testing/microsoft-testing-platform-features.md
+++ b/docs/core/testing/microsoft-testing-platform-features.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform features
 description: Learn about the various Microsoft.Testing.Platform features, both built-in and available as extensions.
 author: nohwnd
 ms.author: jajares
-ms.date: 02/25/2026
+ms.date: 07/03/2026
 ai-usage: ai-assisted
 ---
 
@@ -17,6 +17,8 @@ If you opt out of the auto-generated entry point by setting `<GenerateTestingPla
 
 Extensions that require a NuGet package are shipped with their own licensing model (some less permissive), be sure to refer to the license associated with the extensions you want to use.
 
+Some extensions are *experimental*: their APIs are annotated with the `TPEXP` diagnostic and might change in a future release, so you must acknowledge the diagnostic to use them. Experimental extensions are marked **(experimental)** in the following lists. For more information, see [Microsoft.Testing.Platform diagnostics](https://aka.ms/testingplatform/diagnostics).
+
 ## Start here
 
 Use the following path based on your goal:
@@ -29,6 +31,7 @@ Use the following path based on your goal:
 
 - Need to customize terminal output: [Terminal output](./microsoft-testing-platform-terminal-output.md) (built-in)
 - Need TRX or Azure DevOps reports: [Test reports](./microsoft-testing-platform-test-reports.md) (extension)
+- Need GitHub Actions-native output (log groups, annotations, job summary): [GitHub Actions report](https://www.nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport) (extension, experimental)
 - Need coverage data: [Code coverage](./microsoft-testing-platform-code-coverage.md) (extension)
 - Need crash or hang diagnostics: [Crash and hang dumps](./microsoft-testing-platform-crash-hang-dumps.md) (extension)
 - Need to retry failed tests: [Retry](./microsoft-testing-platform-retry.md#retry) (extension)
@@ -52,6 +55,10 @@ These features require installing NuGet packages.
 **[Test reports](./microsoft-testing-platform-test-reports.md)**
 
 Generate test report files (TRX, Azure DevOps).
+
+**[GitHub Actions report](https://www.nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport)** (experimental, introduced in MTP 2.3.0)
+
+Emit GitHub Actions-native workflow commands so test runs produce a first-class experience: per-assembly log groups, failure annotations (surfaced in the workflow **Annotations** tab and, when the source location resolves, on the pull request's **Files changed** diff), a markdown job summary appended to `GITHUB_STEP_SUMMARY`, and slow-test notices. The extension activates automatically when the `GITHUB_ACTIONS` environment variable is `true`, or elsewhere with the `--report-gh` switch. Each feature is individually toggleable through the `--report-gh-groups`, `--report-gh-annotations`, `--report-gh-step-summary`, `--report-gh-slow-test-notices`, and `--report-gh-slow-test-threshold` options. Register it manually with `builder.AddGitHubActionsProvider()`.
 
 **[Code coverage](./microsoft-testing-platform-code-coverage.md)**
 
@@ -81,28 +88,23 @@ Run tests that use Microsoft Fakes for stubs and shims.
 
 Telemetry collection. Learn how to opt out and what data is collected.
 
-## Logging integration
+**[Video recorder](https://www.nuget.org/packages/Microsoft.Testing.Extensions.VideoRecorder)** (experimental, introduced in MTP 2.3.0)
 
-> [!NOTE]
-> The Microsoft.Extensions.Logging bridge was introduced in MTP 2.3.0.
+Record the screen during a test run. It requires `ffmpeg` to be available on the machine and is enabled with the `--capture-video` option. Register it manually with `builder.AddVideoRecorderProvider()`.
 
-The [Microsoft.Testing.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Logging) package bridges Microsoft.Testing.Platform diagnostics to <xref:Microsoft.Extensions.Logging.ILogger>, so platform and extension logs flow through the same `Microsoft.Extensions.Logging` pipeline your application already uses.
+**[Packaged app deployment](https://www.nuget.org/packages/Microsoft.Testing.Extensions.PackagedApp)** (experimental, introduced in MTP 2.3.0)
 
-Manual registration:
+A reference extension that uses the experimental `ITestHostLauncher` extension point to deploy and launch a packaged-app test host. Register it manually with `builder.AddPackagedAppDeployment()`.
+
+## Microsoft.Extensions integration
+
+These extensions bridge Microsoft.Testing.Platform to the `Microsoft.Extensions.*` libraries your application already uses.
+
+**[Logging bridge](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Logging)** (experimental, introduced in MTP 2.3.0)
+
+The Microsoft.Testing.Extensions.Logging package bridges Microsoft.Testing.Platform diagnostics to <xref:Microsoft.Extensions.Logging.ILogger>, so platform and extension logs flow through the same `Microsoft.Extensions.Logging` pipeline your application already uses. Register it manually with the following call:
 
 ```csharp
 var builder = await TestApplication.CreateBuilderAsync(args);
 builder.AddMicrosoftExtensionsLogging(logging => logging.AddConsole());
 ```
-
-## Experimental extensions
-
-The following extensions are experimental. Their APIs are annotated with the `TPEXP` diagnostic and might change in a future release; using them requires acknowledging the experimental diagnostic. For more information, see [Microsoft.Testing.Platform diagnostics](https://aka.ms/testingplatform/diagnostics).
-
-**[Video recorder](https://www.nuget.org/packages/Microsoft.Testing.Extensions.VideoRecorder)** (experimental, introduced in MTP 2.3.0)
-
-Records the screen during a test run. It requires `ffmpeg` to be available on the machine and is enabled with the `--capture-video` option. Register it manually with `builder.AddVideoRecorderProvider()`.
-
-**[Packaged app deployment](https://www.nuget.org/packages/Microsoft.Testing.Extensions.PackagedApp)** (experimental, introduced in MTP 2.3.0)
-
-A reference extension that uses the experimental `ITestHostLauncher` extension point to deploy and launch a packaged-app test host. Register it manually with `builder.AddPackagedAppDeployment()`.

--- a/docs/core/testing/microsoft-testing-platform-features.md
+++ b/docs/core/testing/microsoft-testing-platform-features.md
@@ -17,7 +17,7 @@ If you opt out of the auto-generated entry point by setting `<GenerateTestingPla
 
 Extensions that require a NuGet package are shipped with their own licensing model (some less permissive), be sure to refer to the license associated with the extensions you want to use.
 
-Some extensions are *experimental*: their APIs are annotated with the `TPEXP` diagnostic and might change in a future release, so you must acknowledge the diagnostic to use them. Experimental extensions are marked **(experimental)** in the following lists. For more information, see [Microsoft.Testing.Platform diagnostics](https://aka.ms/testingplatform/diagnostics).
+Some extensions are *experimental*: their APIs are annotated with the `TPEXP` diagnostic and might change in a future release, so you must acknowledge the diagnostic to use them. Experimental extensions are marked **(experimental)** in the following lists.
 
 ## Start here
 


### PR DESCRIPTION
## Summary

Restructures the [Microsoft.Testing.Platform features](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-features) article so extensions are grouped by **functionality** rather than by lifecycle/experimental status, and documents the new GitHub Actions report extension.

### Changes to `docs/core/testing/microsoft-testing-platform-features.md`

- **Removed the `## Experimental extensions` category.** Its items (Video recorder, Packaged app deployment) now live under `## Extension features`, each keeping an inline **(experimental)** marker. Experimental status is a per-extension flag, not a grouping.
- **Removed the standalone `## Logging integration` category.** Replaced with a functional `## Microsoft.Extensions integration` section (short name) that holds the logging bridge.
- **Marked the logging bridge as experimental.** Confirmed `[Experimental("TPEXP")]` on `AddMicrosoftExtensionsLogging` in [microsoft/testfx](https://github.com/microsoft/testfx).
- **Added a shared intro note** explaining the `TPEXP` experimental diagnostic and the **(experimental)** convention (replaces the paragraph that previously lived only under "Experimental extensions").
- **Documented `Microsoft.Testing.Extensions.GitHubActionsReport`** (from microsoft/testfx#9541) under Extension features, next to Test reports: per-assembly log groups, failure annotations, `GITHUB_STEP_SUMMARY` job summary, slow-test notices, auto-activation via `GITHUB_ACTIONS`, the `--report-gh*` toggles, and `builder.AddGitHubActionsProvider()`. Added a matching "Choose by scenario" bullet.

### Content source

- Logging / video recorder / packaged app content: adapted from existing article text.
- GitHub Actions report section: adapted from the microsoft/testfx#9541 PR description and `PACKAGE.md`.

> [!NOTE]
> microsoft/testfx#9541 is still **open**. The GitHub Actions report entry (package name, options, and `builder.AddGitHubActionsProvider()` registration) is provisional and should be re-verified before/at merge of that PR.

No `toc.yml` changes were needed — these were on-page H2 categories, not separate TOC entries, and no other files referenced the removed section anchors.

ai-usage: ai-assisted

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-features.md](https://github.com/dotnet/docs/blob/d57b72721d7ecf8e52c143a0d3c1280e94d04e19/docs/core/testing/microsoft-testing-platform-features.md) | [Microsoft.Testing.Platform (MTP) features](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-features?branch=pr-en-us-54633) |


<!-- PREVIEW-TABLE-END -->