### PR TITLE
Adjust the instructions for the GHCP

### DIFF
--- a/docs/core/porting/github-copilot-app-modernization/how-to-custom-upgrade-instructions.md
+++ b/docs/core/porting/github-copilot-app-modernization/how-to-custom-upgrade-instructions.md
@@ -41,14 +41,13 @@ Beyond custom upgrade instructions, you can extend GitHub Copilot modernization 
 
 Follow these steps to generate and refine a new instruction file. These sections focus on replacing `Newtonsoft.Json` with `System.Text.Json` as an example.
 
-1. In the **Solution Explorer** window, right-click the **solution** > **Modernize**.
+### Initiate the upgrade
 
-   \-or-
+Use the following steps to start an upgrade:
 
-   Open the Copilot chat panel and type `@Modernize` to start a conversation with the agent.
+[!INCLUDE[github-copilot-how-to-initiate](./includes/how-to-initiate.md)]
 
-   > [!NOTE]
-   > These steps apply to Visual Studio. In Visual Studio Code and other environments, invoke the `modernize-dotnet` agent directly from the Copilot chat panel. In Visual Studio, the agent is named `Modernize`.
+### Create the instruction file
 
 1. In the chat, type: `I want to generate a custom upgrade instruction`.
 1. When asked, provide a scenario like `I want to replace Newtonsoft with System.Text.Json` to have Copilot create the file.
@@ -82,7 +81,7 @@ Use the following steps to start an upgrade:
 
 [!INCLUDE[github-copilot-how-to-initiate](./includes/how-to-initiate.md)]
 
-### Customize the upgrade
+### Test the upgrade instruction
 
 1. In chat, invoke the instruction with wording similar to the file name. For example, `replace Newtonsoft with System.Text.Json`.
 1. Confirm in the chat window that Copilot retrieved the instruction file:

--- a/docs/core/porting/github-copilot-app-modernization/how-to-custom-upgrade-instructions.md
+++ b/docs/core/porting/github-copilot-app-modernization/how-to-custom-upgrade-instructions.md
@@ -76,10 +76,13 @@ Follow these guidelines to write clear, effective custom upgrade instructions th
 
 Before running the instruction during an upgrade, validate it in isolation. Isolated testing helps you refine detection and verify code changes.
 
-1. In the **Solution Explorer** window, right-click the **solution** > **Modernize**.
+### Initiate the upgrade
 
-   > [!NOTE]
-   > These steps apply to Visual Studio. In Visual Studio Code and other environments, invoke the `modernize-dotnet` agent directly from the Copilot chat panel.
+Use the following steps to start an upgrade:
+
+[!INCLUDE[github-copilot-how-to-initiate](./includes/how-to-initiate.md)]
+
+### Customize the upgrade
 
 1. In chat, invoke the instruction with wording similar to the file name. For example, `replace Newtonsoft with System.Text.Json`.
 1. Confirm in the chat window that Copilot retrieved the instruction file:
@@ -106,12 +109,16 @@ If the test run doesn't produce the expected results, use these troubleshooting 
 
 Use these steps to incorporate an existing custom upgrade instruction into the assessment stage of an upgrade.
 
-1. In the **Solution Explorer** window, right-click the **solution** > **Modernize**.
+### Initiate the upgrade
 
-   > [!NOTE]
-   > These steps apply to Visual Studio. In Visual Studio Code and other environments, invoke the `modernize-dotnet` agent directly from the Copilot chat panel.
+To start the upgrade, follow these steps:
 
-1. In the chat, choose `Upgrade to a newer version of .NET`. Answer Copilot's questions until it begins the assessment.
+[!INCLUDE[github-copilot-how-to-initiate](./includes/how-to-initiate.md)]
+
+### Customize the upgrade
+
+Follow these steps during the assessment stage:
+
 1. Monitor the chat to see if Copilot automatically retrieves your custom instruction file during the assessment. Look for a message indicating it opened the Markdown instruction file.
 
    If Copilot doesn't automatically apply the custom instructions, explicitly request them. Use wording similar to the file name. For example, `use the custom instructions to replace Newtonsoft with System.Text.Json during the assessment`.

