### PR TITLE
Add MTP version column to AzDO and terminal option tables

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-terminal-output.md
+++ b/docs/core/testing/microsoft-testing-platform-terminal-output.md
@@ -43,15 +43,15 @@ The progress bar is written based on the selected mode:
 
 ## Options
 
-| Option | Description |
-|---|---|
-| `--no-progress` | Disables reporting progress to screen. Deprecated in MTP 2.3.0 in favor of `--progress off`. |
-| `--progress` | Controls whether progress is shown. Valid values are `auto` (default), `on` (also accepts `true`, `enable`, `1`), and `off` (also accepts `false`, `disable`, `0`). Available in MTP starting with version 2.3.0. |
-| `--no-ansi` | Disables outputting ANSI escape characters to screen. |
-| `--ansi` | Controls whether ANSI escape characters are emitted. Valid values are `auto` (default), `on` (also accepts `true`, `enable`, `1`), and `off` (also accepts `false`, `disable`, `0`). Available in MTP starting with version 2.3.0. |
-| `--output` | Specifies the output verbosity when reporting tests. Valid values are `Normal` and `Detailed`. Default is `Normal`. |
-| `--show-stdout` | Determines when to show captured standard output of a test. Valid values are `All`, `Failed`, and `None`. Default is `All`. Available in MTP starting with version 2.2.1. |
-| `--show-stderr` | Determines when to show captured error output of a test. Valid values are `All`, `Failed`, and `None`. Default is `All`. Available in MTP starting with version 2.2.1. |
+| Option | MTP version | Description |
+|---|---|---|
+| `--no-progress` | — | Disables reporting progress to screen. Deprecated in MTP 2.3.0 in favor of `--progress off`. |
+| `--progress` | 2.3.0 | Controls whether progress is shown. Valid values are `auto` (default), `on` (also accepts `true`, `enable`, `1`), and `off` (also accepts `false`, `disable`, `0`). |
+| `--no-ansi` | — | Disables outputting ANSI escape characters to screen. |
+| `--ansi` | 2.3.0 | Controls whether ANSI escape characters are emitted. Valid values are `auto` (default), `on` (also accepts `true`, `enable`, `1`), and `off` (also accepts `false`, `disable`, `0`). |
+| `--output` | — | Specifies the output verbosity when reporting tests. Valid values are `Normal` and `Detailed`. Default is `Normal`. |
+| `--show-stdout` | 2.2.1 | Determines when to show captured standard output of a test. Valid values are `All`, `Failed`, and `None`. Default is `All`. |
+| `--show-stderr` | 2.2.1 | Determines when to show captured error output of a test. Valid values are `All`, `Failed`, and `None`. Default is `All`. |
 
 > [!NOTE]
 > Starting with MTP 2.3.0, when MTP detects that it runs inside an LLM or AI tool environment, it suppresses the startup banner and changes the default of `--show-stdout` and `--show-stderr` from `All` to `Failed` to reduce noise.

--- a/docs/core/testing/microsoft-testing-platform-terminal-output.md
+++ b/docs/core/testing/microsoft-testing-platform-terminal-output.md
@@ -54,4 +54,7 @@ The progress bar is written based on the selected mode:
 | `--show-stderr` | 2.2.1 | Determines when to show captured error output of a test. Valid values are `All`, `Failed`, and `None`. Default is `All`. |
 
 > [!NOTE]
+> A dash (—) in the **MTP version** column marks core options that aren't tied to a specific version because they've been available since the platform's initial releases.
+
+> [!NOTE]
 > Starting with MTP 2.3.0, when MTP detects that it runs inside an LLM or AI tool environment, it suppresses the startup banner and changes the default of `--show-stdout` and `--show-stderr` from `All` to `Failed` to reduce noise.

--- a/docs/core/testing/microsoft-testing-platform-test-reports.md
+++ b/docs/core/testing/microsoft-testing-platform-test-reports.md
@@ -159,4 +159,7 @@ builder.TestHost.AddAzureDevOpsProvider();
 | `--publish-azdo-test-results` | 2.3.0 | Publishes test results live to the Azure DevOps **Tests** tab. |
 | `--publish-azdo-run-name` | 2.3.0 | Sets a custom Azure DevOps test run name for live test-result publishing. Requires `--publish-azdo-test-results`. |
 
+> [!NOTE]
+> The **MTP version** column lists the MTP release in which each option first became available in a stable build. The Azure DevOps extension itself became stable in MTP 1.9.0 with `--report-azdo` and `--report-azdo-severity`; the remaining options were added in MTP 2.3.0.
+
 The extension automatically detects that it is running in continuous integration (CI) environment by checking the `TF_BUILD` environment variable.

