### PR TITLE
Add link to never rules

### DIFF
--- a/docs/core/project-sdk/msbuild-props.md
+++ b/docs/core/project-sdk/msbuild-props.md
@@ -1163,7 +1163,7 @@ The `CodeAnalysisTreatWarningsAsErrors` property lets you configure whether code
 ### EnforceCodeStyleInBuild
 
 [.NET code style analysis](../../fundamentals/code-analysis/overview.md#code-style-analysis) is disabled, by default, on build for all .NET projects. You can enable code style analysis for .NET projects by setting the `EnforceCodeStyleInBuild` property to `true`.
-(But for performance reasons, a handful of code-style rules that apply only in the Visual Studio IDE won't be run.)
+(But for performance reasons, a [handful of code-style rules](https://github.com/dotnet/roslyn/blob/7c69ea6a9a16bd8ded79ce0d7c0256d59736d486/src/Analyzers/Core/Analyzers/EnforceOnBuildValues.cs#L140) that apply only in the Visual Studio IDE won't be run.)
 
 ```xml
 <PropertyGroup>


### PR DESCRIPTION
Updated the explanation of the EnforceCodeStyleInBuild property to include a link to specific code-style rules that won't be run for performance reasons.

Follow up for https://github.com/dotnet/docs/issues/51575#issuecomment-4025804311.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [docs/core/project-sdk/msbuild-props.md](https://github.com/dotnet/docs/blob/ed0ea665e5e62e2ae537af97018a37e79136e09a/docs/core/project-sdk/msbuild-props.md) | [MSBuild reference for .NET SDK projects](https://review.learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props?branch=pr-en-us-55104) |

<!-- PREVIEW-TABLE-END -->