### PR TITLE
Document MSTest TestCase.Id filtering

### DIFF
--- a/docs/core/testing/selective-unit-tests.md
+++ b/docs/core/testing/selective-unit-tests.md
@@ -2,7 +2,8 @@
 title: Run selected unit tests
 description: How to use a filter expression to run selected unit tests with the dotnet test command in .NET Core.
 author: smadala
-ms.date: 10/29/2021
+ms.date: 07/22/2026
+ai-usage: ai-assisted
 zone_pivot_groups: unit-testing-framework-set-one
 ms.topic: reference
 ---
@@ -29,7 +30,7 @@ dotnet test --filter <Expression>
 
   | Test framework | Supported properties |
   | -------------- | -------------------- |
-  | MSTest         | `FullyQualifiedName`<br>`Name`<br>`ClassName`<br>`Priority`<br>`TestCategory` |
+  | MSTest         | `FullyQualifiedName`<br>`Name`<br>`ClassName`<br>`Priority`<br>`TestCategory`<br>`Id` |
   | xUnit          | `FullyQualifiedName`<br>`DisplayName`<br>`Traits` |
   | Nunit          | `FullyQualifiedName`<br>`Name`<br>`Priority`<br>`TestCategory` |
 
@@ -95,6 +96,9 @@ namespace MSTestNamespace
 | `dotnet test --filter FullyQualifiedName!=MSTestNamespace.UnitTest1.TestMethod1` | Runs all tests except `MSTestNamespace.UnitTest1.TestMethod1`. |
 | `dotnet test --filter TestCategory=CategoryA` | Runs tests that are annotated with `[TestCategory("CategoryA")]`. |
 | `dotnet test --filter Priority=2` | Runs tests that are annotated with `[Priority(2)]`. |
+| `dotnet test --filter "Id=<guid>"` | Runs the test case whose discovered `TestCase.Id` exactly matches the GUID. |
+
+`Id` filtering requires MSTest.TestAdapter 3.6 or later. Obtain the GUID from the test case that VSTest discovery returns in `TestCase.Id`. This filter can select one unfolded data-driven iteration without matching or escaping its display name. Each row must be discovered as an individual test case; a folded data-driven test exposes only one parent identity.
 
 Examples using the conditional operators `|` and `&`:
 

--- a/docs/core/testing/selective-unit-tests.md
+++ b/docs/core/testing/selective-unit-tests.md
@@ -96,7 +96,7 @@ namespace MSTestNamespace
 | `dotnet test --filter FullyQualifiedName!=MSTestNamespace.UnitTest1.TestMethod1` | Runs all tests except `MSTestNamespace.UnitTest1.TestMethod1`. |
 | `dotnet test --filter TestCategory=CategoryA` | Runs tests that are annotated with `[TestCategory("CategoryA")]`. |
 | `dotnet test --filter Priority=2` | Runs tests that are annotated with `[Priority(2)]`. |
-| `dotnet test --filter "Id=<guid>"` | Runs the test case whose discovered `TestCase.Id` exactly matches the GUID. |
+| `dotnet test --filter "Id=<guid>"` | Runs the test case whose discovered `TestCase.Id` value exactly matches the GUID. |
 
 `Id` filtering requires MSTest.TestAdapter 3.6 or later. Obtain the GUID from the test case that VSTest discovery returns in `TestCase.Id`. This filter can select one unfolded data-driven iteration without matching or escaping its display name. Each row must be discovered as an individual test case; a folded data-driven test exposes only one parent identity.
 


### PR DESCRIPTION
## Summary

- Add `Id` to the supported MSTest filter properties.
- Document exact `TestCase.Id` filtering for a discovered test case, including individual data-driven iterations.
- Note the MSTest.TestAdapter 3.6 minimum version and how callers obtain the GUID from VSTest discovery.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/testing/selective-unit-tests.md](https://github.com/dotnet/docs/blob/ea90f363e6b5299b03606684669abe631252b78d/docs/core/testing/selective-unit-tests.md) | [Run selected unit tests](https://review.learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?branch=pr-en-us-54857) |


<!-- PREVIEW-TABLE-END -->