--- a/docs/core/testing/microsoft-testing-platform-test-reports.md
+++ b/docs/core/testing/microsoft-testing-platform-test-reports.md
@@ -143,23 +143,20 @@ builder.TestHost.AddAzureDevOpsProvider();
 
 ### Options
 
-| Option | Description |
-|---|---|
-| `--report-azdo` | Enables the Azure DevOps report generator. Errors and warnings are written to the output in a format that Azure DevOps understands. |
-| `--report-azdo-severity` | Severity to use for reported events. Valid values are `error` (default) and `warning`. |
-| `--report-azdo-flaky-history` | Queries Azure DevOps test result history for the past N days (1-90) and annotates reported failures with flakiness context. Requires `--report-azdo`. |
-| `--report-azdo-demote-known-flaky` | Demotes failures that are flaky enough in the Azure DevOps history window (default threshold is 25%) from errors to warnings. Requires `--report-azdo` and `--report-azdo-flaky-history`. |
-| `--report-azdo-quarantine-file` | Path to a text file that lists quarantined test fully qualified names or glob patterns. Matching failures are reported as warnings. Requires `--report-azdo`. |
-| `--report-azdo-summary` | Writes a Markdown job summary at the end of the test run and uploads it through `##vso[task.uploadsummary]`. An optional file path argument overrides the default location (`{testResultsDir}/azdo-summary-{tfm}.md`). Requires `--report-azdo`. |
-| `--report-azdo-stackframe-filter` | Adds regex patterns, matched against the fully qualified type prefix of each stack frame, that are skipped when the extension locates the user's call site to annotate. The option is repeatable, up to 16 patterns, and each pattern is compiled with a 500-ms match timeout. These patterns are additive to the extension's built-in MSTest assertion-implementation prefixes. Requires `--report-azdo`. |
-| `--report-azdo-upload-artifacts` | Uploads test result files and/or adds build tags to Azure DevOps. Valid values are `off` (default), `tags-only`, `files`, and `all`. |
-| `--report-azdo-upload-artifact-include` | Includes files in the Azure DevOps artifact upload using glob patterns relative to the test results directory. Defaults to `**/*`. Requires `--report-azdo-upload-artifacts` to be a value other than `off`. |
-| `--report-azdo-upload-artifact-exclude` | Excludes files from the Azure DevOps artifact upload using glob patterns relative to the test results directory. Requires `--report-azdo-upload-artifacts` to be a value other than `off`. |
-| `--report-azdo-upload-artifact-name` | Overrides the Azure DevOps artifact container name. Defaults to `TestResults_{assemblyName}_{tfm}`. Requires `--report-azdo-upload-artifacts` to be a value other than `off`. |
-| `--publish-azdo-test-results` | Publishes test results live to the Azure DevOps **Tests** tab. |
-| `--publish-azdo-run-name` | Sets a custom Azure DevOps test run name for live test-result publishing. Requires `--publish-azdo-test-results`. |
-
-> [!NOTE]
-> The Azure DevOps extension became stable in MTP 1.9.0 (`--report-azdo` and `--report-azdo-severity`). All other options in the table — `--report-azdo-flaky-history`, `--report-azdo-demote-known-flaky`, `--report-azdo-quarantine-file`, `--report-azdo-summary`, `--report-azdo-stackframe-filter`, `--report-azdo-upload-artifacts`, `--report-azdo-upload-artifact-include`, `--report-azdo-upload-artifact-exclude`, `--report-azdo-upload-artifact-name`, `--publish-azdo-test-results`, and `--publish-azdo-run-name` — are available in MTP starting with version 2.3.0.
+| Option | MTP version | Description |
+|---|---|---|
+| `--report-azdo` | 1.9.0 | Enables the Azure DevOps report generator. Errors and warnings are written to the output in a format that Azure DevOps understands. |
+| `--report-azdo-severity` | 1.9.0 | Severity to use for reported events. Valid values are `error` (default) and `warning`. |
+| `--report-azdo-flaky-history` | 2.3.0 | Queries Azure DevOps test result history for the past N days (1-90) and annotates reported failures with flakiness context. Requires `--report-azdo`. |
+| `--report-azdo-demote-known-flaky` | 2.3.0 | Demotes failures that are flaky enough in the Azure DevOps history window (default threshold is 25%) from errors to warnings. Requires `--report-azdo` and `--report-azdo-flaky-history`. |
+| `--report-azdo-quarantine-file` | 2.3.0 | Path to a text file that lists quarantined test fully qualified names or glob patterns. Matching failures are reported as warnings. Requires `--report-azdo`. |
+| `--report-azdo-summary` | 2.3.0 | Writes a Markdown job summary at the end of the test run and uploads it through `##vso[task.uploadsummary]`. An optional file path argument overrides the default location (`{testResultsDir}/azdo-summary-{tfm}.md`). Requires `--report-azdo`. |
+| `--report-azdo-stackframe-filter` | 2.3.0 | Adds regex patterns, matched against the fully qualified type prefix of each stack frame, that are skipped when the extension locates the user's call site to annotate. The option is repeatable, up to 16 patterns, and each pattern is compiled with a 500-ms match timeout. These patterns are additive to the extension's built-in MSTest assertion-implementation prefixes. Requires `--report-azdo`. |
+| `--report-azdo-upload-artifacts` | 2.3.0 | Uploads test result files and/or adds build tags to Azure DevOps. Valid values are `off` (default), `tags-only`, `files`, and `all`. |
+| `--report-azdo-upload-artifact-include` | 2.3.0 | Includes files in the Azure DevOps artifact upload using glob patterns relative to the test results directory. Defaults to `**/*`. Requires `--report-azdo-upload-artifacts` to be a value other than `off`. |
+| `--report-azdo-upload-artifact-exclude` | 2.3.0 | Excludes files from the Azure DevOps artifact upload using glob patterns relative to the test results directory. Requires `--report-azdo-upload-artifacts` to be a value other than `off`. |
+| `--report-azdo-upload-artifact-name` | 2.3.0 | Overrides the Azure DevOps artifact container name. Defaults to `TestResults_{assemblyName}_{tfm}`. Requires `--report-azdo-upload-artifacts` to be a value other than `off`. |
+| `--publish-azdo-test-results` | 2.3.0 | Publishes test results live to the Azure DevOps **Tests** tab. |
+| `--publish-azdo-run-name` | 2.3.0 | Sets a custom Azure DevOps test run name for live test-result publishing. Requires `--publish-azdo-test-results`. |
 
 The extension automatically detects that it is running in continuous integration (CI) environment by checking the `TF_BUILD` environment variable.


