### PR TITLE
Add language reference for extension indexers

### DIFF
--- a/docs/csharp/language-reference/keywords/extension.md
+++ b/docs/csharp/language-reference/keywords/extension.md
@@ -1,7 +1,7 @@
 ---
 title: "Extension member declarations"
 description: "Learn the syntax to declare extension members in C#. Extension members enable you to add functionality to types and interfaces in those instances where you don't have the source for the original type. Extensions are often paired with generic interfaces to implement a common set of functionality across all types that implement that interface."
-ms.date: 01/21/2026
+ms.date: 07/08/2026
 f1_keywords:
   - "extension_CSharpKeyword"
   - "extension"
@@ -12,7 +12,7 @@ Starting with C# 14, top-level, nongeneric `static class` declarations can use `
 
 [!INCLUDE[csharp-version-note](../includes/initial-version.md)]
 
-The `extension` block specifies the type and receiver for extension members. You can declare methods, properties, or operators inside the `extension` declaration. The following example declares a single extension block that defines an instance extension method, an instance property, and a static operator method.
+The `extension` block specifies the type and receiver for extension members. You can declare methods, properties, indexers, or operators inside the `extension` declaration. The following example declares a single extension block that defines an instance extension method, an instance property, and a static operator method.
 
 > [!NOTE]
 > All the examples in this article include XML comments for the members and the extension block. The node on the `extension` block describes the extended type and the receiver parameter. The C# compiler copies this node to the generated member for all members in the extension block. These examples demonstrate the preferred style for generating XML documentation for extension members.
@@ -66,9 +66,22 @@ The equivalent extension method declarations demonstrate how those type paramete
 
 :::code language="csharp" source="./snippets/ExtensionMethods.cs" id="GenericExtensionMethods":::
 
+## Extension indexers
+
+Starting with C# 15, you can declare *indexers* in an `extension` block. An extension indexer lets you index into a receiver as though the indexer were declared on the receiver type. Because indexers are always instance members, an extension block that declares an indexer must provide a named receiver parameter. Extension indexers support the same features as ordinary indexers, including `get` and `set` accessors, expression-bodied accessors, and ref-returning accessors.
+
+The following example declares a get-only indexer on `IEnumerable<int>` that returns the element at a specified position:
+
+:::code language="csharp" source="./snippets/extensions.cs" id="ExtensionIndexer":::
+
+You index into the receiver as though the indexer were a member of the receiver type:
+
+:::code language="csharp" source="./snippets/extensions.cs" id="UseExtensionIndexer":::
+
 ## See also
 
 - [Extensions feature specification](~/_csharplang/proposals/csharp-14.0/extensions.md)
+- [Extension indexers feature specification](~/_csharplang/proposals/extension-indexers.md)
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/keywords/extension.md
+++ b/docs/csharp/language-reference/keywords/extension.md
@@ -12,7 +12,7 @@ Starting with C# 14, top-level, nongeneric `static class` declarations can use `
 
 [!INCLUDE[csharp-version-note](../includes/initial-version.md)]
 
-The `extension` block specifies the type and receiver for extension members. You can declare methods, properties, indexers, or operators inside the `extension` declaration. The following example declares a single extension block that defines an instance extension method, an instance property, and a static operator method.
+The `extension` block specifies the type and receiver for extension members. You can declare methods, properties, indexers, and operators inside the `extension` declaration. The following example declares a single extension block that defines an instance extension method, an instance property, and a static operator method.
 
 > [!NOTE]
 > All the examples in this article include XML comments for the members and the extension block. The node on the `extension` block describes the extended type and the receiver parameter. The C# compiler copies this node to the generated member for all members in the extension block. These examples demonstrate the preferred style for generating XML documentation for extension members.

--- a/docs/csharp/language-reference/keywords/snippets/Extensions.cs
+++ b/docs/csharp/language-reference/keywords/snippets/Extensions.cs
@@ -218,7 +218,7 @@ public static class SequenceIndexer
         /// Gets the element at the specified position in the sequence.
         /// </summary>
         /// <param name="index">The zero-based position of the element to retrieve.</param>
-        /// <returns>The element at the specified position.</returns>
+        /// <value>The element at the specified position.</value>
         public int this[int index] => sequence.ElementAt(index);
     }
 }

