### PR TITLE
Add generic MTP capability pages for diagnostics, test host deployment, and Microsoft.Extensions integration

### DIFF
--- a/.openpublishing.redirection.core.json
+++ b/.openpublishing.redirection.core.json
@@ -1926,11 +1926,6 @@
       "redirect_url": "/dotnet/core/testing/microsoft-testing-platform-crash-hang-dumps"
     },
     {
-      "source_path_from_root": "/docs/core/testing/microsoft-testing-platform-diagnostics.md",
-      "redirect_url": "/dotnet/core/testing/microsoft-testing-platform-crash-hang-dumps",
-      "redirect_document_id": false
-    },
-    {
       "source_path_from_root": "/docs/core/testing/unit-testing-platform-exit-codes.md",
       "redirect_url": "/dotnet/core/testing/microsoft-testing-platform-troubleshooting#exit-codes"
     },

--- a/docs/core/testing/microsoft-testing-platform-diagnostics.md
+++ b/docs/core/testing/microsoft-testing-platform-diagnostics.md
@@ -1,0 +1,42 @@
+---
+title: Microsoft.Testing.Platform (MTP) diagnostics
+description: Learn about the MTP extensions that capture evidence, such as screen recordings, to help you diagnose a test run.
+author: evangelink
+ms.author: amauryleve
+ms.date: 07/09/2026
+ai-usage: ai-assisted
+---
+
+# Diagnostics
+
+These extensions capture evidence during a test run so you can diagnose failures after the fact. Each extension requires an additional NuGet package, as described in each section.
+
+> [!TIP]
+> When using [Microsoft.Testing.Platform.MSBuild](https://www.nuget.org/packages/Microsoft.Testing.Platform.MSBuild) (included transitively by MSTest, NUnit, and xUnit runners), these extensions are auto-registered when you install their NuGet packages — no code changes needed. The manual registration specified in this article is only required if you disabled the auto-generated entry point by setting `<GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>`.
+
+For process-level diagnostics, see the related [Crash and hang dumps](microsoft-testing-platform-crash-hang-dumps.md) extensions, which collect process dump files when the test host crashes or hangs.
+
+## Video recorder
+
+The video recorder records the screen while your tests run and attaches the captured videos to the test session as artifacts. Recording is opt-in per run and driven by an external `ffmpeg` process, which must be available on the `PATH` or set through an explicit path. This extension requires the [Microsoft.Testing.Extensions.VideoRecorder](https://nuget.org/packages/Microsoft.Testing.Extensions.VideoRecorder) NuGet package.
+
+> [!NOTE]
+> Available in MTP starting with version 2.3.0. This extension is experimental, and its options and output format might change in a future version.
+
+### Manual registration
+
+```csharp
+var builder = await TestApplication.CreateBuilderAsync(args);
+builder.AddVideoRecorderProvider();
+```
+
+### Options
+
+| Option | MTP version | Description |
+|---|---|---|
+| `--capture-video` | 2.3.0 | Enables screen recording. The optional value controls retention: `on-failure` (default) keeps footage only for failing tests, and `always` keeps footage for every test. |
+| `--capture-video-source` | 2.3.0 | Sets the capture source. Valid values are `screen` (default) and `window`. Requires `--capture-video`. |
+| `--capture-video-granularity` | 2.3.0 | Sets whether the recorder produces one video per test or one chaptered video for the whole run. Valid values are `test` (default) and `session`. Requires `--capture-video`. |
+| `--capture-video-max-duration` | 2.3.0 | Bounds disk usage on long runs by keeping approximately the last N seconds of footage. The value is a positive integer number of seconds. Requires `--capture-video`. |
+| `--capture-video-chapters` | 2.3.0 | Sets whether chapter bookmarks are added to the per-session video. Valid values are `on` (default) and `off`. Requires `--capture-video`. |
+| `--capture-video-args` | 2.3.0 | Passes extra arguments to the underlying recorder (`ffmpeg`). Requires `--capture-video`. |

--- a/docs/core/testing/microsoft-testing-platform-extensions-integration.md
+++ b/docs/core/testing/microsoft-testing-platform-extensions-integration.md
@@ -1,0 +1,31 @@
+---
+title: Microsoft.Extensions integration
+description: Learn about the MTP extensions that bridge Microsoft.Testing.Platform to the Microsoft.Extensions.* libraries your application already uses.
+author: evangelink
+ms.author: amauryleve
+ms.date: 07/09/2026
+ai-usage: ai-assisted
+---
+
+# Microsoft.Extensions integration
+
+These extensions bridge Microsoft.Testing.Platform (MTP) to the `Microsoft.Extensions.*` libraries your application already uses, so platform and extension components flow through the same infrastructure as the rest of your code. Each extension requires an additional NuGet package, as described in each section.
+
+> [!TIP]
+> When using [Microsoft.Testing.Platform.MSBuild](https://www.nuget.org/packages/Microsoft.Testing.Platform.MSBuild) (included transitively by MSTest, NUnit, and xUnit runners), these extensions are auto-registered when you install their NuGet packages — no code changes needed. The manual registration specified in this article is only required if you disabled the auto-generated entry point by setting `<GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>`.
+
+## Logging bridge
+
+The logging bridge forwards Microsoft.Testing.Platform diagnostic logs to <xref:Microsoft.Extensions.Logging.ILogger>, so platform and extension logs flow through the same `Microsoft.Extensions.Logging` pipeline your application already uses. You can reuse an existing logging stack — Console, Debug, Serilog, Application Insights, OpenTelemetry, or a custom `ILoggerProvider` — without writing a custom MTP logger provider. This extension requires the [Microsoft.Testing.Extensions.Logging](https://nuget.org/packages/Microsoft.Testing.Extensions.Logging) NuGet package.
+
+> [!NOTE]
+> Available in MTP starting with version 2.3.0. This extension is experimental, and its options and output format might change in a future version.
+
+The bridge forwards each message only when the platform's diagnostic logging is enabled. When the platform's effective log level is `None` (the default, unless you pass [`--diagnostic`](microsoft-testing-platform-cli-options.md)), the configuration delegate isn't invoked and no logger factory is created. Per-category filters that you set in the `ILoggingBuilder` can narrow the platform's effective diagnostic level, but they can't widen it.
+
+### Manual registration
+
+```csharp
+var builder = await TestApplication.CreateBuilderAsync(args);
+builder.AddMicrosoftExtensionsLogging(logging => logging.AddConsole());
+```

--- a/docs/core/testing/microsoft-testing-platform-extensions-integration.md
+++ b/docs/core/testing/microsoft-testing-platform-extensions-integration.md
@@ -1,5 +1,5 @@
 ---
-title: Microsoft.Extensions integration
+title: Microsoft.Testing.Platform (MTP) Microsoft.Extensions integration
 description: Learn about the MTP extensions that bridge Microsoft.Testing.Platform to the Microsoft.Extensions.* libraries your application already uses.
 author: evangelink
 ms.author: amauryleve

--- a/docs/core/testing/microsoft-testing-platform-features.md
+++ b/docs/core/testing/microsoft-testing-platform-features.md
@@ -34,6 +34,9 @@ Use the following path based on your goal:
 - Need GitHub Actions-native output (log groups, annotations, and job summary): [GitHub Actions report](https://www.nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport) (extension, experimental)
 - Need coverage data: [Code coverage](./microsoft-testing-platform-code-coverage.md) (extension)
 - Need crash or hang diagnostics: [Crash and hang dumps](./microsoft-testing-platform-crash-hang-dumps.md) (extension)
+- Need to record the screen during a run: [Diagnostics](./microsoft-testing-platform-diagnostics.md) (extension, experimental)
+- Need to deploy and launch a packaged-app test host: [Test host deployment](./microsoft-testing-platform-test-host-deployment.md) (extension, experimental)
+- Need to route platform logs through `Microsoft.Extensions.Logging`: [Microsoft.Extensions integration](./microsoft-testing-platform-extensions-integration.md) (extension, experimental)
 - Need to retry failed tests: [Retry](./microsoft-testing-platform-retry.md#retry) (extension)
 - Need hot reload support: [Hot Reload](./microsoft-testing-platform-hot-reload.md) (extension)
 - Need Microsoft Fakes support: [Microsoft Fakes](./microsoft-testing-platform-fakes.md) (extension)
@@ -88,23 +91,14 @@ Run tests that use Microsoft Fakes for stubs and shims.
 
 Telemetry collection. Learn how to opt out and what data is collected.
 
-**[Video recorder](https://www.nuget.org/packages/Microsoft.Testing.Extensions.VideoRecorder)** (experimental, introduced in MTP 2.3.0)
+**[Diagnostics](./microsoft-testing-platform-diagnostics.md)** (experimental, introduced in MTP 2.3.0)
 
-Record the screen during a test run. It requires `ffmpeg` to be available on the machine and is enabled with the `--capture-video` option. Register it manually with `builder.AddVideoRecorderProvider()`.
+Capture evidence to diagnose a run, such as recording the screen with the video recorder.
 
-**[Packaged app deployment](https://www.nuget.org/packages/Microsoft.Testing.Extensions.PackagedApp)** (experimental, introduced in MTP 2.3.0)
+**[Test host deployment](./microsoft-testing-platform-test-host-deployment.md)** (experimental, introduced in MTP 2.3.0)
 
-A reference extension that uses the experimental `ITestHostLauncher` extension point to deploy and launch a packaged-app test host. Register it manually with `builder.AddPackagedAppDeployment()`.
+Control how and where the test host is deployed and launched, such as deploying and launching a packaged-app test host.
 
-## Microsoft.Extensions integration
+**[Microsoft.Extensions integration](./microsoft-testing-platform-extensions-integration.md)** (experimental, introduced in MTP 2.3.0)
 
-These extensions bridge Microsoft.Testing.Platform to the `Microsoft.Extensions.*` libraries your application already uses.
-
-**[Logging bridge](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Logging)** (experimental, introduced in MTP 2.3.0)
-
-The Microsoft.Testing.Extensions.Logging package bridges Microsoft.Testing.Platform diagnostics to <xref:Microsoft.Extensions.Logging.ILogger>, so platform and extension logs flow through the same `Microsoft.Extensions.Logging` pipeline your application already uses. Register it manually with the following call:
-
-```csharp
-var builder = await TestApplication.CreateBuilderAsync(args);
-builder.AddMicrosoftExtensionsLogging(logging => logging.AddConsole());
-```
+Bridge platform and extension diagnostics into the `Microsoft.Extensions.*` libraries your application already uses, such as forwarding logs through the `Microsoft.Extensions.Logging` pipeline.

--- a/docs/core/testing/microsoft-testing-platform-test-host-deployment.md
+++ b/docs/core/testing/microsoft-testing-platform-test-host-deployment.md
@@ -1,0 +1,29 @@
+---
+title: Microsoft.Testing.Platform (MTP) test host deployment
+description: Learn about the MTP extensions that control how and where the test host is deployed and launched.
+author: evangelink
+ms.author: amauryleve
+ms.date: 07/09/2026
+ai-usage: ai-assisted
+---
+
+# Test host deployment
+
+These extensions control how and where the test host is deployed and launched. They build on the experimental `ITestHostLauncher` extension point, which lets an extension take over the deployment and launch of the test host instead of starting it in place. Each extension requires an additional NuGet package, as described in each section.
+
+> [!TIP]
+> When using [Microsoft.Testing.Platform.MSBuild](https://www.nuget.org/packages/Microsoft.Testing.Platform.MSBuild) (included transitively by MSTest, NUnit, and xUnit runners), these extensions are auto-registered when you install their NuGet packages — no code changes needed. The manual registration specified in this article is only required if you disabled the auto-generated entry point by setting `<GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>`.
+
+## Packaged app deployment
+
+The packaged app deployment extension deploys a packaged Windows test host (UWP or packaged WinUI) into an isolated directory and launches it from there, rather than starting the test host in place. It's the reference consumer of the experimental `ITestHostLauncher` extension point for packaged Windows apps. This extension requires the [Microsoft.Testing.Extensions.PackagedApp](https://nuget.org/packages/Microsoft.Testing.Extensions.PackagedApp) NuGet package.
+
+> [!NOTE]
+> Available in MTP starting with version 2.3.0. This extension is experimental, and its options and output format might change in a future version.
+
+### Manual registration
+
+```csharp
+var builder = await TestApplication.CreateBuilderAsync(args);
+builder.AddPackagedAppDeployment();
+```

--- a/docs/navigate/devops-testing/toc.yml
+++ b/docs/navigate/devops-testing/toc.yml
@@ -314,6 +314,15 @@ items:
                   - name: Crash and hang dumps
                     href: ../../core/testing/microsoft-testing-platform-crash-hang-dumps.md
                     displayName: MTP,crash dump,hang dump,diagnostics
+                  - name: Diagnostics
+                    href: ../../core/testing/microsoft-testing-platform-diagnostics.md
+                    displayName: MTP,diagnostics,video recorder,screen recording,capture video
+                  - name: Test host deployment
+                    href: ../../core/testing/microsoft-testing-platform-test-host-deployment.md
+                    displayName: MTP,test host,deployment,packaged app,UWP,WinUI,ITestHostLauncher
+                  - name: Microsoft.Extensions integration
+                    href: ../../core/testing/microsoft-testing-platform-extensions-integration.md
+                    displayName: MTP,Microsoft.Extensions,logging bridge,ILogger,Microsoft.Extensions.Logging
                   - name: OpenTelemetry
                     href: ../../core/testing/microsoft-testing-platform-open-telemetry.md
                     displayName: MTP,OpenTelemetry,traces,metrics


### PR DESCRIPTION
## Summary

Promotes three experimental Microsoft.Testing.Platform (MTP) extensions from inline blurbs/NuGet links in `microsoft-testing-platform-features.md` into dedicated, **generically named** capability pages, each structured to host multiple extensions over time (mirroring the existing **Test reports** page). Reorganizes `features.md` to link to them and adds them to the TOC.

### New pages

| Page | Title | Hosts today |
|---|---|---|
| `microsoft-testing-platform-diagnostics.md` | Diagnostics | Video recorder (`Microsoft.Testing.Extensions.VideoRecorder`, `AddVideoRecorderProvider()`) |
| `microsoft-testing-platform-test-host-deployment.md` | Test host deployment | Packaged app deployment (`Microsoft.Testing.Extensions.PackagedApp`, `AddPackagedAppDeployment()`) |
| `microsoft-testing-platform-extensions-integration.md` | Microsoft.Extensions integration | Logging bridge (`Microsoft.Testing.Extensions.Logging`, `AddMicrosoftExtensionsLogging(...)`) |

Each follows the extension-section pattern from `microsoft-testing-platform-test-reports.md`: H1 + intro, per-extension `## <name>` with NuGet-package line, experimental `> [!NOTE]`, `### Manual registration` C# block, and (video recorder only) a `### Options` table in the three-column `| Option | MTP version | Description |` format.

### Content source breakdown

**`diagnostics.md` — Video recorder**
- *Copied/adapted:* capability summary and ffmpeg/`--capture-video` opt-in framing (from the features.md blurb).
- *Verified from source* (microsoft/testfx `VideoRecorderCommandLineProvider.cs`, `PACKAGE.md`, `PublicAPI.Shipped.txt`): package id, `AddVideoRecorderProvider()`, `[TPEXP]` experimental status, and all six options with their valid values/defaults — `--capture-video` (`on-failure` default / `always`), `--capture-video-source` (`screen` default / `window`), `--capture-video-granularity` (`test` default / `session`), `--capture-video-max-duration` (positive int seconds), `--capture-video-chapters` (`on` default / `off`), `--capture-video-args`. Sub-options require `--capture-video`.
- *Newly written:* the related-capability cross-link to Crash and hang dumps.

**`test-host-deployment.md` — Packaged app deployment**
- *Copied/adapted:* the `ITestHostLauncher` reference-extension framing (from the features.md blurb).
- *Verified from source* (`PackagedAppExtensions.cs`, `PACKAGE.md`, `PublicAPI.Shipped.txt`): package id, `AddPackagedAppDeployment()`, `[TPEXP]` status, UWP/packaged-WinUI deploy-and-launch behavior. No CLI options exist, so no Options table.

**`extensions-integration.md` — Logging bridge**
- *Copied verbatim:* the registration C# sample from features.md.
- *Verified from source* (`MicrosoftExtensionsLoggingBuilderExtensions.cs`, `PACKAGE.md`, `PublicAPI.Shipped.txt`, RFC 013): package id, `AddMicrosoftExtensionsLogging(...)`, `[TPEXP]` status, bridge to <xref:Microsoft.Extensions.Logging.ILogger>, the no-op-when-`--diagnostic`-off behavior, and that per-category filters can narrow but not widen the effective level. No CLI options.

**`features.md`**
- Removed inline Video recorder, Packaged app deployment, and Logging bridge entries; replaced with links to the three new pages.
- Updated the **Choose by scenario** list with three new bullets.
- Removed the now-redundant `## Microsoft.Extensions integration` subsection body (folded into the Extension features list).

**`toc.yml`** — added the three pages next to the other MTP extension entries.

### Needs expert review
- **Versioning:** all three pages state **MTP 2.3.0** (carried over from the existing features.md blurbs and the task decision). Source `glossary.md`/`PACKAGE.md` describe the PackagedApp package as shipping `1.0.0-alpha`; please confirm the 2.3.0 platform-version framing for each extension.
- **Experimental note wording:** reused the standard HTML/JUnit/CTRF sentence ("Available in MTP starting with version 2.3.0. This extension is experimental, and its options and output format might change in a future version."). Confirm this reads correctly for these capabilities.
- **Video recorder options:** verified against the current source provider; confirm defaults/arity match the shipped 2.3.0 build.

All internal links and cross-references were checked to resolve.

ai-usage: ai-generated

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-diagnostics.md](https://github.com/dotnet/docs/blob/83e1cf3e88714d3f6a90fcad09635835a556ed82/docs/core/testing/microsoft-testing-platform-diagnostics.md) | [Diagnostics](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-diagnostics?branch=pr-en-us-54723) |
| [docs/core/testing/microsoft-testing-platform-extensions-integration.md](https://github.com/dotnet/docs/blob/83e1cf3e88714d3f6a90fcad09635835a556ed82/docs/core/testing/microsoft-testing-platform-extensions-integration.md) | [Microsoft.Extensions integration](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-extensions-integration?branch=pr-en-us-54723) |
| [docs/core/testing/microsoft-testing-platform-features.md](https://github.com/dotnet/docs/blob/83e1cf3e88714d3f6a90fcad09635835a556ed82/docs/core/testing/microsoft-testing-platform-features.md) | [Microsoft.Testing.Platform features](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-features?branch=pr-en-us-54723) |
| [docs/core/testing/microsoft-testing-platform-test-host-deployment.md](https://github.com/dotnet/docs/blob/83e1cf3e88714d3f6a90fcad09635835a556ed82/docs/core/testing/microsoft-testing-platform-test-host-deployment.md) | [Test host deployment](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-test-host-deployment?branch=pr-en-us-54723) |
| [docs/navigate/devops-testing/toc.yml](https://github.com/dotnet/docs/blob/83e1cf3e88714d3f6a90fcad09635835a556ed82/docs/navigate/devops-testing/toc.yml) | [docs/navigate/devops-testing/toc](https://review.learn.microsoft.com/en-us/dotnet/navigate/devops-testing/toc?branch=pr-en-us-54723) |


<!-- PREVIEW-TABLE-END -->