### PR TITLE
DOTNET_CLI_ENABLEAOT: enabled by default on all platforms

### DIFF
--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -335,7 +335,7 @@ Set this variable to control the fast path explicitly:
 - To disable it and route every invocation to the managed CLI, set the variable to `false`, `0`, `no`, or `off`.
 
 > [!NOTE]
-> Starting in .NET 11 Preview 7, this fast path is enabled by default (`true`) on Windows. On macOS and Linux it's disabled by default because of a command-line parsing issue ([dotnet/command-line-api#2812](https://github.com/dotnet/command-line-api/issues/2812)): when the native CLI is loaded as a NativeAOT shared library, `Environment.GetCommandLineArgs()` returns an empty array on those platforms, which causes command-line parsing to throw. It will be enabled by default on macOS and Linux once that issue is resolved. In the meantime, you can opt in early on those platforms by setting the variable to a value that enables it.
+> Starting in .NET 11 Preview 7, this fast path is enabled by default (`true`) on all platforms. To turn it off, set the variable to a value that disables it.
 
 ### `DOTNET_GENERATE_ASPNET_CERTIFICATE`
 

--- a/docs/core/tools/dotnet-environment-variables.md
+++ b/docs/core/tools/dotnet-environment-variables.md
@@ -335,7 +335,7 @@ Set this variable to control the fast path explicitly:
 - To disable it and route every invocation to the managed CLI, set the variable to `false`, `0`, `no`, or `off`.
 
 > [!NOTE]
-> Starting in .NET 11 Preview 7, this fast path is enabled by default (`true`) on all platforms. To turn it off, set the variable to a value that disables it.
+> Starting in .NET 11 Preview 7, this fast path is enabled by default (`true`) on all platforms. To disable it, set the variable to `false`, `0`, `no`, or `off`.
 
 ### `DOTNET_GENERATE_ASPNET_CERTIFICATE`
 


### PR DESCRIPTION
Follow-up to #54649.

The command-line parsing crash ([dotnet/command-line-api#2812](https://github.com/dotnet/command-line-api/issues/2812)) that had kept the `DOTNET_CLI_ENABLEAOT` fast path disabled by default on macOS and Linux has been fixed upstream ([dotnet/command-line-api#2820](https://github.com/dotnet/command-line-api/pull/2820)) and has flowed into the .NET SDK (via `System.CommandLine` 3.0.0-preview.7.26359.117).

This updates the note so it states the fast path is enabled by default (`true`) on **all platforms** starting in .NET 11 Preview 7, and removes the macOS/Linux-disabled caveat and the now-obsolete opt-in-early guidance.

Tracks the SDK change in dotnet/sdk#55144 and the breaking-change issue #54650.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/tools/dotnet-environment-variables.md](https://github.com/dotnet/docs/blob/8e83131ac721bb19f9f593a1b0006df619670336/docs/core/tools/dotnet-environment-variables.md) | [docs/core/tools/dotnet-environment-variables](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables?branch=pr-en-us-54735) |


<!-- PREVIEW-TABLE-END -->