### PR TITLE
Document DOTNET_CLI_ENABLEAOT environment variable

### DIFF
--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -327,9 +327,15 @@ Specifies whether performance details about the current CLI session are logged. 
 
 ### `DOTNET_CLI_ENABLEAOT`
 
-Specifies whether the .NET SDK uses its native (ahead-of-time compiled) CLI command-handling fast path. When enabled, common commands (such as command parsing, `dotnet --version`, and `dotnet --info`) are handled by a native entry point for faster startup, transparently falling back to the managed CLI for anything the fast path doesn't handle.
+Specifies whether the .NET SDK uses its native (ahead-of-time compiled) CLI command-handling fast path. When enabled, common commands (such as command-line parsing, `dotnet --version`, and `dotnet --info`) are handled by a native entry point for faster startup, transparently falling back to the managed CLI for anything the fast path doesn't handle.
 
-This fast path is enabled by default only on Windows. On macOS and Linux it's disabled by default because of a command-line parsing issue ([dotnet/command-line-api#2812](https://github.com/dotnet/command-line-api/issues/2812)): when the native CLI is loaded as a NativeAOT shared library, `Environment.GetCommandLineArgs()` returns an empty array on those platforms, which causes command parsing to throw. It will be enabled on macOS and Linux once that issue is resolved. To opt out and route every invocation to the managed CLI, set this variable to `false`, `0`, `no`, or `off`. To explicitly enable it (for example, on macOS or Linux), set it to `true`, `1`, `yes`, or `on`.
+Set this variable to control the fast path explicitly:
+
+- To enable it, set the variable to `true`, `1`, `yes`, or `on`.
+- To disable it and route every invocation to the managed CLI, set the variable to `false`, `0`, `no`, or `off`.
+
+> [!NOTE]
+> This fast path is enabled by default only on Windows. On macOS and Linux it's disabled by default because of a command-line parsing issue ([dotnet/command-line-api#2812](https://github.com/dotnet/command-line-api/issues/2812)): when the native CLI is loaded as a NativeAOT shared library, `Environment.GetCommandLineArgs()` returns an empty array on those platforms, which causes command-line parsing to throw. It will be enabled by default on macOS and Linux once that issue is resolved. In the meantime, you can opt in early on those platforms by setting the variable to a value that enables it.
 
 ### `DOTNET_GENERATE_ASPNET_CERTIFICATE`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -329,7 +329,7 @@ Specifies whether performance details about the current CLI session are logged. 
 
 Specifies whether the .NET SDK uses its native (ahead-of-time compiled) CLI command-handling fast path. When enabled, common commands (such as command parsing, `dotnet --version`, and `dotnet --info`) are handled by a native entry point for faster startup, transparently falling back to the managed CLI for anything the fast path doesn't handle.
 