--- a/docs/core/porting/github-copilot-app-modernization/how-to-upgrade-with-github-copilot.md
+++ b/docs/core/porting/github-copilot-app-modernization/how-to-upgrade-with-github-copilot.md
@@ -21,7 +21,7 @@ Set up GitHub Copilot modernization in your development environment before start
 
 ## Initiate the upgrade
 
-To start an upgrade, use the `modernize-dotnet` agent in Copilot:
+To start the upgrade, follow these steps:
 
 [!INCLUDE[github-copilot-how-to-initiate](./includes/how-to-initiate.md)]
 

--- a/docs/core/porting/github-copilot-app-modernization/includes/how-to-initiate.md
+++ b/docs/core/porting/github-copilot-app-modernization/includes/how-to-initiate.md
@@ -1,16 +1,16 @@
 ---
 author: adegeo
 ms.author: adegeo
-ms.date: 03/04/2026
+ms.date: 07/08/2026
 ms.topic: include
 ---
 
 1. Open your .NET project or solution in your development environment.
 1. Start the agent by using one of these methods:
 
-   - **Visual Studio**: Right-click the solution or project in **Solution Explorer** and select **Modernize**. Or, open the **GitHub Copilot Chat** window and type `@Modernize`.
+   - **Visual Studio**: Right-click the solution or project in **Solution Explorer** and select **Modernize**. Alternatively, open the **GitHub Copilot Chat** window and type `@Modernize`.
    - **Visual Studio Code**: Open the **GitHub Copilot Chat** panel and type `@modernize-dotnet`.
-   - **GitHub Copilot CLI**: Type `@modernize-dotnet` followed by your upgrade or migration request.
-   - **GitHub.com**: Use the `modernize-dotnet` coding agent in your repository.
+   - **GitHub Copilot CLI**: Type `@upgrade` followed by your upgrade or migration request.
+   - **GitHub Copilot app**: In the **Agent** picker, select `Upgrade`.
 
 1. Tell the agent what to upgrade or migrate.

--- a/docs/core/porting/github-copilot-app-modernization/includes/how-to-initiate.md
+++ b/docs/core/porting/github-copilot-app-modernization/includes/how-to-initiate.md
@@ -5,7 +5,6 @@ ms.date: 07/08/2026
 ms.topic: include
 ---
 
-1. Open your .NET project or solution in your development environment.
 1. Start the agent by using one of these methods:
 
    - **Visual Studio**: Right-click the solution or project in **Solution Explorer** and select **Modernize**. Alternatively, open the **GitHub Copilot Chat** window and type `@Modernize`.

--- a/docs/core/porting/github-copilot-app-modernization/install.md
+++ b/docs/core/porting/github-copilot-app-modernization/install.md
@@ -53,7 +53,7 @@ Before you install, make sure you have:
 Install as a Visual Studio Code extension:
 
 1. In Visual Studio Code, open the **Extensions** view (<kbd>Ctrl+Shift+X</kbd>).
-1. Search for **GitHub Copilot upgrade**.
+1. Search for **GitHub Copilot upgrmodernizationade**.
 1. Select **Install**.
 
 The extension automatically acquires the .NET SDK if it's missing, registers tools, and adds the agent to Copilot Chat as `Upgrade`.
@@ -61,12 +61,12 @@ The extension automatically acquires the .NET SDK if it's missing, registers too
 ## Verify the installation
 
 1. Open a project in Visual Studio Code.
-1. Open the **GitHub Copilot Chat** window.
-1. Send `@upgrade` in chat and confirm the agent responds.
+1. Open the **GitHub Copilot Chat** view.
+1. Send `@modernize-dotnet` in chat and confirm the agent responds.
 
    -or-
 
-   Select the `Agent` dropdown and find the `Upgrade` entry.
+   Select the `Agent` picker and find the `modernize-dotnet` entry.
 
 ::: zone-end
 
@@ -127,7 +127,7 @@ Run `/agent` to confirm that `upgrade-agent:upgrade` appears in the agent list.
 
 -or-
 
-Select the **Default agent** dropdown and find the **Upgrade** entry.
+Select the **Default agent** picker and find the **Upgrade** entry.
 
 ::: zone-end
 

