### PR TITLE
Reorganize GitHub Actions report as a test-report extension

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-features.md
+++ b/docs/core/testing/microsoft-testing-platform-features.md
@@ -31,7 +31,7 @@ Use the following path based on your goal:
 
 - Need to customize terminal output: [Terminal output](./microsoft-testing-platform-terminal-output.md) (built-in)
 - Need TRX or Azure DevOps reports: [Test reports](./microsoft-testing-platform-test-reports.md) (extension)
-- Need GitHub Actions-native output (log groups, annotations, and job summary): [GitHub Actions report](https://www.nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport) (extension, experimental)
+- Need GitHub Actions-native output (log groups, annotations, and job summary): [GitHub Actions report](./microsoft-testing-platform-test-reports.md#github-actions-reports) (extension, experimental)
 - Need coverage data: [Code coverage](./microsoft-testing-platform-code-coverage.md) (extension)
 - Need crash or hang diagnostics: [Crash and hang dumps](./microsoft-testing-platform-crash-hang-dumps.md) (extension)
 - Need to retry failed tests: [Retry](./microsoft-testing-platform-retry.md#retry) (extension)
@@ -54,11 +54,7 @@ These features require installing NuGet packages.
 
 **[Test reports](./microsoft-testing-platform-test-reports.md)**
 
-Generate test report files (TRX, Azure DevOps).
-
-**[GitHub Actions report](https://www.nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport)** (experimental, introduced in MTP 2.3.0)
-
-Emit GitHub Actions-native workflow commands so test runs produce a first-class experience: per-assembly log groups, failure annotations (surfaced in the workflow **Annotations** tab and, when the source location resolves, on the pull request's **Files changed** diff), a Markdown job summary appended to `GITHUB_STEP_SUMMARY`, and slow-test notices. The extension activates automatically when the `GITHUB_ACTIONS` environment variable is `true`, or elsewhere with the `--report-gh` switch. Each feature can be turned on or off individually with the `--report-gh-groups`, `--report-gh-annotations`, `--report-gh-step-summary`, and `--report-gh-slow-test-notices` options, and the slow-test threshold is set with `--report-gh-slow-test-threshold`. Register it manually with `builder.AddGitHubActionsProvider()`.
+Generate test report files (TRX, HTML, JUnit, CTRF, Azure DevOps, GitHub Actions).
 
 **[Code coverage](./microsoft-testing-platform-code-coverage.md)**
 

--- a/docs/core/testing/microsoft-testing-platform-test-reports.md
+++ b/docs/core/testing/microsoft-testing-platform-test-reports.md
@@ -166,7 +166,7 @@ The extension automatically detects that it is running in continuous integration
 
 ## GitHub Actions reports
 
-The GitHub Actions report emits GitHub Actions-native workflow commands so test runs produce a first-class experience on the runner: per-assembly log groups, failure and skip annotations (surfaced in the workflow **Annotations** tab and, when the source location resolves, on the pull request's **Files changed** diff), a Markdown job summary appended to the file referenced by `GITHUB_STEP_SUMMARY`, and slow-test notices. This extension requires the [Microsoft.Testing.Extensions.GitHubActionsReport](https://nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport) NuGet package.
+The GitHub Actions report emits GitHub Actions-native workflow commands so test runs produce a first-class experience on the runner: per-assembly log groups, failed and skipped test annotations (surfaced in the workflow **Annotations** tab and, when the source location resolves, on the pull request's **Files changed** diff), a Markdown job summary appended to the file referenced by `GITHUB_STEP_SUMMARY`, and slow-test notices.
 
 The extension activates only when the run is on GitHub Actions (the `GITHUB_ACTIONS` environment variable is `true`) and the `--report-gh` switch is set; otherwise it does nothing. When active, each feature is enabled by default and can be turned off individually with its `--report-gh-*` option.
 

--- a/docs/core/testing/microsoft-testing-platform-test-reports.md
+++ b/docs/core/testing/microsoft-testing-platform-test-reports.md
@@ -1,6 +1,6 @@
 ---
 title: Microsoft.Testing.Platform (MTP) test reports
-description: Learn about the MTP extensions that create test report files (TRX, HTML, JUnit, CTRF, Azure DevOps).
+description: Learn about the MTP extensions that create test report files (TRX, HTML, JUnit, CTRF, Azure DevOps, GitHub Actions).
 author: evangelink
 ms.author: amauryleve
 ms.date: 06/16/2026
@@ -163,3 +163,30 @@ builder.TestHost.AddAzureDevOpsProvider();
 > The Azure DevOps extension became stable in MTP 1.9.0 (`--report-azdo` and `--report-azdo-severity`). All other options in the table — `--report-azdo-flaky-history`, `--report-azdo-demote-known-flaky`, `--report-azdo-quarantine-file`, `--report-azdo-summary`, `--report-azdo-stackframe-filter`, `--report-azdo-upload-artifacts`, `--report-azdo-upload-artifact-include`, `--report-azdo-upload-artifact-exclude`, `--report-azdo-upload-artifact-name`, `--publish-azdo-test-results`, and `--publish-azdo-run-name` — are available in MTP starting with version 2.3.0.
 
 The extension automatically detects that it is running in continuous integration (CI) environment by checking the `TF_BUILD` environment variable.
+
+## GitHub Actions reports
+
+The GitHub Actions report emits GitHub Actions-native workflow commands so test runs produce a first-class experience on the runner: per-assembly log groups, failure and skip annotations (surfaced in the workflow **Annotations** tab and, when the source location resolves, on the pull request's **Files changed** diff), a Markdown job summary appended to the file referenced by `GITHUB_STEP_SUMMARY`, and slow-test notices. This extension requires the [Microsoft.Testing.Extensions.GitHubActionsReport](https://nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport) NuGet package.
+
+The extension activates only when the run is on GitHub Actions (the `GITHUB_ACTIONS` environment variable is `true`) and the `--report-gh` switch is set; otherwise it does nothing. When active, each feature is enabled by default and can be turned off individually with its `--report-gh-*` option.
+
+> [!NOTE]
+> Available in MTP starting with version 2.3.0. This extension is experimental, and its options and output format might change in a future version.
+
+### Manual registration
+
+```csharp
+var builder = await TestApplication.CreateBuilderAsync(args);
+builder.AddGitHubActionsProvider();
+```
+
+### Options
+
+| Option | MTP version | Description |
+|---|---|---|
+| `--report-gh` | 2.3.0 | Enables the GitHub Actions report generator so test runs emit workflow commands. Requires the run to be on GitHub Actions. |
+| `--report-gh-groups` | 2.3.0 | Enables or disables per-assembly log groups. Valid values are `on` (default) and `off`. Requires `--report-gh`. |
+| `--report-gh-annotations` | 2.3.0 | Enables or disables annotations for failed and skipped tests. Valid values are `on` (default) and `off`. Requires `--report-gh`. |
+| `--report-gh-step-summary` | 2.3.0 | Enables or disables writing a Markdown job summary to the file referenced by `GITHUB_STEP_SUMMARY`. Valid values are `on` (default) and `off`. Requires `--report-gh`. |
+| `--report-gh-slow-test-notices` | 2.3.0 | Enables or disables slow-test notices. Valid values are `on` (default) and `off`. Requires `--report-gh`. |
+| `--report-gh-slow-test-threshold` | 2.3.0 | The duration a test can run before a slow-test notice is emitted. Accepts a bare number of seconds or a value with a unit suffix such as `90s`, `2m`, or `1.5h`. The default is `60s`. Requires `--report-gh`. |

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -307,7 +307,7 @@ items:
                     displayName: MTP,terminal,test reporter,ANSI,progress
                   - name: Test reports
                     href: ../../core/testing/microsoft-testing-platform-test-reports.md
-                    displayName: MTP,TRX,test report,Azure DevOps
+                    displayName: MTP,TRX,test report,Azure DevOps,GitHub Actions
                   - name: Code coverage
                     href: ../../core/testing/microsoft-testing-platform-code-coverage.md
                     displayName: MTP,code coverage,coverage


### PR DESCRIPTION
## Summary

Treats the **GitHub Actions report** MTP extension as a test-report extension alongside Azure DevOps, TRX, HTML, JUnit, and CTRF, instead of a top-level extension feature. The inline prose in `microsoft-testing-platform-features.md` is replaced with a dedicated `## GitHub Actions reports` section in `microsoft-testing-platform-test-reports.md` that mirrors the Azure DevOps section structure.

## Changes

**`docs/core/testing/microsoft-testing-platform-test-reports.md`**
- New `## GitHub Actions reports` section (after Azure DevOps): intro + activation behavior, NuGet requirement line, experimental `> [!NOTE]`, `### Manual registration` (`builder.AddGitHubActionsProvider();`), and a `### Options` table using the three-column `| Option | MTP version | Description |` format (all options `2.3.0`).
- `description:` frontmatter now enumerates GitHub Actions.

**`docs/core/testing/microsoft-testing-platform-features.md`**
- Removed the top-level `**[GitHub Actions report]…**` entry from `## Extension features`.
- Repointed the `## Choose by scenario` bullet to `./microsoft-testing-platform-test-reports.md#github-actions-reports` (was the raw NuGet URL).
- Updated the **Test reports** blurb to `TRX, HTML, JUnit, CTRF, Azure DevOps, GitHub Actions`.

**`docs/navigate/devops-testing/toc.yml`**
- Added `GitHub Actions` to the Test reports `displayName` for searchability (no new node; content lives in an existing file).

## Content source breakdown

All option names, values, defaults, versions, and the registration call were **verified against the extension source** in [microsoft/testfx](https://github.com/microsoft/testfx) (`Microsoft.Testing.Extensions.GitHubActionsReport`): `GitHubActionsCommandLineOptions.cs`, `GitHubActionsFeature.cs`, `GitHubActionsExtensions.cs`, the package `PACKAGE.md`, and `HelpInfoAllExtensionsTests.cs` (help text). Descriptions were adapted from that source and the original features.md prose.

## ⚠️ Accuracy correction — please confirm

The **previous** features.md prose said the extension "activates automatically when the `GITHUB_ACTIONS` environment variable is `true`, or elsewhere with the `--report-gh` switch." The authoritative source contradicts this:

> `GitHubActionsFeature.cs`: *"The extension activates only when running on GitHub Actions (`GITHUB_ACTIONS=true`) **and** the `--report-gh` master switch is set."* (Same statement in `PACKAGE.md`.)

The new section states that **both** `GITHUB_ACTIONS=true` **and** `--report-gh` are required. Flagging this in case the runner-side auto-injection of `--report-gh` (via MSTest.Sdk / MSBuild props) was the intent of the original "automatic" wording — an expert should confirm the final phrasing.

ai-usage: ai-assisted (kept on both files).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-features.md](https://github.com/dotnet/docs/blob/f4ca8acbd52c3e05303d4a303d223ddb8b0c04d4/docs/core/testing/microsoft-testing-platform-features.md) | [Microsoft.Testing.Platform (MTP) features](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-features?branch=pr-en-us-54722) |
| [docs/core/testing/microsoft-testing-platform-test-reports.md](https://github.com/dotnet/docs/blob/f4ca8acbd52c3e05303d4a303d223ddb8b0c04d4/docs/core/testing/microsoft-testing-platform-test-reports.md) | [Microsoft.Testing.Platform (MTP) test reports](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-test-reports?branch=pr-en-us-54722) |
| [docs/navigate/devops-testing/toc.yml](https://github.com/dotnet/docs/blob/f4ca8acbd52c3e05303d4a303d223ddb8b0c04d4/docs/navigate/devops-testing/toc.yml) | [docs/navigate/devops-testing/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/devops-testing/toc?branch=pr-en-us-54722) |


<!-- PREVIEW-TABLE-END -->