### PR TITLE
Document MSTest 4.3 random test order and MTP 2.3 filter mutual exclusion

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-cli-options.md
+++ b/docs/core/testing/microsoft-testing-platform-cli-options.md
@@ -95,7 +95,7 @@ This article gives a central entry point for MTP command-line options.
   Filters the tests to run by their test node UIDs. Accepts one or more UIDs.
 
   > [!NOTE]
-  > This option is available in MTP starting with version 1.8.0. You can't combine `--filter-uid` with `--treenode-filter`.
+  > This option is available in MTP starting with version 1.8.0. Starting with MTP 2.3.0, you can't combine `--filter-uid` with `--treenode-filter`; specifying both fails command-line validation with the `InvalidCommandLine` exit code.
 
 - **`--help`**
 
@@ -151,7 +151,7 @@ This article gives a central entry point for MTP command-line options.
   Filters the tests to run by using a tree filter expression. Tree filters offer richer matching than `--filter` for advanced scenarios.
 
   > [!NOTE]
-  > You can't combine `--treenode-filter` with `--filter-uid`. Starting with MTP 2.3.0, specifying both options fails command-line validation with the `InvalidCommandLine` exit code.
+  > Starting with MTP 2.3.0, you can't combine `--treenode-filter` with `--filter-uid`; specifying both fails command-line validation with the `InvalidCommandLine` exit code.
 
 - **`--zero-tests-policy`**
 

--- a/docs/core/testing/microsoft-testing-platform-cli-options.md
+++ b/docs/core/testing/microsoft-testing-platform-cli-options.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform (MTP) CLI options reference
 description: Find platform and extension command-line options for MTP in one place.
 author: Evangelink
 ms.author: amauryleve
-ms.date: 06/16/2026
+ms.date: 07/09/2026
 ai-usage: ai-assisted
 ---
 
@@ -95,7 +95,7 @@ This article gives a central entry point for MTP command-line options.
   Filters the tests to run by their test node UIDs. Accepts one or more UIDs.
 
   > [!NOTE]
-  > This option is available in MTP starting with version 1.8.0.
+  > This option is available in MTP starting with version 1.8.0. You can't combine `--filter-uid` with `--treenode-filter`.
 
 - **`--help`**
 
@@ -149,6 +149,9 @@ This article gives a central entry point for MTP command-line options.
 - **`--treenode-filter`**
 
   Filters the tests to run by using a tree filter expression. Tree filters offer richer matching than `--filter` for advanced scenarios.
+
+  > [!NOTE]
+  > You can't combine `--treenode-filter` with `--filter-uid`. Starting with MTP 2.3.0, specifying both options fails command-line validation with the `InvalidCommandLine` exit code.
 
 - **`--zero-tests-policy`**
 

--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -51,7 +51,7 @@ Starting with MSTest 3.6, a new runsettings option lets you run tests by test na
 
 ## Order randomly
 
-Starting with MSTest 4.3, to surface hidden ordering dependencies between tests, you can run tests in a random order. Set the `RandomizeTestOrder` setting to **true** in your runsettings file:
+In MSTest 4.3 and later, run tests in a random order to surface hidden ordering dependencies between tests. To enable random order, set the `RandomizeTestOrder` setting to **true** in your runsettings file:
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -64,7 +64,7 @@ Starting with MSTest 4.3, to surface hidden ordering dependencies between tests,
 </RunSettings>
 ```
 
-To make the random order reproducible across runs, set the `RandomTestOrderSeed` setting to an integer seed. When the seed is unset, a new seed is used for each run. You can't combine `RandomizeTestOrder` with `OrderTestsByNameInClass`. For more information, see [Configure MSTest](unit-testing-mstest-configure.md).
+To make the random order reproducible, set the `RandomTestOrderSeed` setting to an integer seed. MSTest then replays the same order on every run. When you leave the seed unset, MSTest generates a new seed for each run. Don't combine `RandomizeTestOrder` with `OrderTestsByNameInClass`, because MSTest applies only one ordering mode at a time. For more information, see [Configure MSTest](unit-testing-mstest-configure.md).
 
 :::zone-end
 :::zone pivot="xunit"

--- a/docs/core/testing/order-unit-tests.md
+++ b/docs/core/testing/order-unit-tests.md
@@ -1,7 +1,7 @@
 ---
 title: Order unit tests
 description: Learn how to order unit tests with .NET Core.
-ms.date: 02/20/2026
+ms.date: 07/08/2026
 ai-usage: ai-assisted
 zone_pivot_groups: unit-testing-framework-set-one
 ---
@@ -48,6 +48,23 @@ Starting with MSTest 3.6, a new runsettings option lets you run tests by test na
 
 </RunSettings>
 ```