### PR DESCRIPTION
## Summary

Moves per-option availability version information out of prose notes and into a dedicated **MTP version** column in two MTP option tables, making it easier to answer "which version can I use this in?" per option and reducing the risk of version notes drifting out of sync.

## Changes

**`microsoft-testing-platform-test-reports.md` (Azure DevOps reports)**
- Added an `MTP version` column to the Azure DevOps options table (`1.9.0` for `--report-azdo`/`--report-azdo-severity`, `2.3.0` for the rest).
- Removed the long note that enumerated every option by name to state its version.

**`microsoft-testing-platform-terminal-output.md`**
- Added an `MTP version` column to the terminal output options table.
- Moved inline "Available in MTP starting with version..." text out of descriptions: `--progress`/`--ansi` → `2.3.0`, `--show-stdout`/`--show-stderr` → `2.2.1`.
- Original, never-version-gated options (`--no-progress`, `--no-ansi`, `--output`) use `—` rather than an invented version.
- Kept the `--no-progress` deprecation detail (deprecated-in is distinct from added-in) and the LLM/AI-environment behavioral note.

## Not changed (intentionally)

The HTML, JUnit, CTRF, and TRX option tables were left as-is: their options all share a single version (or aren't per-option version-gated), so a column of identical values would add noise rather than clarity. A single note above those tables remains the lighter option.

## Notes

- No content was invented; version values were carried over from the existing notes/descriptions.
- ai-usage: ai-assisted (both files already carry this).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-terminal-output.md](https://github.com/dotnet/docs/blob/7343b9c983df0de06d9fa2fd61327ae7d9c32428/docs/core/testing/microsoft-testing-platform-terminal-output.md) | [Terminal output](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-terminal-output?branch=pr-en-us-54721) |
| [docs/core/testing/microsoft-testing-platform-test-reports.md](https://github.com/dotnet/docs/blob/7343b9c983df0de06d9fa2fd61327ae7d9c32428/docs/core/testing/microsoft-testing-platform-test-reports.md) | [Microsoft.Testing.Platform (MTP) test reports](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-test-reports?branch=pr-en-us-54721) |


<!-- PREVIEW-TABLE-END -->