--- a/docs/csharp/language-reference/keywords/snippets/Extensions.cs
+++ b/docs/csharp/language-reference/keywords/snippets/Extensions.cs
@@ -202,6 +202,28 @@ public static class GenericExtensions
 }
 // </GenericExtension>
 
+// <ExtensionIndexer>
+/// <summary>
+/// Contains an extension indexer for numeric sequences.
+/// </summary>
+public static class SequenceIndexer
+{
+    /// <summary>
+    /// Defines an indexer for integer sequences.
+    /// </summary>
+    /// <param name="sequence">The sequence used as a receiver.</param>
+    extension(IEnumerable<int> sequence)
+    {
+        /// <summary>
+        /// Gets the element at the specified position in the sequence.
+        /// </summary>
+        /// <param name="index">The zero-based position of the element to retrieve.</param>
+        /// <returns>The element at the specified position.</returns>
+        public int this[int index] => sequence.ElementAt(index);
+    }
+}
+// </ExtensionIndexer>
+
 public static class ExtensionExamples
 {
     public static void BasicExample()
@@ -219,5 +241,9 @@ public static class ExtensionExamples
         var newSequence = IEnumerable<int>.Generate(5, 10, 2);
         var identity = IEnumerable<int>.Identity;
         // </UseStaticExtensions>
+
+        // <UseExtensionIndexer>
+        int third = numbers[2];
+        // </UseExtensionIndexer>
     }
 }

--- a/docs/csharp/language-reference/xmldoc/examples.md
+++ b/docs/csharp/language-reference/xmldoc/examples.md
@@ -44,11 +44,11 @@ Add XML comments for `<summary>`, `<param>`, and, if necessary, `<typeparam>` to
 
 The C# compiler copies the XML nodes from the `extension` block to all members declared in that block.
 
-For an extension indexer, `cref` syntax can reference the indexer and its accessors through the `extension` block that declares it. The following examples show how to reference the `this[int]` indexer and its generated `get_Item` accessor from the preceding example:
+For an extension indexer, `cref` syntax can reference the indexer and its accessors through the `extension` block that declares it, and it can reference the implementation methods on the containing class. The following examples show how to reference the `this[int]` indexer and its generated `get_Item` accessor from the preceding example:
 
 ```csharp
 /// <seealso cref="Extensions.extension{TSequence}(System.Collections.Generic.IEnumerable{TSequence}).this[int]"/>
-/// <seealso cref="Extensions.get_Item"/>
+/// <seealso cref="Extensions.extension{TSequence}(System.Collections.Generic.IEnumerable{TSequence}).get_Item(int)"/>
 ```
 
 ## Math class example

--- a/docs/csharp/language-reference/xmldoc/examples.md
+++ b/docs/csharp/language-reference/xmldoc/examples.md
@@ -44,6 +44,13 @@ Add XML comments for `<summary>`, `<param>`, and, if necessary, `<typeparam>` to
 
 The C# compiler copies the XML nodes from the `extension` block to all members declared in that block.
 
+For an extension indexer, `cref` syntax can reference the indexer and its accessors through the `extension` block that declares it. The following examples show how to reference the `this[int]` indexer and its generated `get_Item` accessor from the preceding example:
+
+```csharp
+/// <seealso cref="Extensions.extension{TSequence}(System.Collections.Generic.IEnumerable{TSequence}).this[int]"/>
+/// <seealso cref="Extensions.get_Item"/>
+```
+
 ## Math class example
 
 The following code shows a realistic example of adding doc comments to a math library.

--- a/docs/csharp/language-reference/xmldoc/snippets/xmldoc/DocComments.cs
+++ b/docs/csharp/language-reference/xmldoc/snippets/xmldoc/DocComments.cs
@@ -362,6 +362,13 @@ public static class Extensions
                 yield return generator();
             }
         }
+
+        /// <summary>
+        /// Gets the element at the specified position in the sequence.
+        /// </summary>
+        /// <param name="index">The zero-based position of the element to retrieve.</param>
+        /// <returns>The element at the specified position.</returns>
+        public TSequence this[int index] => sequence.ElementAt(index);
     }
 }
 // </ExtensionExample>

