### PR TITLE
Document terminal progress console output limitation

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-terminal-output.md
+++ b/docs/core/testing/microsoft-testing-platform-terminal-output.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform (MTP) terminal output
 description: Learn about the built-in terminal test reporter in MTP, including output modes, ANSI support, and progress indicators.
 author: evangelink
 ms.author: amauryleve
-ms.date: 06/16/2026
+ms.date: 07/17/2026
 ai-usage: ai-assisted
 ---
 
@@ -40,6 +40,14 @@ The progress bar is written based on the selected mode:
 
 - ANSI, the progress bar is animated, sticking to the bottom of the screen and is refreshed every 500ms. The progress bar hides once test execution is done.
 - non-ANSI, the progress bar is written to screen as is every 3 seconds. The progress remains in the output.
+
+### Direct console output and progress redraw
+
+To animate the progress bar, the ANSI progress renderer takes control of the terminal cursor and repeatedly redraws the bottom of the screen. Any text that's written directly to `stdout` or `stderr` outside the test framework's capture path can be overwritten or removed during this redraw. For example, a `Console.WriteLine` call from assembly-level or session-level lifecycle code (such as a `Before(Assembly)` or `Before(TestSession)` hook), or from an extension, might flash briefly and then disappear when the progress bar refreshes.
+
+This behavior is distinct from *captured* per-test standard output and error. Text that a test writes while it runs is captured by the framework and shown according to `--show-stdout` and `--show-stderr`, so the animated progress bar doesn't overwrite it.
+
+If your code must write directly to the console and you need that output to remain visible, use `--progress off` to disable the animated progress bar. Alternatively, `--ansi off` switches to the append-only progress renderer, which writes progress as new lines instead of redrawing in place and so doesn't overwrite prior direct output.
 
 ## Options
 

--- a/docs/core/testing/microsoft-testing-platform-terminal-output.md
+++ b/docs/core/testing/microsoft-testing-platform-terminal-output.md
@@ -45,9 +45,9 @@ The progress bar is written based on the selected mode:
 
 To animate the progress bar, the ANSI progress renderer takes control of the terminal cursor and repeatedly redraws the bottom of the screen. Any text that's written directly to `stdout` or `stderr` outside the test framework's capture path can be overwritten or removed during this redraw. For example, a `Console.WriteLine` call from assembly-level or session-level lifecycle code (such as a `Before(Assembly)` or `Before(TestSession)` hook), or from an extension, might flash briefly and then disappear when the progress bar refreshes.
 
-This behavior is distinct from *captured* per-test standard output and error. Text that a test writes while it runs is captured by the framework and shown according to `--show-stdout` and `--show-stderr`, so the animated progress bar doesn't overwrite it.
+This behavior is distinct from *captured* per-test standard output and standard error. Output that a test writes while it runs is captured by the framework and shown according to `--show-stdout` and `--show-stderr`, so the progress bar doesn't overwrite it.
 
-If your code must write directly to the console and you need that output to remain visible, use `--progress off` to disable the animated progress bar. Alternatively, `--ansi off` switches to the append-only progress renderer, which writes progress as new lines instead of redrawing in place and so doesn't overwrite prior direct output.
+If your code must write directly to the console and you need that output to remain visible, disable progress (`--progress off` in MTP 2.3.0+, or `--no-progress` in earlier versions). Alternatively, disable ANSI (`--ansi off` in MTP 2.3.0+, or `--no-ansi` in earlier versions) to use the non-ANSI progress output, which appends new lines instead of redrawing in place and doesn't overwrite prior direct output.
 
 ## Options
 


### PR DESCRIPTION
## Summary

Documents a terminal-output limitation of Microsoft.Testing.Platform (MTP) discussed in microsoft/testfx#4425.

The animated ANSI progress bar takes control of the terminal cursor and repeatedly redraws the bottom of the screen. As a result, text written **directly** to `stdout`/`stderr` outside the test framework's capture path — for example a `Console.WriteLine` from assembly-level or session-level lifecycle code (`Before(Assembly)`, `Before(TestSession)`) or from an extension — can be overwritten or removed during redraw.

This is distinct from **captured** per-test standard output/error, which the framework captures and displays according to `--show-stdout` / `--show-stderr` and is therefore not overwritten by the progress bar.

## Changes

- Added a new **Direct console output and progress redraw** subsection under **Progress** in `docs/core/testing/microsoft-testing-platform-terminal-output.md`.
- Recommends `--progress off` when code must write directly to the console, and mentions `--ansi off` as the append-only progress renderer that writes new lines instead of redrawing in place.
- Updated `ms.date`. The article already carries `ai-usage: ai-assisted`.

Fixes context from microsoft/testfx#4425.

## Internal previews

[!INCLUDE [dotnet-content](~/includes/dotnet-content.md)]

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-terminal-output.md](https://github.com/dotnet/docs/blob/cacb577b7e3d36c78e179f3bc1687b5c8c1fabf2/docs/core/testing/microsoft-testing-platform-terminal-output.md) | [Terminal output](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-terminal-output?branch=pr-en-us-54825) |


<!-- PREVIEW-TABLE-END -->