### PR TITLE
Clarify HybridCache stampede protection scope

### DIFF
--- a/docs/core/extensions/caching.md
+++ b/docs/core/extensions/caching.md
@@ -1,7 +1,7 @@
 ---
 title: Caching in .NET
 description: Discover effective ways to implement in-memory and distributed caching in .NET. Boost app performance and scalability with .NET caching.
-ms.date: 10/22/2025
+ms.date: 07/28/2026
 ai-usage: ai-assisted
 ---
 
@@ -253,7 +253,7 @@ The <xref:Microsoft.Extensions.Caching.Hybrid.HybridCache> library combines the 
 `HybridCache` offers several advantages over using `IMemoryCache` and `IDistributedCache` separately:
 
 - **Two-level caching**: Automatically manages both in-memory (L1) and distributed (L2) cache layers. Data is retrieved from in-memory cache first for speed, then from distributed cache if needed, and finally from the source.
-- **Stampede protection**: Prevents multiple concurrent requests from executing the same expensive operation. Only one request fetches the data while others wait for the result.
+- **Stampede protection**: Prevents multiple concurrent requests using the same `HybridCache` instance from executing the same expensive operation. Only one request fetches the data while others wait for the result. This coordination doesn't extend to other `HybridCache` instances, even if they use the same distributed cache.
 - **Configurable serialization**: Supports multiple serialization formats including JSON (default), protobuf, and XML.
 - **Tag-based invalidation**: Groups related cache entries with tags for efficient batch invalidation.
 - **Simplified API**: The `GetOrCreateAsync` method handles cache misses, serialization, and storage automatically.

--- a/docs/core/extensions/caching.md
+++ b/docs/core/extensions/caching.md
@@ -253,7 +253,7 @@ The <xref:Microsoft.Extensions.Caching.Hybrid.HybridCache> library combines the 
 `HybridCache` offers several advantages over using `IMemoryCache` and `IDistributedCache` separately:
 
 - **Two-level caching**: Automatically manages both in-memory (L1) and distributed (L2) cache layers. Data is retrieved from in-memory cache first for speed, then from distributed cache if needed, and finally from the source.
-- **Stampede protection**: Prevents multiple concurrent requests using the same `HybridCache` instance from executing the same expensive operation. Only one request fetches the data while others wait for the result. This coordination doesn't extend to other `HybridCache` instances, even if they use the same distributed cache.
+- **Stampede protection**: Prevents multiple concurrent requests that use the same `HybridCache` instance from executing the same expensive operation. Only one request fetches the data while others wait for the result. This coordination doesn't extend to other `HybridCache` instances, even if they use the same distributed cache.
 - **Configurable serialization**: Supports multiple serialization formats including JSON (default), protobuf, and XML.
 - **Tag-based invalidation**: Groups related cache entries with tags for efficient batch invalidation.
 - **Simplified API**: The `GetOrCreateAsync` method handles cache misses, serialization, and storage automatically.


### PR DESCRIPTION
## Summary

Clarifies that HybridCache stampede protection coordinates callers using the same `HybridCache` instance, including when multiple instances share a distributed cache.

Related to dotnet/extensions#6759.

Companion to dotnet/AspNetCore.Docs#37395.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/extensions/caching.md](https://github.com/dotnet/docs/blob/0f3f8823a1010e09b22c5ee1b851892a26dd89fa/docs/core/extensions/caching.md) | [docs/core/extensions/caching](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/caching?branch=pr-en-us-55180) |


<!-- PREVIEW-TABLE-END -->