--- a/docs/csharp/language-reference/xmldoc/snippets/xmldoc/DocComments.cs
+++ b/docs/csharp/language-reference/xmldoc/snippets/xmldoc/DocComments.cs
@@ -367,7 +367,7 @@ public static class Extensions
         /// Gets the element at the specified position in the sequence.
         /// </summary>
         /// <param name="index">The zero-based position of the element to retrieve.</param>
-        /// <returns>The element at the specified position.</returns>
+        /// <value>The element at the specified position.</value>
         public TSequence this[int index] => sequence.ElementAt(index);
     }
 }

--- a/docs/csharp/language-reference/xmldoc/snippets/xmldoc/xmldoc.csproj
+++ b/docs/csharp/language-reference/xmldoc/snippets/xmldoc/xmldoc.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DocumentationFile>xmldoc.xml</DocumentationFile>

--- a/docs/csharp/whats-new/csharp-15.md
+++ b/docs/csharp/whats-new/csharp-15.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in C# 15
 description: Get an overview of the new features in C# 15. C# 15 ships with .NET 11.
-ms.date: 06/16/2026
+ms.date: 07/08/2026
 ms.topic: whats-new
 ms.update-cycle: 365-days
 ai-usage: ai-assisted
@@ -13,6 +13,7 @@ C# 15 includes the following new features. Try these features by using the lates
 - [Collection expression arguments](#collection-expression-arguments)
 - [Union types](#union-types)
 - [Closed hierarchies](#closed-hierarchies)
+- [Extension indexers](#extension-indexers)
 - [Memory safety](#memory-safety)
 
 C# 15 is the latest C# preview release. .NET 11 preview versions support C# 15. For more information, see [C# language versioning](../language-reference/configure-language-version.md).
@@ -107,6 +108,31 @@ The `closed` modifier is a contextual keyword. A `closed` class is implicitly `a
 > ```
 
 For more information, see the [closed modifier](../language-reference/keywords/closed.md) and [Closed hierarchy patterns](../language-reference/operators/patterns.md#closed-hierarchy-patterns) in the language reference, or the [feature specification](~/_csharplang/proposals/closed-hierarchies.md). You can copy the examples in this section, including the `ClosedAttribute` workaround, from the [keywords snippets project](https://github.com/dotnet/docs/blob/main/docs/csharp/language-reference/keywords/snippets/shared) in the `dotnet/docs` GitHub repository.
+
+## Extension indexers
+
+Starting with C# 15, you can declare *indexers* in an `extension` block. Extension indexers let you index into a receiver as though the indexer were declared on the receiver type. Because indexers are always instance members, an extension block that declares an indexer must provide a named receiver parameter.
+
+The following example declares a get-only indexer on `IEnumerable<int>` that returns the element at a specified position:
+
+```csharp
+public static class SequenceIndexer
+{
+    extension(IEnumerable<int> sequence)
+    {
+        public int this[int index] => sequence.ElementAt(index);
+    }
+}
+```
+
+You index into the receiver as though the indexer were a member of the receiver type:
+
+```csharp
+IEnumerable<int> numbers = Enumerable.Range(1, 10);
+int third = numbers[2];
+```
+
+For more information, see [Extension declaration](../language-reference/keywords/extension.md#extension-indexers) in the language reference or the [feature specification](~/_csharplang/proposals/extension-indexers.md).
 
 ## Memory safety
 


### PR DESCRIPTION
Add the information for extension indexers into the language reference.

Fixes #54656

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/csharp/language-reference/keywords/extension.md](https://github.com/dotnet/docs/blob/ef26d5b4e182b00000bd5e7c99b24eeb077fd132/docs/csharp/language-reference/keywords/extension.md) | [Extension declaration (C# Reference)](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/extension?branch=pr-en-us-54716) |
| [docs/csharp/language-reference/xmldoc/examples.md](https://github.com/dotnet/docs/blob/ef26d5b4e182b00000bd5e7c99b24eeb077fd132/docs/csharp/language-reference/xmldoc/examples.md) | ["Example XML documentation comments"](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/examples?branch=pr-en-us-54716) |
| [docs/csharp/whats-new/csharp-15.md](https://github.com/dotnet/docs/blob/ef26d5b4e182b00000bd5e7c99b24eeb077fd132/docs/csharp/whats-new/csharp-15.md) | [What's new in C# 15](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-15?branch=pr-en-us-54716) |


<!-- PREVIEW-TABLE-END -->