### PR TITLE
fix(csharp): allocate requested stack buffer size

### DIFF
--- a/docs/csharp/language-reference/operators/snippets/shared/StackallocOperator.cs
+++ b/docs/csharp/language-reference/operators/snippets/shared/StackallocOperator.cs
@@ -72,7 +72,7 @@ public static class StackallocOperator
     {
         // <SnippetLimitStackalloc>
         const int MaxStackLimit = 1024;
-        Span<byte> buffer = inputLength <= MaxStackLimit ? stackalloc byte[MaxStackLimit] : new byte[inputLength];
+        Span<byte> buffer = inputLength <= MaxStackLimit ? stackalloc byte[inputLength] : new byte[inputLength];
         // </SnippetLimitStackalloc>
     }
 }


### PR DESCRIPTION
## Summary
Corrects the `LimitStackalloc` snippet so its stack allocation uses the requested `inputLength` rather than always allocating `MaxStackLimit`.

## Changes
- Use `stackalloc byte[inputLength]` when `inputLength` is within the stack limit.

## Related issue
Fixes #54665

## Validation
- `git diff --cached --check`
- Targeted source assertion confirming the corrected conditional allocation

## Notes
- The local .NET SDK is not installed, so a project build was not run.