--- a/docs/core/porting/github-copilot-app-modernization/install.md
+++ b/docs/core/porting/github-copilot-app-modernization/install.md
@@ -53,10 +53,10 @@ Before you install, make sure you have:
 Install as a Visual Studio Code extension:
 
 1. In Visual Studio Code, open the **Extensions** view (<kbd>Ctrl+Shift+X</kbd>).
-1. Search for **GitHub Copilot upgrmodernizationade**.
+1. Search for **GitHub Copilot modernization**.
 1. Select **Install**.
 
-The extension automatically acquires the .NET SDK if it's missing, registers tools, and adds the agent to Copilot Chat as `Upgrade`.
+The extension automatically acquires the .NET SDK if it's missing, registers tools, and adds the agent to Copilot Chat as `modernize-dotnet`.
 
 ## Verify the installation
 
@@ -66,7 +66,7 @@ The extension automatically acquires the .NET SDK if it's missing, registers too
 
    -or-
 
-   Select the `Agent` picker and find the `modernize-dotnet` entry.
+   Select the **Agent** picker and find the `modernize-dotnet` entry.
 
 ::: zone-end
 

--- a/docs/core/porting/github-copilot-app-modernization/working-with-agent.md
+++ b/docs/core/porting/github-copilot-app-modernization/working-with-agent.md
@@ -30,9 +30,7 @@ public API surface."
 
 ## Start a conversation
 
-1. Open **Copilot Chat** in VS Code, Visual Studio, or Copilot CLI.
-1. Select the **GitHub Copilot modernization agent for .NET** from the agent picker, or type the correct agent mention for your environment: `@modernize-dotnet` in VS Code and Copilot CLI, or `@Modernize` in Visual Studio.
-1. Describe what you want to accomplish in natural language.
+[!INCLUDE [how-to-initiate](includes/how-to-initiate.md)]
 
 ### What to say
 


### PR DESCRIPTION
- Change VSCode back to the other agent.
- Adjust the start steps.
- Make the customize article less visual studio specific.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/porting/github-copilot-app-modernization/how-to-custom-upgrade-instructions.md](https://github.com/dotnet/docs/blob/0a5e9f6743b93f16a66742e71a674462ee0bf0bd/docs/core/porting/github-copilot-app-modernization/how-to-custom-upgrade-instructions.md) | [Apply custom upgrade instructions for .NET upgrades](https://review.learn.microsoft.com/en-us/dotnet/core/porting/github-copilot-app-modernization/how-to-custom-upgrade-instructions?branch=pr-en-us-54715) |
| [docs/core/porting/github-copilot-app-modernization/how-to-upgrade-with-github-copilot.md](https://github.com/dotnet/docs/blob/0a5e9f6743b93f16a66742e71a674462ee0bf0bd/docs/core/porting/github-copilot-app-modernization/how-to-upgrade-with-github-copilot.md) | [Upgrade a .NET app with GitHub Copilot modernization](https://review.learn.microsoft.com/en-us/dotnet/core/porting/github-copilot-app-modernization/how-to-upgrade-with-github-copilot?branch=pr-en-us-54715) |
| [docs/core/porting/github-copilot-app-modernization/install.md](https://github.com/dotnet/docs/blob/0a5e9f6743b93f16a66742e71a674462ee0bf0bd/docs/core/porting/github-copilot-app-modernization/install.md) | [Install GitHub Copilot modernization](https://review.learn.microsoft.com/en-us/dotnet/core/porting/github-copilot-app-modernization/install?branch=pr-en-us-54715) |
| [docs/core/porting/github-copilot-app-modernization/working-with-agent.md](https://github.com/dotnet/docs/blob/0a5e9f6743b93f16a66742e71a674462ee0bf0bd/docs/core/porting/github-copilot-app-modernization/working-with-agent.md) | [Work with GitHub Copilot modernization](https://review.learn.microsoft.com/en-us/dotnet/core/porting/github-copilot-app-modernization/working-with-agent?branch=pr-en-us-54715) |


<!-- PREVIEW-TABLE-END -->