### PR TITLE
Update close-issues policy to remove 'Not Triaged' label

### DIFF
--- a/.github/policies/close-issues.yml
+++ b/.github/policies/close-issues.yml
@@ -43,3 +43,5 @@ configuration:
                   label: code-of-conduct
             then:
               - closeIssue
+              - removeLabel:
+                  label: ':watch: Not Triaged'


### PR DESCRIPTION
Remove 'Not Triaged' label when closing issues with code-of-conduct label.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/policies/close-issues.yml](https://github.com/dotnet/docs/blob/082ab9b8e19a4fd9452c41ca8ce12d785ebe7f7f/.github/policies/close-issues.yml) | [.github/policies/close-issues](https://review.learn.microsoft.com/en-us/dotnet/.github/policies/close-issues?branch=pr-en-us-54848) |

<!-- PREVIEW-TABLE-END -->