### PR TITLE
Clarify usage of `IUnionMembers` interface 

### DIFF
--- a/docs/csharp/language-reference/builtin-types/snippets/unions/MemberProvider.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/unions/MemberProvider.cs
@@ -1,6 +1,6 @@
 // <MemberProvider>
 [System.Runtime.CompilerServices.Union]
-public record class Outcome<T> : Outcome<T>.IUnionMembers
+public struct Outcome<T> : Outcome<T>.IUnionMembers
 {
     private readonly object? _value;
 
@@ -8,8 +8,8 @@ public record class Outcome<T> : Outcome<T>.IUnionMembers
 
     public interface IUnionMembers
     {
-        static Outcome<T> Create(T? value) => new((object?)value);
-        static Outcome<T> Create(Exception? value) => new((object?)value);
+        static Outcome<T> Create(T? value) => new(value);
+        static Outcome<T> Create(Exception? value) => new(value);
         object? Value { get; }
 
         // only when needed

--- a/docs/csharp/language-reference/builtin-types/snippets/unions/MemberProvider.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/unions/MemberProvider.cs
@@ -8,12 +8,38 @@ public record class Outcome<T> : Outcome<T>.IUnionMembers
 
     public interface IUnionMembers
     {
-        static Outcome<T> Create(T? value) => new(value);
-        static Outcome<T> Create(Exception? value) => new(value);
+        public static Outcome<T> Create(T? value) => new(value: value);
+        public static Outcome<T> Create(Exception? value) => new(value: value);
         object? Value { get; }
+
+        // only when needed
+        bool TryGetValue(out T value);
+        bool TryGetValue(out Exception value);
     }
 
     object? IUnionMembers.Value => _value;
+
+    public bool TryGetValue(out T value)
+    {
+        if (_value is T t)
+        {
+            value = t;
+            return true;
+        }
+        value = default!;
+        return false;
+    }
+
+    public bool TryGetValue(out Exception value)
+    {
+        if (_value is Exception e)
+        {
+            value = e;
+            return true;
+        }
+        value = default!;
+        return false;
+    }
 }
 // </MemberProvider>
 

--- a/docs/csharp/language-reference/builtin-types/snippets/unions/MemberProvider.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/unions/MemberProvider.cs
@@ -8,8 +8,8 @@ public record class Outcome<T> : Outcome<T>.IUnionMembers
 
     public interface IUnionMembers
     {
-        static Outcome<T> Create(T? value) => new(value: value);
-        static Outcome<T> Create(Exception? value) => new(value: value);
+        static Outcome<T> Create(T? value) => new((object?)value);
+        static Outcome<T> Create(Exception? value) => new((object?)value);
         object? Value { get; }
 
         // only when needed

--- a/docs/csharp/language-reference/builtin-types/snippets/unions/MemberProvider.cs
+++ b/docs/csharp/language-reference/builtin-types/snippets/unions/MemberProvider.cs
@@ -8,8 +8,8 @@ public record class Outcome<T> : Outcome<T>.IUnionMembers
 
     public interface IUnionMembers
     {
-        public static Outcome<T> Create(T? value) => new(value: value);
-        public static Outcome<T> Create(Exception? value) => new(value: value);
+        static Outcome<T> Create(T? value) => new(value: value);
+        static Outcome<T> Create(Exception? value) => new(value: value);
         object? Value { get; }
 
         // only when needed

--- a/docs/csharp/language-reference/builtin-types/union.md
+++ b/docs/csharp/language-reference/builtin-types/union.md
@@ -171,10 +171,7 @@ The compiler prefers `TryGetValue` over the `Value` property when implementing p
 
 ### Union member providers
 
-> [!NOTE]
-> If an `IUnionMembers` interface is used, all union members must be defined on that interface.
-
-A union type can delegate its union members to a nested `IUnionMembers` interface. When this interface is present, the compiler looks for `Create` factory methods instead of constructors:
+A union type can delegate its union members to a nested `IUnionMembers` interface. When this interface is present, the `union` type behaves as a *union member provider*. The compiler generates code to call the `IUnionMembers` interface. It won't generate calls to members declared on the union type that aren't members of the nested `IUnionMembers` interface. As the following example shows, that means you must add the necessary factory methods and the appropriate `TryGetValue` methods for all case types:
 
 :::code language="csharp" source="snippets/unions/MemberProvider.cs" id="MemberProvider":::
 

--- a/docs/csharp/language-reference/builtin-types/union.md
+++ b/docs/csharp/language-reference/builtin-types/union.md
@@ -171,6 +171,9 @@ The compiler prefers `TryGetValue` over the `Value` property when implementing p
 
 ### Union member providers
 
+> [!NOTE]
+> If a `IUnionMembers` interface is used all union members must be defined on that interface
+
 A union type can delegate its union members to a nested `IUnionMembers` interface. When this interface is present, the compiler looks for `Create` factory methods instead of constructors:
 
 :::code language="csharp" source="snippets/unions/MemberProvider.cs" id="MemberProvider":::

--- a/docs/csharp/language-reference/builtin-types/union.md
+++ b/docs/csharp/language-reference/builtin-types/union.md
@@ -172,7 +172,7 @@ The compiler prefers `TryGetValue` over the `Value` property when implementing p
 ### Union member providers
 
 > [!NOTE]
-> If a `IUnionMembers` interface is used all union members must be defined on that interface
+> If an `IUnionMembers` interface is used, all union members must be defined on that interface.
 
 A union type can delegate its union members to a nested `IUnionMembers` interface. When this interface is present, the compiler looks for `Create` factory methods instead of constructors:
 


### PR DESCRIPTION
## Summary

clarify that all union members must be part of the interface  
so far the paragraph mostly talks about factory methods.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/snippets/unions/MemberProvider.cs](https://github.com/dotnet/docs/blob/909e111e2132947ac6ad331ff157cde632afbf21/docs/csharp/language-reference/builtin-types/snippets/unions/MemberProvider.cs) | [docs/csharp/language-reference/builtin-types/snippets/unions/MemberProvider.cs](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/union?branch=pr-en-us-55183) |
| [docs/csharp/language-reference/builtin-types/union.md](https://github.com/dotnet/docs/blob/909e111e2132947ac6ad331ff157cde632afbf21/docs/csharp/language-reference/builtin-types/union.md) | [docs/csharp/language-reference/builtin-types/union](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/union?branch=pr-en-us-55183) |


<!-- PREVIEW-TABLE-END -->