### PR TITLE
Remove outdated labels from breaking change issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-breaking-change.yml
+++ b/.github/ISSUE_TEMPLATE/02-breaking-change.yml
@@ -3,8 +3,6 @@ description: This template is for .NET product team members to report breaking c
 title: "[Breaking change]: "
 labels:
   - breaking-change
-  - Pri1
-  - doc-idea
 assignees:
  - gewarren
 body:


### PR DESCRIPTION
Removed 'Pri1' and 'doc-idea' labels from breaking change issue template. These labels don't seem to exist anymore.

(Note that this doesn't seem to be a problem when the issue template is used directly on GitHub, but it confused copilot.)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/ISSUE_TEMPLATE/02-breaking-change.yml](https://github.com/dotnet/docs/blob/13522fb76bbe6de3a09536b33a0a317c8a488551/.github/ISSUE_TEMPLATE/02-breaking-change.yml) | [.github/ISSUE_TEMPLATE/02-breaking-change](https://review.learn.microsoft.com/en-us/dotnet/.github/ISSUE_TEMPLATE/02-breaking-change?branch=pr-en-us-54637) |

<!-- PREVIEW-TABLE-END -->