-This fast path is enabled by default on all platforms except macOS. On macOS it's disabled by default because of a command-line parsing issue ([dotnet/command-line-api#2812](https://github.com/dotnet/command-line-api/issues/2812)) and will be enabled once that issue is resolved. To opt out and route every invocation to the managed CLI, set this variable to `false`, `0`, `no`, or `off`. To explicitly enable it (for example, on macOS), set it to `true`, `1`, `yes`, or `on`.
+This fast path is enabled by default only on Windows. On macOS and Linux it's disabled by default because of a command-line parsing issue ([dotnet/command-line-api#2812](https://github.com/dotnet/command-line-api/issues/2812)): when the native CLI is loaded as a NativeAOT shared library, `Environment.GetCommandLineArgs()` returns an empty array on those platforms, which causes command parsing to throw. It will be enabled on macOS and Linux once that issue is resolved. To opt out and route every invocation to the managed CLI, set this variable to `false`, `0`, `no`, or `off`. To explicitly enable it (for example, on macOS or Linux), set it to `true`, `1`, `yes`, or `on`.
 
 ### `DOTNET_GENERATE_ASPNET_CERTIFICATE`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -192,6 +192,7 @@ This section describes the following environment variables:
 - [`DOTNET_SERVICING`](#dotnet_servicing)
 - [`DOTNET_NOLOGO`](#dotnet_nologo)
 - [`DOTNET_CLI_PERF_LOG`](#dotnet_cli_perf_log)
+- [`DOTNET_CLI_ENABLEAOT`](#dotnet_cli_enableaot)
 - [`DOTNET_GENERATE_ASPNET_CERTIFICATE`](#dotnet_generate_aspnet_certificate)
 - [`DOTNET_ADD_GLOBAL_TOOLS_TO_PATH`](#dotnet_add_global_tools_to_path)
 - [`DOTNET_CLI_TELEMETRY_OPTOUT`](#dotnet_cli_telemetry_optout)
@@ -323,6 +324,12 @@ Specifies whether .NET welcome and telemetry messages are displayed on the first
 ### `DOTNET_CLI_PERF_LOG`
 
 Specifies whether performance details about the current CLI session are logged. Enabled when set to `1`, `true`, or `yes`. This is disabled by default.
+
+### `DOTNET_CLI_ENABLEAOT`
+
+Specifies whether the .NET SDK uses its native (ahead-of-time compiled) CLI command-handling fast path. When enabled, common commands (such as command parsing, `dotnet --version`, and `dotnet --info`) are handled by a native entry point for faster startup, transparently falling back to the managed CLI for anything the fast path doesn't handle.
+
+This fast path is enabled by default. To opt out and route every invocation to the managed CLI, set this variable to `false`, `0`, `no`, or `off`. To explicitly enable it, set it to `true`, `1`, `yes`, or `on`, or leave it unset.
 
 ### `DOTNET_GENERATE_ASPNET_CERTIFICATE`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -335,7 +335,7 @@ Set this variable to control the fast path explicitly:
 - To disable it and route every invocation to the managed CLI, set the variable to `false`, `0`, `no`, or `off`.
 
 > [!NOTE]
-> This fast path is enabled by default only on Windows. On macOS and Linux it's disabled by default because of a command-line parsing issue ([dotnet/command-line-api#2812](https://github.com/dotnet/command-line-api/issues/2812)): when the native CLI is loaded as a NativeAOT shared library, `Environment.GetCommandLineArgs()` returns an empty array on those platforms, which causes command-line parsing to throw. It will be enabled by default on macOS and Linux once that issue is resolved. In the meantime, you can opt in early on those platforms by setting the variable to a value that enables it.
+> Starting in .NET 11 Preview 7, this fast path is enabled by default (`true`) on Windows. On macOS and Linux it's disabled by default because of a command-line parsing issue ([dotnet/command-line-api#2812](https://github.com/dotnet/command-line-api/issues/2812)): when the native CLI is loaded as a NativeAOT shared library, `Environment.GetCommandLineArgs()` returns an empty array on those platforms, which causes command-line parsing to throw. It will be enabled by default on macOS and Linux once that issue is resolved. In the meantime, you can opt in early on those platforms by setting the variable to a value that enables it.
 
 ### `DOTNET_GENERATE_ASPNET_CERTIFICATE`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -329,7 +329,7 @@ Specifies whether performance details about the current CLI session are logged. 
 
 Specifies whether the .NET SDK uses its native (ahead-of-time compiled) CLI command-handling fast path. When enabled, common commands (such as command parsing, `dotnet --version`, and `dotnet --info`) are handled by a native entry point for faster startup, transparently falling back to the managed CLI for anything the fast path doesn't handle.
 
-This fast path is enabled by default. To opt out and route every invocation to the managed CLI, set this variable to `false`, `0`, `no`, or `off`. To explicitly enable it, set it to `true`, `1`, `yes`, or `on`, or leave it unset.
+This fast path is enabled by default on all platforms except macOS. On macOS it's disabled by default because of a command-line parsing issue ([dotnet/command-line-api#2812](https://github.com/dotnet/command-line-api/issues/2812)) and will be enabled once that issue is resolved. To opt out and route every invocation to the managed CLI, set this variable to `false`, `0`, `no`, or `off`. To explicitly enable it (for example, on macOS), set it to `true`, `1`, `yes`, or `on`.
 
 ### `DOTNET_GENERATE_ASPNET_CERTIFICATE`
 


### PR DESCRIPTION
Documents the `DOTNET_CLI_ENABLEAOT` environment variable in the .NET SDK and CLI environment variables reference.

Starting with the .NET SDK preview that resolves [dotnet/sdk#55078](https://github.com/dotnet/sdk/issues/55078), the SDK''s NativeAOT-compiled CLI command-handling fast path is enabled by default. This adds a reference entry describing its purpose, the enabled-by-default behavior, and the accepted opt-out values (`false`/`0`/`no`/`off`).

Fixes #54648

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-environment-variables.md](https://github.com/dotnet/docs/blob/e9a52b27579b0d412893fd1f5a23766f8e7ffb84/docs/core/tools/dotnet-environment-variables.md) | [docs/core/tools/dotnet-environment-variables](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables?branch=pr-en-us-54649) |


<!-- PREVIEW-TABLE-END -->