+
+## Order randomly
+
+Starting with MSTest 4.3, to surface hidden ordering dependencies between tests, you can run tests in a random order. Set the `RandomizeTestOrder` setting to **true** in your runsettings file:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+
+  <MSTest>
+    <RandomizeTestOrder>true</RandomizeTestOrder>
+  </MSTest>
+
+</RunSettings>
+```
+
+To make the random order reproducible across runs, set the `RandomTestOrderSeed` setting to an integer seed. When the seed is unset, a new seed is used for each run. You can't combine `RandomizeTestOrder` with `OrderTestsByNameInClass`. For more information, see [Configure MSTest](unit-testing-mstest-configure.md).
 
 :::zone-end
 :::zone pivot="xunit"


### PR DESCRIPTION
## Summary

Follow-up review of MTP 2.3.0/2.3.1 and MSTest 4.3.0 feature coverage against the docs. The existing documentation (largely from #54187, #54480, and #54633) was already comprehensive; this PR fills the two remaining gaps found during the audit.

## Changes

- **`order-unit-tests.md`** — Added an "Order randomly" section to the MSTest zone covering the MSTest 4.3 `RandomizeTestOrder` and `RandomTestOrderSeed` runsettings options. Previously the article only documented `OrderTestsByNameInClass` (3.6), so the random-order feature wasn't discoverable from the dedicated ordering article (it was only in the Configure MSTest reference tables).
- **`microsoft-testing-platform-cli-options.md`** — Documented the new `--treenode-filter` ↔ `--filter-uid` mutual exclusion introduced in MTP 2.3.0 ([testfx#9458](https://github.com/microsoft/testfx/pull/9458)); added reciprocal notes on both option entries.

## Audit result

Every other feature in the MTP 2.3.0/2.3.1 (`Changelog-Platform.md`) and MSTest 4.3.0 (`Changelog.md`) changelogs was verified as already documented:

- Analyzers MSTEST0064–0071 (files, overview table, and TOC)
- New assertions (`AreSequenceEqual`/`AreNotSequenceEqual` incl. `SequenceOrder.InAnyOrder`, `AreEquivalent`, `ContainsAll`/`DoesNotContainAll`, `AreAllNotNull`/`AreAllDistinct`/`AreAllOfType`, `AddValueFormatter`, `Span<T>`/`Memory<T>` `HasCount` overloads, structured messages)
- Condition attributes (`[MemberCondition]`, `[ArchitectureCondition]`, `[ExecutableCondition]`), class-level `[Retry]`, `[AssemblyFixtureProvider]`, `TestContext.Properties` lifecycle flow
- Experimental APIs (reflection source generator, `ITestFilter`/`[TestFilterProviderAttribute]`, `TestRun.Current`)
- MSBuild parallelization properties and random-order config
- MTP 2.3 CLI/extension surface: `--ansi`, `--progress`, crash/hangdump `-if-supported` options, `--list-tests json`, `--zero-tests-policy`, HtmlReport/JUnitReport/CtrfReport/GitHubActionsReport/VideoRecorder/PackagedApp extensions, Azure DevOps publishing/attachments/coverage, Logging bridge, testconfig.json `environmentVariables`/IConfiguration, two-stage Ctrl+C, LLM-env behavior

MTP 2.3.1 is a single forward-compat bug fix with no user-facing doc need.

ai-usage: ai-assisted

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-cli-options.md](https://github.com/dotnet/docs/blob/0ee9e810e7324abebcf22d6fe026de9177cc81ac/docs/core/testing/microsoft-testing-platform-cli-options.md) | [Microsoft.Testing.Platform (MTP) CLI options reference](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-cli-options?branch=pr-en-us-54724) |
| [docs/core/testing/order-unit-tests.md](https://github.com/dotnet/docs/blob/0ee9e810e7324abebcf22d6fe026de9177cc81ac/docs/core/testing/order-unit-tests.md) | [Order unit tests](https://review.learn.microsoft.com/en-us/dotnet/core/testing/order-unit-tests?branch=pr-en-us-54724) |


<!-- PREVIEW-TABLE-END -->