### PR TITLE
Fold COREHOST_TRACE section into DOTNET_HOST_TRACE

### DIFF
--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -449,7 +449,7 @@ Specifies whether .NET SDK local tools search for tool manifest files in the roo
 Controls diagnostics tracing from the hosting components, such as `dotnet.exe`, `hostfxr`, and `hostpolicy`.
 
 > [!NOTE]
-> Prior to .NET 10, the `COREHOST_` prefix was used instead of `DOTNET_HOST_` (e.g., `COREHOST_TRACE`). The functionality and values remain identical.
+> Prior to .NET 10, the `COREHOST_` prefix was used instead of `DOTNET_HOST_` (for example, `COREHOST_TRACE`). The functionality and values remain identical.
 
 - `DOTNET_HOST_TRACE=[0/1]` - default is `0` - tracing disabled. If set to `1`, diagnostics tracing is enabled.
 - `DOTNET_HOST_TRACEFILE=<file path>` - has an effect only if tracing is enabled by setting `DOTNET_HOST_TRACE=1`. When set, the tracing information is written to the specified file; otherwise, the trace information is written to `stderr`.

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -454,6 +454,7 @@ Controls diagnostics tracing from the hosting components, such as `dotnet.exe`, 
 - `DOTNET_HOST_TRACE=[0/1]` - default is `0` - tracing disabled. If set to `1`, diagnostics tracing is enabled.
 - `DOTNET_HOST_TRACEFILE=<file path>` - has an effect only if tracing is enabled by setting `DOTNET_HOST_TRACE=1`. When set, the tracing information is written to the specified file; otherwise, the trace information is written to `stderr`.
 - `DOTNET_HOST_TRACE_VERBOSITY=[1/2/3/4]` - default is `4`. The setting is used only when tracing is enabled via `DOTNET_HOST_TRACE=1`.
+
   - `4` - all tracing information is written
   - `3` - only informational, warning, and error messages are written
   - `2` - only warning and error messages are written

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -449,7 +449,7 @@ Specifies whether .NET SDK local tools search for tool manifest files in the roo
 Controls diagnostics tracing from the hosting components, such as `dotnet.exe`, `hostfxr`, and `hostpolicy`.
 
 > [!NOTE]
-> These variables apply to **.NET 10 and later versions**. For older versions, replace the `DOTNET_HOST_` prefix with `COREHOST_` (e.g., `COREHOST_TRACE`). The functionality and values remain identical.
+> Prior to .NET 10, the `COREHOST_` prefix was used instead of `DOTNET_HOST_` (e.g., `COREHOST_TRACE`). The functionality and values remain identical.
 
 - `DOTNET_HOST_TRACE=[0/1]` - default is `0` - tracing disabled. If set to `1`, diagnostics tracing is enabled.
 - `DOTNET_HOST_TRACEFILE=<file path>` - has an effect only if tracing is enabled by setting `DOTNET_HOST_TRACE=1`. When set, the tracing information is written to the specified file; otherwise, the trace information is written to `stderr`.

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -217,7 +217,6 @@ This section describes the following environment variables:
 - [`DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK`](#dotnet_skip_workload_integrity_check)
 - [`DOTNET_TOOLS_ALLOW_MANIFEST_IN_ROOT`](#dotnet_tools_allow_manifest_in_root)
 - [`DOTNET_HOST_TRACE`](#dotnet_host_trace)
-- [`COREHOST_TRACE`](#corehost_trace)
 - [`SuppressNETCoreSdkPreviewMessage`](#suppressnetcoresdkpreviewmessage)
 - [Configure MSBuild in the .NET CLI](#configure-msbuild-in-the-net-cli)
 - [`DOTNET_NEW_PREFERRED_LANG`](#dotnet_new_preferred_lang)
@@ -447,31 +446,20 @@ Specifies whether .NET SDK local tools search for tool manifest files in the roo
 
 ### `DOTNET_HOST_TRACE`
 
-**This variable applies to .NET 10 and later versions.** For older versions, replace the `DOTNET_HOST_` prefix with [`COREHOST_`](#corehost_trace).
-
 Controls diagnostics tracing from the hosting components, such as `dotnet.exe`, `hostfxr`, and `hostpolicy`.
+
+> [!NOTE]
+> These variables apply to **.NET 10 and later versions**. For older versions, replace the `DOTNET_HOST_` prefix with `COREHOST_` (e.g., `COREHOST_TRACE`). The functionality and values remain identical.
 
 - `DOTNET_HOST_TRACE=[0/1]` - default is `0` - tracing disabled. If set to `1`, diagnostics tracing is enabled.
 - `DOTNET_HOST_TRACEFILE=<file path>` - has an effect only if tracing is enabled by setting `DOTNET_HOST_TRACE=1`. When set, the tracing information is written to the specified file; otherwise, the trace information is written to `stderr`.
 - `DOTNET_HOST_TRACE_VERBOSITY=[1/2/3/4]` - default is `4`. The setting is used only when tracing is enabled via `DOTNET_HOST_TRACE=1`.
-
   - `4` - all tracing information is written
   - `3` - only informational, warning, and error messages are written
   - `2` - only warning and error messages are written
   - `1` - only error messages are written
 
 The typical way to get detailed trace information about application startup is to set `DOTNET_HOST_TRACE=1` and `DOTNET_HOST_TRACEFILE=host_trace.txt` and then run the application. A new file `host_trace.txt` will be created in the current directory with the detailed information.
-
-### `COREHOST_TRACE`
-
-Controls diagnostics tracing from the hosting components, such as `dotnet.exe`, `hostfxr`, and `hostpolicy`.
-
-> [!NOTE]
-> Starting with .NET 10, use the [`DOTNET_HOST_TRACE`](#dotnet_host_trace) environment variables instead. The `COREHOST_TRACE` variables work the same as `DOTNET_HOST_TRACE` variables.
-
-- `COREHOST_TRACE` - see [`DOTNET_HOST_TRACE`](#dotnet_host_trace).
-- `COREHOST_TRACEFILE` - see [`DOTNET_HOST_TRACEFILE`](#dotnet_host_trace).
-- `COREHOST_TRACE_VERBOSITY` - see [`DOTNET_HOST_TRACE_VERBOSITY`](#dotnet_host_trace).
 
 ### `SuppressNETCoreSdkPreviewMessage`
 


### PR DESCRIPTION
## Summary

It's just a note, doesn't need a separate section.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-environment-variables.md](https://github.com/dotnet/docs/blob/20300287039139f717f46dc7429e1be60b5d138e/docs/core/tools/dotnet-environment-variables.md) | [docs/core/tools/dotnet-environment-variables](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables?branch=pr-en-us-54720) |


<!-- PREVIEW-TABLE-END -->