### PR TITLE
Document ISOSDacInterface private DAC APIs used by ClrMD

### DIFF
--- a/docs/framework/unmanaged-api/debugging/dacpappdomaindata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpappdomaindata-structure.md
@@ -1,0 +1,85 @@
+---
+description: "Learn more about: DacpAppDomainData Structure"
+title: "DacpAppDomainData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpAppDomainData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpAppDomainData Structure"
+helpviewer.keywords:
+  - "DacpAppDomainData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpAppDomainData Structure
+
+Defines a transport buffer for runtime application domain information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpAppDomainData : ZeroInit<DacpAppDomainData>
+{
+    // The pointer to the BaseDomain (not necessarily an AppDomain).  
+    // It's useful to keep this around in the structure
+    CLRDATA_ADDRESS AppDomainPtr; 
+    CLRDATA_ADDRESS AppSecDesc;
+    CLRDATA_ADDRESS pLowFrequencyHeap;
+    CLRDATA_ADDRESS pHighFrequencyHeap;
+    CLRDATA_ADDRESS pStubHeap;
+    CLRDATA_ADDRESS DomainLocalBlock;
+    CLRDATA_ADDRESS pDomainLocalModules;    
+    // The creation sequence number of this app domain (starting from 1)
+    DWORD dwId;
+    LONG AssemblyCount;
+    LONG FailedAssemblyCount;
+    DacpAppDomainDataStage appDomainStage; 
+    
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr)
+    {
+        return sos->GetAppDomainData(addr, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `AppDomainPtr` | The address of the base domain. For an application domain, this value is the application domain address. |
+| `AppSecDesc` | The address of the application security descriptor. |
+| `pLowFrequencyHeap` | The address of the low-frequency loader heap. |
+| `pHighFrequencyHeap` | The address of the high-frequency loader heap. |
+| `pStubHeap` | The address of the stub heap. |
+| `DomainLocalBlock` | The address of the domain local block. |
+| `pDomainLocalModules` | The address of the domain local modules. |
+| `dwId` | The creation sequence number of the application domain, starting from 1. |
+| `AssemblyCount` | The number of assemblies in the application domain. |
+| `FailedAssemblyCount` | The number of failed assemblies in the application domain. |
+| `appDomainStage` | A `DacpAppDomainDataStage` value that indicates the application domain lifecycle stage. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetAppDomainData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpappdomainstoredata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpappdomainstoredata-structure.md
@@ -1,0 +1,66 @@
+---
+description: "Learn more about: DacpAppDomainStoreData Structure"
+title: "DacpAppDomainStoreData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpAppDomainStoreData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpAppDomainStoreData Structure"
+helpviewer.keywords:
+  - "DacpAppDomainStoreData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpAppDomainStoreData Structure
+
+Defines a transport buffer for runtime application domain store information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpAppDomainStoreData : ZeroInit<DacpAppDomainStoreData>
+{
+    CLRDATA_ADDRESS sharedDomain;
+    CLRDATA_ADDRESS systemDomain;
+    LONG DomainCount;
+
+    HRESULT Request(ISOSDacInterface *sos)
+    {
+        return sos->GetAppDomainStoreData(this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `sharedDomain` | The address of the shared domain. |
+| `systemDomain` | The address of the system domain. |
+| `DomainCount` | The number of application domains in the runtime. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetAppDomainStoreData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpassemblydata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpassemblydata-structure.md
@@ -1,0 +1,85 @@
+---
+description: "Learn more about: DacpAssemblyData Structure"
+title: "DacpAssemblyData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpAssemblyData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpAssemblyData Structure"
+helpviewer.keywords:
+  - "DacpAssemblyData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpAssemblyData Structure
+
+Defines a transport buffer for runtime assembly information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpAssemblyData : ZeroInit<DacpAssemblyData>
+{
+    CLRDATA_ADDRESS AssemblyPtr; //useful to have
+    CLRDATA_ADDRESS ClassLoader;
+    CLRDATA_ADDRESS ParentDomain;
+    CLRDATA_ADDRESS BaseDomainPtr;
+    CLRDATA_ADDRESS AssemblySecDesc;
+    BOOL isDynamic;
+    UINT ModuleCount;
+    UINT LoadContext;
+    BOOL isDomainNeutral;
+    DWORD dwLocationFlags;
+
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr, CLRDATA_ADDRESS baseDomainPtr)
+    {
+        return sos->GetAssemblyData(baseDomainPtr, addr, this);
+    }
+
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr)
+    {
+        return Request(sos, addr, NULL);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `AssemblyPtr` | The address of the assembly. |
+| `ClassLoader` | The address of the class loader for the assembly. |
+| `ParentDomain` | The address of the parent application domain. |
+| `BaseDomainPtr` | The address of the base domain that contains the assembly. |
+| `AssemblySecDesc` | The address of the assembly security descriptor. |
+| `isDynamic` | A value that indicates whether the assembly is dynamic. |
+| `ModuleCount` | The number of modules in the assembly. |
+| `LoadContext` | The assembly load context value. |
+| `isDomainNeutral` | A value that indicates whether the assembly is domain-neutral. |
+| `dwLocationFlags` | A bitmask of location flags for the assembly. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetAssemblyData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpccwdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpccwdata-structure.md
@@ -1,0 +1,88 @@
+---
+description: "Learn more about: DacpCCWData Structure"
+title: "DacpCCWData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpCCWData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpCCWData Structure"
+helpviewer.keywords:
+  - "DacpCCWData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpCCWData Structure
+
+Defines a transport buffer for COM callable wrapper (CCW) information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpCCWData : ZeroInit<DacpCCWData>
+{
+    CLRDATA_ADDRESS outerIUnknown;
+    CLRDATA_ADDRESS managedObject;
+    CLRDATA_ADDRESS handle;
+    CLRDATA_ADDRESS ccwAddress;
+
+    LONG refCount;
+    LONG interfaceCount;
+    BOOL isNeutered;
+
+    LONG jupiterRefCount;
+    BOOL isPegged;
+    BOOL isGlobalPegged;
+    BOOL hasStrongRef;
+    BOOL isExtendsCOMObject;
+    BOOL isAggregated;
+    
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS ccw)
+    {
+        return sos->GetCCWData(ccw, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `outerIUnknown` | The address of the outer `IUnknown` pointer. |
+| `managedObject` | The address of the managed object associated with the CCW. |
+| `handle` | The address of the handle for the managed object. |
+| `ccwAddress` | The address of the CCW. |
+| `refCount` | The reference count for the CCW. |
+| `interfaceCount` | The number of interfaces associated with the CCW. |
+| `isNeutered` | A value that indicates whether the CCW is neutered. |
+| `jupiterRefCount` | The Jupiter reference count for the CCW. |
+| `isPegged` | A value that indicates whether the CCW is pegged. |
+| `isGlobalPegged` | A value that indicates whether the CCW is globally pegged. |
+| `hasStrongRef` | A value that indicates whether the CCW has a strong reference. |
+| `isExtendsCOMObject` | A value that indicates whether the managed object extends a COM object. |
+| `isAggregated` | A value that indicates whether the CCW is aggregated. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetCCWData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpcodeheaderdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpcodeheaderdata-structure.md
@@ -70,7 +70,6 @@ This structure lives inside the runtime and is not exposed through any headers o
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
 
-
 ## See also
 
 - [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/dacpcodeheaderdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpcodeheaderdata-structure.md
@@ -1,0 +1,77 @@
+---
+description: "Learn more about: DacpCodeHeaderData Structure"
+title: "DacpCodeHeaderData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpCodeHeaderData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpCodeHeaderData Structure"
+helpviewer.keywords:
+  - "DacpCodeHeaderData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpCodeHeaderData Structure
+
+Defines a transport buffer for JIT-compiled code header information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpCodeHeaderData : ZeroInit<DacpCodeHeaderData>
+{        
+    CLRDATA_ADDRESS GCInfo;
+    JITTypes                   JITType;
+    CLRDATA_ADDRESS MethodDescPtr;
+    CLRDATA_ADDRESS MethodStart;
+    DWORD                    MethodSize;
+    CLRDATA_ADDRESS ColdRegionStart;
+    DWORD           ColdRegionSize;
+    DWORD           HotRegionSize;
+    
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS IPAddr)
+    {
+        return sos->GetCodeHeaderData(IPAddr, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `GCInfo` | The address of the garbage collection information for the method. |
+| `JITType` | A `JITTypes` value that identifies the kind of JIT compiler that produced the code. |
+| `MethodDescPtr` | The address of the method descriptor for the code. |
+| `MethodStart` | The starting address of the hot code region. |
+| `MethodSize` | The size, in bytes, of the method code. |
+| `ColdRegionStart` | The starting address of the cold code region. |
+| `ColdRegionSize` | The size, in bytes, of the cold code region. |
+| `HotRegionSize` | The size, in bytes, of the hot code region. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetCodeHeaderData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpcominterfacepointerdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpcominterfacepointerdata-structure.md
@@ -1,0 +1,60 @@
+---
+description: "Learn more about: DacpCOMInterfacePointerData Structure"
+title: "DacpCOMInterfacePointerData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpCOMInterfacePointerData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpCOMInterfacePointerData Structure"
+helpviewer.keywords:
+  - "DacpCOMInterfacePointerData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpCOMInterfacePointerData Structure
+
+Defines a transport buffer for COM interface pointer information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpCOMInterfacePointerData : ZeroInit<DacpCOMInterfacePointerData>
+{
+    CLRDATA_ADDRESS methodTable;
+    CLRDATA_ADDRESS interfacePtr;
+    CLRDATA_ADDRESS comContext;
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `methodTable` | The address of the method table for the interface. |
+| `interfacePtr` | The address of the COM interface pointer. |
+| `comContext` | The address of the COM context associated with the interface pointer. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpdomainlocalmoduledata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpdomainlocalmoduledata-structure.md
@@ -1,0 +1,76 @@
+---
+description: "Learn more about: DacpDomainLocalModuleData Structure"
+title: "DacpDomainLocalModuleData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpDomainLocalModuleData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpDomainLocalModuleData Structure"
+helpviewer.keywords:
+  - "DacpDomainLocalModuleData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpDomainLocalModuleData Structure
+
+Defines a transport buffer for domain-local module information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpDomainLocalModuleData : ZeroInit<DacpDomainLocalModuleData>
+{
+    // These two parameters are used as input params when calling the
+    // no-argument form of Request below.
+    CLRDATA_ADDRESS appDomainAddr;
+    ULONG64  ModuleID;
+    
+    CLRDATA_ADDRESS pClassData;   
+    CLRDATA_ADDRESS pDynamicClassTable;   
+    CLRDATA_ADDRESS pGCStaticDataStart;
+    CLRDATA_ADDRESS pNonGCStaticDataStart; 
+
+    // Called when you have a pointer to the DomainLocalModule
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr)
+    {
+        return sos->GetDomainLocalModuleData(addr, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `appDomainAddr` | The address of the application domain used as an input parameter for a request. |
+| `ModuleID` | The module identifier used as an input parameter for a request. |
+| `pClassData` | The address of the class data. |
+| `pDynamicClassTable` | The address of the dynamic class table. |
+| `pGCStaticDataStart` | The start address for garbage-collected static data. |
+| `pNonGCStaticDataStart` | The start address for non-garbage-collected static data. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetDomainLocalModuleData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpdomainlocalmoduledata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpdomainlocalmoduledata-structure.md
@@ -29,8 +29,7 @@ Defines a transport buffer for domain-local module information.
 ```cpp
 struct DacpDomainLocalModuleData : ZeroInit<DacpDomainLocalModuleData>
 {
-    // These two parameters are used as input params when calling the
-    // no-argument form of Request below.
+    // These two parameters are used as input parameters when calling Request below.
     CLRDATA_ADDRESS appDomainAddr;
     ULONG64  ModuleID;
     
@@ -57,7 +56,7 @@ struct DacpDomainLocalModuleData : ZeroInit<DacpDomainLocalModuleData>
 | `pDynamicClassTable` | The address of the dynamic class table. |
 | `pGCStaticDataStart` | The start address for garbage-collected static data. |
 | `pNonGCStaticDataStart` | The start address for non-garbage-collected static data. |
-| `Request` | Populates the structure by calling `ISOSDacInterface::GetDomainLocalModuleData`. |
+| `Request` | Populates the structure by calling [`ISOSDacInterface::GetDomainLocalModuleData`](isosdacinterface-getdomainlocalmoduledata-method.md). |
 
 ## Remarks
 
@@ -74,3 +73,4 @@ This structure lives inside the runtime and is not exposed through any headers o
 
 - [Debugging](index.md)
 - [Debugging Structures](debugging-structures.md)
+- [ISOSDacInterface::GetDomainLocalModuleData Method](isosdacinterface-getdomainlocalmoduledata-method.md)

--- a/docs/framework/unmanaged-api/debugging/dacpfielddescdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpfielddescdata-structure.md
@@ -30,7 +30,7 @@ Defines a transport buffer for FieldDesc information.
 struct DacpFieldDescData : ZeroInit<DacpFieldDescData>
 {
     CorElementType Type;
-    CorElementType sigType;     // ELEMENT_TYPE_XXX from signature. We need this to disply pretty name for String in minidump's case
+    CorElementType sigType;     // ELEMENT_TYPE_XXX from signature. We need this to display pretty name for String in minidump's case
     CLRDATA_ADDRESS MTOfType; // NULL if Type is not loaded
     
     CLRDATA_ADDRESS ModuleOfType;

--- a/docs/framework/unmanaged-api/debugging/dacpfielddescdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpfielddescdata-structure.md
@@ -1,0 +1,86 @@
+---
+description: "Learn more about: DacpFieldDescData Structure"
+title: "DacpFieldDescData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpFieldDescData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpFieldDescData Structure"
+helpviewer.keywords:
+  - "DacpFieldDescData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpFieldDescData Structure
+
+Defines a transport buffer for FieldDesc information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpFieldDescData : ZeroInit<DacpFieldDescData>
+{
+    CorElementType Type;
+    CorElementType sigType;     // ELEMENT_TYPE_XXX from signature. We need this to disply pretty name for String in minidump's case
+    CLRDATA_ADDRESS MTOfType; // NULL if Type is not loaded
+    
+    CLRDATA_ADDRESS ModuleOfType;
+    mdTypeDef TokenOfType;
+    
+    mdFieldDef mb;
+    CLRDATA_ADDRESS MTOfEnclosingClass;
+    DWORD dwOffset;
+    BOOL bIsThreadLocal;
+    BOOL bIsContextLocal;
+    BOOL bIsStatic;
+    CLRDATA_ADDRESS NextField;
+
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr)
+    {
+        return sos->GetFieldDescData(addr, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `Type` | The field type. |
+| `sigType` | The `ELEMENT_TYPE_XXX` value from the field signature. The runtime uses this member to display a friendly name for `String` in minidump scenarios. |
+| `MTOfType` | The address of the method table for the field type, or `NULL` if the type is not loaded. |
+| `ModuleOfType` | The address of the module that contains the field type. |
+| `TokenOfType` | The metadata token for the field type. |
+| `mb` | The metadata token for the field. |
+| `MTOfEnclosingClass` | The address of the method table for the enclosing class. |
+| `dwOffset` | The field offset. |
+| `bIsThreadLocal` | A value that indicates whether the field is thread local. |
+| `bIsContextLocal` | A value that indicates whether the field is context local. |
+| `bIsStatic` | A value that indicates whether the field is static. |
+| `NextField` | The address of the next field. |
+| `Request` | Populates the structure from a FieldDesc address by calling `ISOSDacInterface::GetFieldDescData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpgcheapanalyzedata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpgcheapanalyzedata-structure.md
@@ -1,0 +1,78 @@
+---
+description: "Learn more about: DacpGcHeapAnalyzeData Structure"
+title: "DacpGcHeapAnalyzeData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpGcHeapAnalyzeData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpGcHeapAnalyzeData Structure"
+helpviewer.keywords:
+  - "DacpGcHeapAnalyzeData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpGcHeapAnalyzeData Structure
+
+Defines a transport buffer for garbage collection heap analysis information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpGcHeapAnalyzeData
+    : ZeroInit<DacpGcHeapAnalyzeData>
+{
+    CLRDATA_ADDRESS heapAddr; // Only filled in in server mode, otherwise NULL
+
+    CLRDATA_ADDRESS internal_root_array;
+    ULONG64         internal_root_array_index;
+    BOOL            heap_analyze_success;
+
+    // Use this for workstation mode (DacpGcHeapDat.bServerMode==FALSE).
+    HRESULT Request(ISOSDacInterface *sos)
+    {
+        return sos->GetHeapAnalyzeStaticData(this);   
+    }
+
+    // Use this for Server mode, as there are multiple heaps,
+    // and you need to pass a heap address in addr.
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr)
+    {
+        return sos->GetHeapAnalyzeData(addr, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `heapAddr` | The address of the GC heap. This member is filled only in server mode; otherwise, it is `NULL`. |
+| `internal_root_array` | The address of the internal root array. |
+| `internal_root_array_index` | The index into the internal root array. |
+| `heap_analyze_success` | A value that indicates whether heap analysis succeeded. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetHeapAnalyzeStaticData` or `ISOSDacInterface::GetHeapAnalyzeData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpgcheapdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpgcheapdata-structure.md
@@ -1,0 +1,69 @@
+---
+description: "Learn more about: DacpGcHeapData Structure"
+title: "DacpGcHeapData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpGcHeapData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpGcHeapData Structure"
+helpviewer.keywords:
+  - "DacpGcHeapData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpGcHeapData Structure
+
+Defines a transport buffer for general garbage collection heap information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpGcHeapData
+    : ZeroInit<DacpGcHeapData>
+{
+    BOOL bServerMode;
+    BOOL bGcStructuresValid;
+    UINT HeapCount;
+    UINT g_max_generation;
+    
+    HRESULT Request(ISOSDacInterface *sos)
+    {
+        return sos->GetGCHeapData(this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `bServerMode` | A value that indicates whether the runtime uses server GC. |
+| `bGcStructuresValid` | A value that indicates whether the GC structures are valid. |
+| `HeapCount` | The number of GC heaps. |
+| `g_max_generation` | The maximum GC generation number. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetGCHeapData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpgcheapdetails-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpgcheapdetails-structure.md
@@ -1,0 +1,103 @@
+---
+description: "Learn more about: DacpGcHeapDetails Structure"
+title: "DacpGcHeapDetails Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpGcHeapDetails Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpGcHeapDetails Structure"
+helpviewer.keywords:
+  - "DacpGcHeapDetails Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpGcHeapDetails Structure
+
+Defines a transport buffer for detailed garbage collection heap information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+#define DAC_NUMBERGENERATIONS 4
+
+struct DacpGcHeapDetails : ZeroInit<DacpGcHeapDetails>
+{
+    CLRDATA_ADDRESS heapAddr; // Only filled in in server mode, otherwise NULL
+    CLRDATA_ADDRESS alloc_allocated;
+
+    CLRDATA_ADDRESS mark_array;
+    CLRDATA_ADDRESS current_c_gc_state;
+    CLRDATA_ADDRESS next_sweep_obj;
+    CLRDATA_ADDRESS saved_sweep_ephemeral_seg;
+    CLRDATA_ADDRESS saved_sweep_ephemeral_start;
+    CLRDATA_ADDRESS background_saved_lowest_address;
+    CLRDATA_ADDRESS background_saved_highest_address;
+
+    DacpGenerationData generation_table [DAC_NUMBERGENERATIONS]; 
+    CLRDATA_ADDRESS ephemeral_heap_segment;        
+    CLRDATA_ADDRESS finalization_fill_pointers [DAC_NUMBERGENERATIONS + 3];
+    CLRDATA_ADDRESS lowest_address;
+    CLRDATA_ADDRESS highest_address;
+    CLRDATA_ADDRESS card_table;
+
+    // Use this for workstation mode (DacpGcHeapDat.bServerMode==FALSE).
+    HRESULT Request(ISOSDacInterface *sos)
+    {
+        return sos->GetGCHeapStaticData(this);
+    }
+
+    // Use this for Server mode, as there are multiple heaps,
+    // and you need to pass a heap address in addr.
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr)
+    {
+        return sos->GetGCHeapDetails(addr, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `heapAddr` | The address of the GC heap. This member is filled only in server mode; otherwise, it is `NULL`. |
+| `alloc_allocated` | The current allocation pointer for the heap. |
+| `mark_array` | The address of the mark array. |
+| `current_c_gc_state` | The address of the current compacting GC state. |
+| `next_sweep_obj` | The address of the next object to sweep. |
+| `saved_sweep_ephemeral_seg` | The address of the saved ephemeral segment for a sweep. |
+| `saved_sweep_ephemeral_start` | The address of the saved ephemeral sweep start. |
+| `background_saved_lowest_address` | The lowest address saved for background GC state. |
+| `background_saved_highest_address` | The highest address saved for background GC state. |
+| `generation_table` | An array of [DacpGenerationData structures](dacpgenerationdata-structure.md) with data for each GC generation. |
+| `ephemeral_heap_segment` | The address of the ephemeral heap segment. |
+| `finalization_fill_pointers` | An array of finalization fill pointers. |
+| `lowest_address` | The lowest address in the heap. |
+| `highest_address` | The highest address in the heap. |
+| `card_table` | The address of the GC card table. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetGCHeapStaticData` for workstation GC or `ISOSDacInterface::GetGCHeapDetails` for server GC. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)
+- [DacpGenerationData Structure](dacpgenerationdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/dacpgcheapdetails-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpgcheapdetails-structure.md
@@ -49,7 +49,7 @@ struct DacpGcHeapDetails : ZeroInit<DacpGcHeapDetails>
     CLRDATA_ADDRESS highest_address;
     CLRDATA_ADDRESS card_table;
 
-    // Use this for workstation mode (DacpGcHeapDat.bServerMode==FALSE).
+    // Use this for workstation mode (DacpGcHeapData.bServerMode==FALSE).
     HRESULT Request(ISOSDacInterface *sos)
     {
         return sos->GetGCHeapStaticData(this);

--- a/docs/framework/unmanaged-api/debugging/dacpgenerationdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpgenerationdata-structure.md
@@ -1,0 +1,64 @@
+---
+description: "Learn more about: DacpGenerationData Structure"
+title: "DacpGenerationData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpGenerationData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpGenerationData Structure"
+helpviewer.keywords:
+  - "DacpGenerationData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpGenerationData Structure
+
+Defines a transport buffer for garbage collection generation information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpGenerationData : ZeroInit<DacpGenerationData>
+{    
+    CLRDATA_ADDRESS start_segment;
+    CLRDATA_ADDRESS allocation_start;
+
+    // These are examined only for generation 0, otherwise NULL
+    CLRDATA_ADDRESS allocContextPtr;
+    CLRDATA_ADDRESS allocContextLimit;
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `start_segment` | The address of the first heap segment for the generation. |
+| `allocation_start` | The address where allocation starts for the generation. |
+| `allocContextPtr` | The current allocation context pointer for generation 0; otherwise `NULL`. |
+| `allocContextLimit` | The allocation context limit for generation 0; otherwise `NULL`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpheapsegmentdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpheapsegmentdata-structure.md
@@ -1,0 +1,98 @@
+---
+description: "Learn more about: DacpHeapSegmentData Structure"
+title: "DacpHeapSegmentData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpHeapSegmentData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpHeapSegmentData Structure"
+helpviewer.keywords:
+  - "DacpHeapSegmentData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpHeapSegmentData Structure
+
+Defines a transport buffer for garbage collection heap segment information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpHeapSegmentData
+    : ZeroInit<DacpHeapSegmentData>
+{
+    CLRDATA_ADDRESS segmentAddr;
+    CLRDATA_ADDRESS allocated;
+    CLRDATA_ADDRESS committed;
+    CLRDATA_ADDRESS reserved;
+    CLRDATA_ADDRESS used;
+    CLRDATA_ADDRESS mem;
+    // pass this to request if non-null to get the next segments.
+    CLRDATA_ADDRESS next;
+    CLRDATA_ADDRESS gc_heap; // only filled in in server mode, otherwise NULL
+    // computed field: if this is the ephemeral segment highMark includes the ephemeral generation
+    CLRDATA_ADDRESS highAllocMark;
+
+    size_t flags;
+    CLRDATA_ADDRESS background_allocated;
+
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr, const DacpGcHeapDetails& heap)
+    {
+        HRESULT hr = sos->GetHeapSegmentData(addr, this);
+
+        // if this is the start segment, set highAllocMark too.
+        if (SUCCEEDED(hr))
+        {
+            // TODO:  This needs to be put on the Dac side.
+            if (this->segmentAddr == heap.generation_table[0].start_segment)
+                highAllocMark = heap.alloc_allocated;
+            else
+                highAllocMark = allocated;
+        }    
+        return hr;
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `segmentAddr` | The address of the heap segment. |
+| `allocated` | The address of the allocated portion of the segment. |
+| `committed` | The address up to which memory is committed for the segment. |
+| `reserved` | The address up to which memory is reserved for the segment. |
+| `used` | The address up to which memory is used for the segment. |
+| `mem` | The start address of the segment memory. |
+| `next` | The address of the next segment. Pass this value to `Request` if it is non-null to retrieve the next segment. |
+| `gc_heap` | The address of the GC heap. This member is filled only in server mode; otherwise, it is `NULL`. |
+| `highAllocMark` | The high allocation mark. If this segment is the ephemeral segment, this value includes the ephemeral generation. |
+| `flags` | The heap segment flags. |
+| `background_allocated` | The background GC allocated address for the segment. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetHeapSegmentData` and computes `highAllocMark`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)
+- [DacpGcHeapDetails Structure](dacpgcheapdetails-structure.md)

--- a/docs/framework/unmanaged-api/debugging/dacpjitcodeheapinfo-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpjitcodeheapinfo-structure.md
@@ -1,0 +1,71 @@
+---
+description: "Learn more about: DacpJitCodeHeapInfo Structure"
+title: "DacpJitCodeHeapInfo Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpJitCodeHeapInfo Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpJitCodeHeapInfo Structure"
+helpviewer.keywords:
+  - "DacpJitCodeHeapInfo Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpJitCodeHeapInfo Structure
+
+Defines a transport buffer for JIT code heap information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpJitCodeHeapInfo : ZeroInit<DacpJitCodeHeapInfo>
+{
+    DWORD codeHeapType; // for union below
+
+    union
+    {
+        CLRDATA_ADDRESS LoaderHeap;    // if CODEHEAP_LOADER
+        struct
+        {
+            CLRDATA_ADDRESS baseAddr; // if CODEHEAP_HOST
+            CLRDATA_ADDRESS currentAddr;
+        } HostData;
+    };
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `codeHeapType` | The code heap type value. |
+| `LoaderHeap` | The address of the loader heap when `codeHeapType` is `CODEHEAP_LOADER`. |
+| `HostData` | Host code heap data when `codeHeapType` is `CODEHEAP_HOST`. |
+| `HostData.baseAddr` | The base address of the host code heap. |
+| `HostData.currentAddr` | The current address in the host code heap. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpjitcodeheapinfo-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpjitcodeheapinfo-structure.md
@@ -64,7 +64,6 @@ This structure lives inside the runtime and is not exposed through any headers o
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
 
-
 ## See also
 
 - [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/dacpjitmanagerinfo-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpjitmanagerinfo-structure.md
@@ -54,7 +54,6 @@ This structure lives inside the runtime and is not exposed through any headers o
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
 
-
 ## See also
 
 - [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/dacpjitmanagerinfo-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpjitmanagerinfo-structure.md
@@ -1,0 +1,61 @@
+---
+description: "Learn more about: DacpJitManagerInfo Structure"
+title: "DacpJitManagerInfo Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpJitManagerInfo Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpJitManagerInfo Structure"
+helpviewer.keywords:
+  - "DacpJitManagerInfo Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpJitManagerInfo Structure
+
+Defines a transport buffer for JIT manager information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpJitManagerInfo : ZeroInit<DacpJitManagerInfo>
+{
+    CLRDATA_ADDRESS managerAddr;
+    DWORD codeType; // for union below
+    CLRDATA_ADDRESS ptrHeapList;    // A HeapList * if IsMiIL(codeType)
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `managerAddr` | The address of the JIT manager. |
+| `codeType` | The JIT code type value. |
+| `ptrHeapList` | The address of the heap list when `codeType` represents MiIL code. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpmethodtabledata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpmethodtabledata-structure.md
@@ -1,0 +1,90 @@
+---
+description: "Learn more about: DacpMethodTableData Structure"
+title: "DacpMethodTableData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpMethodTableData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpMethodTableData Structure"
+helpviewer.keywords:
+  - "DacpMethodTableData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpMethodTableData Structure
+
+Defines a transport buffer for method table information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpMethodTableData : ZeroInit<DacpMethodTableData>
+{
+    BOOL bIsFree; // everything else is NULL if this is true.
+    CLRDATA_ADDRESS Module;
+    CLRDATA_ADDRESS Class;
+    CLRDATA_ADDRESS ParentMethodTable;
+    WORD wNumInterfaces;
+    WORD wNumMethods;
+    WORD wNumVtableSlots;
+    WORD wNumVirtuals;
+    DWORD BaseSize;
+    DWORD ComponentSize;
+    mdTypeDef cl; // Metadata token    
+    DWORD dwAttrClass; // cached metadata
+    BOOL bIsShared; // flags & enum_flag_DomainNeutral
+    BOOL bIsDynamic;
+    BOOL bContainsPointers;
+    
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr)
+    {
+        return sos->GetMethodTableData(addr, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `bIsFree` | A value that indicates whether the method table is free. If this member is `TRUE`, all other members are `NULL`. |
+| `Module` | The address of the module that contains the method table. |
+| `Class` | The address of the EEClass for the method table. |
+| `ParentMethodTable` | The address of the parent method table. |
+| `wNumInterfaces` | The number of interfaces implemented by the type. |
+| `wNumMethods` | The number of methods on the method table. |
+| `wNumVtableSlots` | The number of vtable slots on the method table. |
+| `wNumVirtuals` | The number of virtual methods on the method table. |
+| `BaseSize` | The base size for instances of the type. |
+| `ComponentSize` | The component size for array or string instances. |
+| `cl` | The metadata token for the type. |
+| `dwAttrClass` | The cached metadata attributes for the type. |
+| `bIsShared` | A value that indicates whether the method table is shared. |
+| `bIsDynamic` | A value that indicates whether the method table represents a dynamic type. |
+| `bContainsPointers` | A value that indicates whether instances of the type contain object references. |
+| `Request` | Populates the structure from a method table address by calling `ISOSDacInterface::GetMethodTableData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpmethodtablefielddata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpmethodtablefielddata-structure.md
@@ -1,0 +1,74 @@
+---
+description: "Learn more about: DacpMethodTableFieldData Structure"
+title: "DacpMethodTableFieldData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpMethodTableFieldData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpMethodTableFieldData Structure"
+helpviewer.keywords:
+  - "DacpMethodTableFieldData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpMethodTableFieldData Structure
+
+Defines a transport buffer for method table field information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpMethodTableFieldData : ZeroInit<DacpMethodTableFieldData>
+{
+    WORD wNumInstanceFields;
+    WORD wNumStaticFields;
+    WORD wNumThreadStaticFields;
+
+    CLRDATA_ADDRESS FirstField; // If non-null, you can retrieve more
+    
+    WORD wContextStaticOffset;
+    WORD wContextStaticsSize;
+    
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr)
+    {
+        return sos->GetMethodTableFieldData(addr, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `wNumInstanceFields` | The number of instance fields. |
+| `wNumStaticFields` | The number of static fields. |
+| `wNumThreadStaticFields` | The number of thread-static fields. |
+| `FirstField` | The address of the first field. If this member is non-null, you can retrieve more fields. |
+| `wContextStaticOffset` | The context-static field offset. |
+| `wContextStaticsSize` | The size of the context-static fields. |
+| `Request` | Populates the structure from a method table address by calling `ISOSDacInterface::GetMethodTableFieldData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpobjectdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpobjectdata-structure.md
@@ -1,0 +1,88 @@
+---
+description: "Learn more about: DacpObjectData Structure"
+title: "DacpObjectData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpObjectData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpObjectData Structure"
+helpviewer.keywords:
+  - "DacpObjectData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpObjectData Structure
+
+Defines a transport buffer for runtime object information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpObjectData : ZeroInit<DacpObjectData>
+{
+    CLRDATA_ADDRESS MethodTable;
+    DacpObjectType ObjectType;
+    ULONG64 Size;
+    CLRDATA_ADDRESS ElementTypeHandle;
+    CorElementType ElementType;
+    DWORD dwRank;
+    ULONG64 dwNumComponents;
+    ULONG64 dwComponentSize;
+    CLRDATA_ADDRESS ArrayDataPtr;
+    CLRDATA_ADDRESS ArrayBoundsPtr;
+    CLRDATA_ADDRESS ArrayLowerBoundsPtr;
+
+    CLRDATA_ADDRESS RCW;
+    CLRDATA_ADDRESS CCW;
+    
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr)
+    {
+        return sos->GetObjectData(addr, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `MethodTable` | The address of the object's method table. |
+| `ObjectType` | A [DacpObjectType enumeration](dacpobjecttype-enumeration.md) value that identifies the object type. |
+| `Size` | The size of the object, in bytes. |
+| `ElementTypeHandle` | For arrays, the address of the element type handle. |
+| `ElementType` | For arrays, the CorElementType value for the element type. |
+| `dwRank` | For arrays, the number of dimensions. |
+| `dwNumComponents` | For arrays, the number of elements. |
+| `dwComponentSize` | For arrays, the size of each component, in bytes. |
+| `ArrayDataPtr` | For arrays, the address of the array data. |
+| `ArrayBoundsPtr` | For arrays, the address of the array bounds. |
+| `ArrayLowerBoundsPtr` | For arrays, the address of the array lower bounds. |
+| `RCW` | The address of the runtime callable wrapper associated with the object. |
+| `CCW` | The address of the COM callable wrapper associated with the object. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetObjectData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)
+- [DacpObjectType Enumeration](dacpobjecttype-enumeration.md)

--- a/docs/framework/unmanaged-api/debugging/dacpobjecttype-enumeration.md
+++ b/docs/framework/unmanaged-api/debugging/dacpobjecttype-enumeration.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: DacpObjectType Enumeration"
+title: "DacpObjectType Enumeration"
+ms.date: "07/30/2026"
+api_name:
+  - "DacpObjectType"
+api_location:
+  - "mscordacwks.dll"
+api_type:
+  - "COM"
+f1_keywords:
+  - "DacpObjectType"
+helpviewer_keywords:
+  - "DacpObjectType enumeration [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpObjectType Enumeration
+
+Indicates the type of runtime object.
+
+## Syntax
+
+```cpp
+enum DacpObjectType { OBJ_STRING=0,OBJ_FREE,OBJ_OBJECT,OBJ_ARRAY,OBJ_OTHER };
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `OBJ_STRING` | The object is a string. |
+| `OBJ_FREE` | The object is free space on the managed heap. |
+| `OBJ_OBJECT` | The object is a non-array object. |
+| `OBJ_ARRAY` | The object is an array. |
+| `OBJ_OTHER` | The object is another object type. |
+
+## Remarks
+
+This enumeration lives inside the runtime and is not exposed through any headers or library files. To use it, define the enumeration as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging Enumerations](debugging-enumerations.md)
+- [Debugging](index.md)
+- [DacpObjectData Structure](dacpobjectdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/dacpoomdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpoomdata-structure.md
@@ -1,0 +1,81 @@
+---
+description: "Learn more about: DacpOomData Structure"
+title: "DacpOomData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpOomData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpOomData Structure"
+helpviewer.keywords:
+  - "DacpOomData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpOomData Structure
+
+Defines a transport buffer for garbage collector out-of-memory information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpOomData : ZeroInit<DacpOomData>
+{
+    int reason;
+    ULONG64 alloc_size;
+    ULONG64 available_pagefile_mb;
+    ULONG64 gc_index;
+    int fgm;
+    ULONG64 size;
+    BOOL loh_p;
+
+    HRESULT Request(ISOSDacInterface *sos)
+    {
+        return sos->GetOOMStaticData(this);
+    }
+
+    // Use this for Server mode, as there are multiple heaps,
+    // and you need to pass a heap address in addr.
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr)
+    {
+        return sos->GetOOMData(addr, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `reason` | The out-of-memory reason code. |
+| `alloc_size` | The allocation size that contributed to the out-of-memory condition. |
+| `available_pagefile_mb` | The amount of available page file space, in megabytes. |
+| `gc_index` | The GC index associated with the out-of-memory condition. |
+| `fgm` | A value associated with full GC mechanisms for the out-of-memory condition. |
+| `size` | The size value associated with the out-of-memory condition. |
+| `loh_p` | A value that indicates whether the allocation was for the large object heap. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetOOMStaticData` or `ISOSDacInterface::GetOOMData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacprcwdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacprcwdata-structure.md
@@ -1,0 +1,106 @@
+---
+description: "Learn more about: DacpRCWData Structure"
+title: "DacpRCWData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpRCWData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpRCWData Structure"
+helpviewer.keywords:
+  - "DacpRCWData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpRCWData Structure
+
+Defines a transport buffer for runtime callable wrapper (RCW) information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpRCWData : ZeroInit<DacpRCWData>
+{
+    CLRDATA_ADDRESS identityPointer;
+    CLRDATA_ADDRESS unknownPointer;
+    CLRDATA_ADDRESS managedObject;
+    CLRDATA_ADDRESS jupiterObject;
+    CLRDATA_ADDRESS vtablePtr;
+    CLRDATA_ADDRESS creatorThread;
+    CLRDATA_ADDRESS ctxCookie;
+    
+    LONG refCount;
+    LONG interfaceCount;
+
+    BOOL isJupiterObject;
+    BOOL supportsIInspectable;
+    BOOL isAggregated;
+    BOOL isContained;
+    BOOL isFreeThreaded;
+    BOOL isDisconnected;
+    
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS rcw)
+    {
+        return sos->GetRCWData(rcw, this);
+    }
+
+    HRESULT IsDCOMProxy(ISOSDacInterface *sos, CLRDATA_ADDRESS rcw, BOOL* isDCOMProxy)
+    {
+        ISOSDacInterface2 *pSOS2 = nullptr;
+        HRESULT hr = sos->QueryInterface(__uuidof(ISOSDacInterface2), reinterpret_cast<LPVOID*>(&pSOS2));
+        if (SUCCEEDED(hr))
+        {
+            hr = pSOS2->IsRCWDCOMProxy(rcw, isDCOMProxy);
+            pSOS2->Release();
+        }
+
+        return hr;
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `identityPointer` | The address of the COM identity pointer. |
+| `unknownPointer` | The address of the `IUnknown` pointer. |
+| `managedObject` | The address of the managed object associated with the RCW. |
+| `jupiterObject` | The address of the associated Jupiter object. |
+| `vtablePtr` | The address of the vtable pointer. |
+| `creatorThread` | The address of the thread that created the RCW. |
+| `ctxCookie` | The context cookie for the RCW. |
+| `refCount` | The reference count for the RCW. |
+| `interfaceCount` | The number of interfaces associated with the RCW. |
+| `isJupiterObject` | A value that indicates whether the RCW represents a Jupiter object. |
+| `supportsIInspectable` | A value that indicates whether the RCW supports `IInspectable`. |
+| `isAggregated` | A value that indicates whether the RCW is aggregated. |
+| `isContained` | A value that indicates whether the RCW is contained. |
+| `isFreeThreaded` | A value that indicates whether the RCW is free-threaded. |
+| `isDisconnected` | A value that indicates whether the RCW is disconnected. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetRCWData`. |
+| `IsDCOMProxy` | Determines whether the RCW is a DCOM proxy by using `ISOSDacInterface2::IsRCWDCOMProxy`, when that interface is available. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpsyncblockcleanupdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpsyncblockcleanupdata-structure.md
@@ -1,0 +1,72 @@
+---
+description: "Learn more about: DacpSyncBlockCleanupData Structure"
+title: "DacpSyncBlockCleanupData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpSyncBlockCleanupData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpSyncBlockCleanupData Structure"
+helpviewer.keywords:
+  - "DacpSyncBlockCleanupData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpSyncBlockCleanupData Structure
+
+Defines a transport buffer for sync block cleanup information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpSyncBlockCleanupData : ZeroInit<DacpSyncBlockCleanupData>
+{
+    CLRDATA_ADDRESS SyncBlockPointer;
+    
+    CLRDATA_ADDRESS nextSyncBlock;
+    CLRDATA_ADDRESS blockRCW;
+    CLRDATA_ADDRESS blockClassFactory;
+    CLRDATA_ADDRESS blockCCW;
+    
+    // Pass NULL on the first request to start a traversal.
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS psyncBlock)
+    {
+        return sos->GetSyncBlockCleanupData(psyncBlock, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `SyncBlockPointer` | The address of the sync block. |
+| `nextSyncBlock` | The address of the next sync block in the cleanup list. |
+| `blockRCW` | The address of the runtime callable wrapper associated with the sync block. |
+| `blockClassFactory` | The address of the class factory associated with the sync block. |
+| `blockCCW` | The address of the COM callable wrapper associated with the sync block. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetSyncBlockCleanupData`. Pass `NULL` on the first request to start a traversal. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpsyncblockdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpsyncblockdata-structure.md
@@ -1,0 +1,88 @@
+---
+description: "Learn more about: DacpSyncBlockData Structure"
+title: "DacpSyncBlockData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpSyncBlockData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpSyncBlockData Structure"
+helpviewer.keywords:
+  - "DacpSyncBlockData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpSyncBlockData Structure
+
+Defines a transport buffer for sync block information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpSyncBlockData : ZeroInit<DacpSyncBlockData>
+{        
+    CLRDATA_ADDRESS Object;
+    BOOL            bFree; // if set, no other fields are useful
+    
+    // fields below provide data from this, so it's just for display
+    CLRDATA_ADDRESS SyncBlockPointer;
+    DWORD           COMFlags;
+    UINT            MonitorHeld;
+    UINT            Recursion;
+    CLRDATA_ADDRESS HoldingThread;
+    UINT            AdditionalThreadCount;
+    CLRDATA_ADDRESS appDomainPtr;
+    
+    // SyncBlockCount will always be filled in with the number of SyncBlocks.
+    // SyncBlocks may be requested from [1,SyncBlockCount]
+    UINT            SyncBlockCount;
+
+    // SyncBlockNumber must be from [1,SyncBlockCount]    
+    // If there are no SyncBlocks, a call to Request with SyncBlockCount = 1
+    // will return E_FAIL.
+    HRESULT Request(ISOSDacInterface *sos, UINT SyncBlockNumber)
+    {
+        return sos->GetSyncBlockData(SyncBlockNumber, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `Object` | The address of the object associated with the sync block. |
+| `bFree` | A value that indicates whether the sync block is free. If this member is set, no other fields are useful. |
+| `SyncBlockPointer` | The address of the sync block. |
+| `COMFlags` | Flags that describe COM interop data associated with the sync block. |
+| `MonitorHeld` | The number of times the monitor is held. |
+| `Recursion` | The monitor recursion count. |
+| `HoldingThread` | The address of the thread that holds the monitor. |
+| `AdditionalThreadCount` | The number of additional threads associated with the sync block. |
+| `appDomainPtr` | The address of the application domain associated with the sync block. |
+| `SyncBlockCount` | The number of sync blocks. Sync blocks can be requested from 1 through this value. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetSyncBlockData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpthreaddata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpthreaddata-structure.md
@@ -1,0 +1,90 @@
+---
+description: "Learn more about: DacpThreadData Structure"
+title: "DacpThreadData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpThreadData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpThreadData Structure"
+helpviewer.keywords:
+  - "DacpThreadData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpThreadData Structure
+
+Defines a transport buffer for runtime thread information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpThreadData : ZeroInit<DacpThreadData>
+{
+    DWORD corThreadId;
+    DWORD osThreadId;
+    int state;
+    ULONG preemptiveGCDisabled;
+    CLRDATA_ADDRESS allocContextPtr;
+    CLRDATA_ADDRESS allocContextLimit;
+    CLRDATA_ADDRESS context;
+    CLRDATA_ADDRESS domain;
+    CLRDATA_ADDRESS pFrame;
+    DWORD lockCount;
+    CLRDATA_ADDRESS firstNestedException; // Pass this pointer to DacpNestedExceptionInfo
+    CLRDATA_ADDRESS teb;
+    CLRDATA_ADDRESS fiberData;
+    CLRDATA_ADDRESS lastThrownObjectHandle;
+    CLRDATA_ADDRESS nextThread;
+
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr)
+    {
+        return sos->GetThreadData(addr, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `corThreadId` | The managed thread identifier. |
+| `osThreadId` | The operating system thread identifier. |
+| `state` | The thread state flags. |
+| `preemptiveGCDisabled` | A value that indicates whether preemptive garbage collection is disabled for the thread. |
+| `allocContextPtr` | The current allocation context pointer for the thread. |
+| `allocContextLimit` | The allocation context limit for the thread. |
+| `context` | The address of the thread context. |
+| `domain` | The address of the application domain for the thread. |
+| `pFrame` | The address of the current frame. |
+| `lockCount` | The number of locks held by the thread. |
+| `firstNestedException` | The address of the first nested exception. Pass this pointer to `DacpNestedExceptionInfo`. |
+| `teb` | The address of the thread environment block. |
+| `fiberData` | The address of the fiber data. |
+| `lastThrownObjectHandle` | The handle for the last object thrown on the thread. |
+| `nextThread` | The address of the next thread in the runtime thread list. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetThreadData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpthreadlocalmoduledata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpthreadlocalmoduledata-structure.md
@@ -29,8 +29,7 @@ Defines a transport buffer for thread-local module information.
 ```cpp
 struct DacpThreadLocalModuleData : ZeroInit<DacpThreadLocalModuleData>
 {
-    // These two parameters are used as input params when calling the
-    // no-argument form of Request below.
+    // These two parameters are used as input parameters when populating the structure.
     CLRDATA_ADDRESS threadAddr;
     ULONG64 ModuleIndex;
     

--- a/docs/framework/unmanaged-api/debugging/dacpthreadlocalmoduledata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpthreadlocalmoduledata-structure.md
@@ -1,0 +1,69 @@
+---
+description: "Learn more about: DacpThreadLocalModuleData Structure"
+title: "DacpThreadLocalModuleData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpThreadLocalModuleData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpThreadLocalModuleData Structure"
+helpviewer.keywords:
+  - "DacpThreadLocalModuleData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpThreadLocalModuleData Structure
+
+Defines a transport buffer for thread-local module information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpThreadLocalModuleData : ZeroInit<DacpThreadLocalModuleData>
+{
+    // These two parameters are used as input params when calling the
+    // no-argument form of Request below.
+    CLRDATA_ADDRESS threadAddr;
+    ULONG64 ModuleIndex;
+    
+    CLRDATA_ADDRESS pClassData;   
+    CLRDATA_ADDRESS pDynamicClassTable;   
+    CLRDATA_ADDRESS pGCStaticDataStart;
+    CLRDATA_ADDRESS pNonGCStaticDataStart;
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `threadAddr` | The address of the thread used as an input parameter for a request. |
+| `ModuleIndex` | The module index used as an input parameter for a request. |
+| `pClassData` | The address of the class data. |
+| `pDynamicClassTable` | The address of the dynamic class table. |
+| `pGCStaticDataStart` | The start address for garbage-collected static data. |
+| `pNonGCStaticDataStart` | The start address for non-garbage-collected static data. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpthreadpooldata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpthreadpooldata-structure.md
@@ -1,0 +1,104 @@
+---
+description: "Learn more about: DacpThreadpoolData Structure"
+title: "DacpThreadpoolData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpThreadpoolData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpThreadpoolData Structure"
+helpviewer.keywords:
+  - "DacpThreadpoolData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpThreadpoolData Structure
+
+Defines a transport buffer for runtime thread pool information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpThreadpoolData : ZeroInit<DacpThreadpoolData>
+{
+    LONG cpuUtilization;    
+    int NumIdleWorkerThreads;
+    int NumWorkingWorkerThreads;
+    int NumRetiredWorkerThreads;
+    LONG MinLimitTotalWorkerThreads;
+    LONG MaxLimitTotalWorkerThreads;
+
+    CLRDATA_ADDRESS FirstUnmanagedWorkRequest;
+
+    CLRDATA_ADDRESS HillClimbingLog;
+    int HillClimbingLogFirstIndex;
+    int HillClimbingLogSize;
+
+    DWORD NumTimers;
+    // TODO: mstanton, stuff to enumerate timers too...
+
+    LONG   NumCPThreads;
+    LONG   NumFreeCPThreads;
+    LONG   MaxFreeCPThreads; 
+    LONG   NumRetiredCPThreads;
+    LONG   MaxLimitTotalCPThreads;
+    LONG   CurrentLimitTotalCPThreads;
+    LONG   MinLimitTotalCPThreads;
+
+    CLRDATA_ADDRESS AsyncTimerCallbackCompletionFPtr;
+    
+    HRESULT Request(ISOSDacInterface *sos)
+    {
+        return sos->GetThreadpoolData(this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `cpuUtilization` | The CPU utilization value used by the thread pool. |
+| `NumIdleWorkerThreads` | The number of idle worker threads. |
+| `NumWorkingWorkerThreads` | The number of active worker threads. |
+| `NumRetiredWorkerThreads` | The number of retired worker threads. |
+| `MinLimitTotalWorkerThreads` | The minimum total worker thread limit. |
+| `MaxLimitTotalWorkerThreads` | The maximum total worker thread limit. |
+| `FirstUnmanagedWorkRequest` | The address of the first unmanaged work request. |
+| `HillClimbingLog` | The address of the hill climbing log. |
+| `HillClimbingLogFirstIndex` | The first index in the hill climbing log. |
+| `HillClimbingLogSize` | The size of the hill climbing log. |
+| `NumTimers` | The number of timers. |
+| `NumCPThreads` | The number of completion port threads. |
+| `NumFreeCPThreads` | The number of free completion port threads. |
+| `MaxFreeCPThreads` | The maximum number of free completion port threads. |
+| `NumRetiredCPThreads` | The number of retired completion port threads. |
+| `MaxLimitTotalCPThreads` | The maximum total completion port thread limit. |
+| `CurrentLimitTotalCPThreads` | The current total completion port thread limit. |
+| `MinLimitTotalCPThreads` | The minimum total completion port thread limit. |
+| `AsyncTimerCallbackCompletionFPtr` | The address of the asynchronous timer callback completion function pointer. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetThreadpoolData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpthreadpooldata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpthreadpooldata-structure.md
@@ -43,7 +43,6 @@ struct DacpThreadpoolData : ZeroInit<DacpThreadpoolData>
     int HillClimbingLogSize;
 
     DWORD NumTimers;
-    // TODO: mstanton, stuff to enumerate timers too...
 
     LONG   NumCPThreads;
     LONG   NumFreeCPThreads;

--- a/docs/framework/unmanaged-api/debugging/dacpthreadstoredata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpthreadstoredata-structure.md
@@ -38,7 +38,7 @@ struct DacpThreadStoreData : ZeroInit<DacpThreadStoreData>
     CLRDATA_ADDRESS finalizerThread;
     CLRDATA_ADDRESS gcThread;
     DWORD fHostConfig;          // Uses hosting flags defined above
-	
+ 
     HRESULT Request(ISOSDacInterface *sos)
     {
         return sos->GetThreadStoreData(this);

--- a/docs/framework/unmanaged-api/debugging/dacpthreadstoredata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpthreadstoredata-structure.md
@@ -1,0 +1,78 @@
+---
+description: "Learn more about: DacpThreadStoreData Structure"
+title: "DacpThreadStoreData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpThreadStoreData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpThreadStoreData Structure"
+helpviewer.keywords:
+  - "DacpThreadStoreData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpThreadStoreData Structure
+
+Defines a transport buffer for runtime thread store information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpThreadStoreData : ZeroInit<DacpThreadStoreData>
+{
+    LONG threadCount;
+    LONG unstartedThreadCount;
+    LONG backgroundThreadCount;
+    LONG pendingThreadCount;
+    LONG deadThreadCount;
+    CLRDATA_ADDRESS firstThread;
+    CLRDATA_ADDRESS finalizerThread;
+    CLRDATA_ADDRESS gcThread;
+    DWORD fHostConfig;          // Uses hosting flags defined above
+	
+    HRESULT Request(ISOSDacInterface *sos)
+    {
+        return sos->GetThreadStoreData(this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `threadCount` | The total number of runtime threads. |
+| `unstartedThreadCount` | The number of threads that have not started. |
+| `backgroundThreadCount` | The number of background threads. |
+| `pendingThreadCount` | The number of pending threads. |
+| `deadThreadCount` | The number of dead threads. |
+| `firstThread` | The address of the first thread in the runtime thread list. |
+| `finalizerThread` | The address of the finalizer thread. |
+| `gcThread` | The address of the garbage collection thread. |
+| `fHostConfig` | A bitmask of runtime hosting flags such as `CLRMEMORYHOSTED`, `CLRTASKHOSTED`, and `CLRHOSTED`. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetThreadStoreData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpusefulglobalsdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpusefulglobalsdata-structure.md
@@ -58,7 +58,6 @@ This structure lives inside the runtime and is not exposed through any headers o
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
 
-
 ## See also
 
 - [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/dacpusefulglobalsdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpusefulglobalsdata-structure.md
@@ -1,0 +1,65 @@
+---
+description: "Learn more about: DacpUsefulGlobalsData Structure"
+title: "DacpUsefulGlobalsData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpUsefulGlobalsData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpUsefulGlobalsData Structure"
+helpviewer.keywords:
+  - "DacpUsefulGlobalsData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpUsefulGlobalsData Structure
+
+Defines a transport buffer for global runtime method table addresses.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpUsefulGlobalsData : ZeroInit<DacpUsefulGlobalsData>
+{
+    CLRDATA_ADDRESS ArrayMethodTable;
+    CLRDATA_ADDRESS StringMethodTable;
+    CLRDATA_ADDRESS ObjectMethodTable;
+    CLRDATA_ADDRESS ExceptionMethodTable;
+    CLRDATA_ADDRESS FreeMethodTable;
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `ArrayMethodTable` | The address of the array method table. |
+| `StringMethodTable` | The address of the string method table. |
+| `ObjectMethodTable` | The address of the object method table. |
+| `ExceptionMethodTable` | The address of the exception method table. |
+| `FreeMethodTable` | The address of the free object method table. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/dacpworkrequestdata-structure.md
+++ b/docs/framework/unmanaged-api/debugging/dacpworkrequestdata-structure.md
@@ -1,0 +1,66 @@
+---
+description: "Learn more about: DacpWorkRequestData Structure"
+title: "DacpWorkRequestData Structure"
+ms.date: "07/30/2026"
+api.name:
+  - "DacpWorkRequestData Structure"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "DacpWorkRequestData Structure"
+helpviewer.keywords:
+  - "DacpWorkRequestData Structure [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# DacpWorkRequestData Structure
+
+Defines a transport buffer for thread pool work request information.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+struct DacpWorkRequestData : ZeroInit<DacpWorkRequestData>
+{
+    CLRDATA_ADDRESS Function;
+    CLRDATA_ADDRESS Context;
+    CLRDATA_ADDRESS NextWorkRequest;
+        
+    HRESULT Request(ISOSDacInterface *sos, CLRDATA_ADDRESS addr)
+    {
+        return sos->GetWorkRequestData(addr, this);
+    }
+};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `Function` | The address of the function associated with the work request. |
+| `Context` | The address of the context associated with the work request. |
+| `NextWorkRequest` | The address of the next work request. |
+| `Request` | Populates the structure by calling `ISOSDacInterface::GetWorkRequestData`. |
+
+## Remarks
+
+This structure lives inside the runtime and is not exposed through any headers or library files. To use it, define the structure as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [Debugging Structures](debugging-structures.md)

--- a/docs/framework/unmanaged-api/debugging/debugging-enumerations.md
+++ b/docs/framework/unmanaged-api/debugging/debugging-enumerations.md
@@ -61,6 +61,15 @@ This section describes the unmanaged enumerations that the debugging API uses.
  [CorDebugJITCompilerFlagsDeprecated enumeration](cordebugjitcompilerflagsdeprecated-enumeration.md)\
  Obsolete. Use the `CORDEBUG_JIT_DEFAULT` member of the [CorDebugJITCompilerFlags](../../../core/unmanaged-api/debugging/icordebug/cordebugjitcompilerflags-enumeration.md) enumeration instead.
 
+ [DacpObjectType Enumeration](dacpobjecttype-enumeration.md)\
+ Indicates the type of runtime object.
+
+ [ModuleMapType Enumeration](modulemaptype-enumeration.md)\
+ Indicates the kind of module map to traverse.
+
+ [VCSHeapType Enumeration](vcsheaptype-enumeration.md)\
+ Identifies a virtual call stub heap type.
+
 ## Related Sections
 
  [Debugging Coclasses](debugging-coclasses.md)

--- a/docs/framework/unmanaged-api/debugging/debugging-structures.md
+++ b/docs/framework/unmanaged-api/debugging/debugging-structures.md
@@ -47,6 +47,90 @@ This section describes the unmanaged structures that the debugging API uses.
  [StackTrace_SimpleContext Structure](stacktrace-simplecontext-structure.md)\
  Provides a simple context that can be used in place of a full `CONTEXT` structure.
 
+ [DacpAppDomainData Structure](dacpappdomaindata-structure.md)\
+ Defines a transport buffer for runtime application domain information.
+
+ [DacpAppDomainStoreData Structure](dacpappdomainstoredata-structure.md)\
+ Defines a transport buffer for runtime application domain store information.
+
+ [DacpAssemblyData Structure](dacpassemblydata-structure.md)\
+ Defines a transport buffer for runtime assembly information.
+
+ [DacpCCWData Structure](dacpccwdata-structure.md)\
+ Defines a transport buffer for COM callable wrapper (CCW) information.
+
+ [DacpCodeHeaderData Structure](dacpcodeheaderdata-structure.md)\
+ Defines a transport buffer for JIT-compiled code header information.
+
+ [DacpCOMInterfacePointerData Structure](dacpcominterfacepointerdata-structure.md)\
+ Defines a transport buffer for COM interface pointer information.
+
+ [DacpDomainLocalModuleData Structure](dacpdomainlocalmoduledata-structure.md)\
+ Defines a transport buffer for domain-local module information.
+
+ [DacpFieldDescData Structure](dacpfielddescdata-structure.md)\
+ Defines a transport buffer for FieldDesc information.
+
+ [DacpGcHeapAnalyzeData Structure](dacpgcheapanalyzedata-structure.md)\
+ Defines a transport buffer for garbage collection heap analysis information.
+
+ [DacpGcHeapData Structure](dacpgcheapdata-structure.md)\
+ Defines a transport buffer for general garbage collection heap information.
+
+ [DacpGcHeapDetails Structure](dacpgcheapdetails-structure.md)\
+ Defines a transport buffer for detailed garbage collection heap information.
+
+ [DacpGenerationData Structure](dacpgenerationdata-structure.md)\
+ Defines a transport buffer for garbage collection generation information.
+
+ [DacpHeapSegmentData Structure](dacpheapsegmentdata-structure.md)\
+ Defines a transport buffer for garbage collection heap segment information.
+
+ [DacpJitCodeHeapInfo Structure](dacpjitcodeheapinfo-structure.md)\
+ Defines a transport buffer for JIT code heap information.
+
+ [DacpJitManagerInfo Structure](dacpjitmanagerinfo-structure.md)\
+ Defines a transport buffer for JIT manager information.
+
+ [DacpMethodTableData Structure](dacpmethodtabledata-structure.md)\
+ Defines a transport buffer for method table information.
+
+ [DacpMethodTableFieldData Structure](dacpmethodtablefielddata-structure.md)\
+ Defines a transport buffer for method table field information.
+
+ [DacpObjectData Structure](dacpobjectdata-structure.md)\
+ Defines a transport buffer for runtime object information.
+
+ [DacpOomData Structure](dacpoomdata-structure.md)\
+ Defines a transport buffer for garbage collector out-of-memory information.
+
+ [DacpRCWData Structure](dacprcwdata-structure.md)\
+ Defines a transport buffer for runtime callable wrapper (RCW) information.
+
+ [DacpSyncBlockCleanupData Structure](dacpsyncblockcleanupdata-structure.md)\
+ Defines a transport buffer for sync block cleanup information.
+
+ [DacpSyncBlockData Structure](dacpsyncblockdata-structure.md)\
+ Defines a transport buffer for sync block information.
+
+ [DacpThreadData Structure](dacpthreaddata-structure.md)\
+ Defines a transport buffer for runtime thread information.
+
+ [DacpThreadLocalModuleData Structure](dacpthreadlocalmoduledata-structure.md)\
+ Defines a transport buffer for thread-local module information.
+
+ [DacpThreadpoolData Structure](dacpthreadpooldata-structure.md)\
+ Defines a transport buffer for runtime thread pool information.
+
+ [DacpThreadStoreData Structure](dacpthreadstoredata-structure.md)\
+ Defines a transport buffer for runtime thread store information.
+
+ [DacpUsefulGlobalsData Structure](dacpusefulglobalsdata-structure.md)\
+ Defines a transport buffer for global runtime method table addresses.
+
+ [DacpWorkRequestData Structure](dacpworkrequestdata-structure.md)\
+ Defines a transport buffer for thread pool work request information.
+
 ## Related Sections
 
  [Debugging Coclasses](debugging-coclasses.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getappdomaindata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getappdomaindata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetAppDomainData Method"
+title: "ISOSDacInterface::GetAppDomainData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetAppDomainData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetAppDomainData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetAppDomainData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetAppDomainData Method
+
+Retrieves data for the application domain at the specified address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetAppDomainData(CLRDATA_ADDRESS addr, struct DacpAppDomainData *data);
+```
+
+## Parameters
+
+`addr`\
+[in] The address of the application domain to retrieve information for.
+
+`data`\
+[out] A pointer to a [DacpAppDomainData structure](dacpappdomaindata-structure.md) that receives the application domain data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 7th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpAppDomainData Structure](dacpappdomaindata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getappdomaindata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getappdomaindata-method.md
@@ -54,3 +54,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpAppDomainData Structure](dacpappdomaindata-structure.md)
+- [ISOSDacInterface::GetAppDomainStoreData Method](isosdacinterface-getappdomainstoredata-method.md)
+- [ISOSDacInterface::GetAppDomainList Method](isosdacinterface-getappdomainlist-method.md)
+- [ISOSDacInterface::GetAssemblyData Method](isosdacinterface-getassemblydata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getappdomainlist-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getappdomainlist-method.md
@@ -56,3 +56,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::GetAppDomainStoreData Method](isosdacinterface-getappdomainstoredata-method.md)
+- [ISOSDacInterface::GetAppDomainData Method](isosdacinterface-getappdomaindata-method.md)
+- [ISOSDacInterface::GetAssemblyData Method](isosdacinterface-getassemblydata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getappdomainlist-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getappdomainlist-method.md
@@ -1,0 +1,58 @@
+---
+description: "Learn more about: ISOSDacInterface::GetAppDomainList Method"
+title: "ISOSDacInterface::GetAppDomainList Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetAppDomainList Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetAppDomainList Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetAppDomainList Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetAppDomainList Method
+
+Retrieves the list of application domains in the runtime.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetAppDomainList(unsigned int count, CLRDATA_ADDRESS values[], unsigned int *pNeeded);
+```
+
+## Parameters
+
+`count`\
+[in] The number of elements that the `values` array can hold.
+
+`values`\
+[out] An array of `CLRDATA_ADDRESS` values that receives the application domain addresses.
+
+`pNeeded`\
+[out] A pointer to the number of application domain addresses available.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 6th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getappdomainstoredata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getappdomainstoredata-method.md
@@ -51,3 +51,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpAppDomainStoreData Structure](dacpappdomainstoredata-structure.md)
+- [ISOSDacInterface::GetAppDomainList Method](isosdacinterface-getappdomainlist-method.md)
+- [ISOSDacInterface::GetAppDomainData Method](isosdacinterface-getappdomaindata-method.md)
+- [ISOSDacInterface::GetAssemblyData Method](isosdacinterface-getassemblydata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getappdomainstoredata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getappdomainstoredata-method.md
@@ -1,0 +1,53 @@
+---
+description: "Learn more about: ISOSDacInterface::GetAppDomainStoreData Method"
+title: "ISOSDacInterface::GetAppDomainStoreData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetAppDomainStoreData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetAppDomainStoreData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetAppDomainStoreData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetAppDomainStoreData Method
+
+Retrieves data about the runtime application domain store.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetAppDomainStoreData(struct DacpAppDomainStoreData *data);
+```
+
+## Parameters
+
+`data`\
+[out] A pointer to a [DacpAppDomainStoreData structure](dacpappdomainstoredata-structure.md) that receives the application domain store data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 5th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpAppDomainStoreData Structure](dacpappdomainstoredata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getassemblydata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getassemblydata-method.md
@@ -1,0 +1,59 @@
+---
+description: "Learn more about: ISOSDacInterface::GetAssemblyData Method"
+title: "ISOSDacInterface::GetAssemblyData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetAssemblyData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetAssemblyData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetAssemblyData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetAssemblyData Method
+
+Retrieves data for the assembly at the specified address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetAssemblyData(CLRDATA_ADDRESS baseDomainPtr, CLRDATA_ADDRESS assembly, struct DacpAssemblyData *data);
+```
+
+## Parameters
+
+`baseDomainPtr`\
+[in] The address of the base domain that contains the assembly, or `NULL` to use the default base domain context.
+
+`assembly`\
+[in] The address of the assembly to retrieve information for.
+
+`data`\
+[out] A pointer to a [DacpAssemblyData structure](dacpassemblydata-structure.md) that receives the assembly data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 11th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpAssemblyData Structure](dacpassemblydata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getassemblydata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getassemblydata-method.md
@@ -57,3 +57,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpAssemblyData Structure](dacpassemblydata-structure.md)
+- [ISOSDacInterface::GetAppDomainStoreData Method](isosdacinterface-getappdomainstoredata-method.md)
+- [ISOSDacInterface::GetAppDomainList Method](isosdacinterface-getappdomainlist-method.md)
+- [ISOSDacInterface::GetAppDomainData Method](isosdacinterface-getappdomaindata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getccwdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getccwdata-method.md
@@ -54,3 +54,4 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpCCWData Structure](dacpccwdata-structure.md)
+- [ISOSDacInterface::GetCCWInterfaces Method](isosdacinterface-getccwinterfaces-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getccwdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getccwdata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetCCWData Method"
+title: "ISOSDacInterface::GetCCWData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetCCWData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetCCWData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetCCWData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetCCWData Method
+
+Retrieves COM callable wrapper (CCW) data for a COM wrapper address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetCCWData(CLRDATA_ADDRESS ccw, struct DacpCCWData *data);
+```
+
+## Parameters
+
+`ccw`\
+[in] The address of the CCW to retrieve information for.
+
+`data`\
+[out] A pointer to a [DacpCCWData structure](dacpccwdata-structure.md) that receives the CCW data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 77th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpCCWData Structure](dacpccwdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getccwinterfaces-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getccwinterfaces-method.md
@@ -1,0 +1,62 @@
+---
+description: "Learn more about: ISOSDacInterface::GetCCWInterfaces Method"
+title: "ISOSDacInterface::GetCCWInterfaces Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetCCWInterfaces Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetCCWInterfaces Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetCCWInterfaces Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetCCWInterfaces Method
+
+Retrieves COM interface pointer data for a COM callable wrapper (CCW).
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetCCWInterfaces(CLRDATA_ADDRESS ccw, unsigned int count, struct DacpCOMInterfacePointerData *interfaces, unsigned int *pNeeded);
+```
+
+## Parameters
+
+`ccw`\
+[in] The address of the CCW to retrieve interface information for.
+
+`count`\
+[in] The number of elements that the `interfaces` array can hold.
+
+`interfaces`\
+[out] An array of [DacpCOMInterfacePointerData structures](dacpcominterfacepointerdata-structure.md) that receives interface pointer data.
+
+`pNeeded`\
+[out] A pointer to the number of interface pointer entries available.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 78th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpCOMInterfacePointerData Structure](dacpcominterfacepointerdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getccwinterfaces-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getccwinterfaces-method.md
@@ -60,3 +60,4 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpCOMInterfacePointerData Structure](dacpcominterfacepointerdata-structure.md)
+- [ISOSDacInterface::GetCCWData Method](isosdacinterface-getccwdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getcodeheaderdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getcodeheaderdata-method.md
@@ -49,7 +49,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
 
-
 ## See also
 
 - [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getcodeheaderdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getcodeheaderdata-method.md
@@ -54,3 +54,5 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpCodeHeaderData Structure](dacpcodeheaderdata-structure.md)
+- [ISOSDacInterface::GetJitManagerList Method](isosdacinterface-getjitmanagerlist-method.md)
+- [ISOSDacInterface::GetCodeHeapList Method](isosdacinterface-getcodeheaplist-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getcodeheaderdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getcodeheaderdata-method.md
@@ -1,0 +1,57 @@
+---
+description: "Learn more about: ISOSDacInterface::GetCodeHeaderData Method"
+title: "ISOSDacInterface::GetCodeHeaderData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetCodeHeaderData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetCodeHeaderData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetCodeHeaderData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetCodeHeaderData Method
+
+Retrieves code header data for the JIT-compiled method that contains the specified instruction pointer.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetCodeHeaderData(CLRDATA_ADDRESS ip, struct DacpCodeHeaderData *data);
+```
+
+## Parameters
+
+`ip`\
+[in] The instruction pointer for the code header to retrieve.
+
+`data`\
+[out] A pointer to a [DacpCodeHeaderData structure](dacpcodeheaderdata-structure.md) that receives the code header data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 27th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpCodeHeaderData Structure](dacpcodeheaderdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getcodeheaplist-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getcodeheaplist-method.md
@@ -55,7 +55,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
 
-
 ## See also
 
 - [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getcodeheaplist-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getcodeheaplist-method.md
@@ -1,0 +1,63 @@
+---
+description: "Learn more about: ISOSDacInterface::GetCodeHeapList Method"
+title: "ISOSDacInterface::GetCodeHeapList Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetCodeHeapList Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetCodeHeapList Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetCodeHeapList Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetCodeHeapList Method
+
+Retrieves the list of code heaps for the specified JIT manager.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetCodeHeapList(CLRDATA_ADDRESS jitManager, unsigned int count, struct DacpJitCodeHeapInfo *codeHeaps, unsigned int *pNeeded);
+```
+
+## Parameters
+
+`jitManager`\
+[in] The address of the JIT manager whose code heaps to retrieve.
+
+`count`\
+[in] The number of elements available in the `codeHeaps` array.
+
+`codeHeaps`\
+[out] A pointer to an array of [DacpJitCodeHeapInfo structures](dacpjitcodeheapinfo-structure.md) that receives the code heap data.
+
+`pNeeded`\
+[out] A pointer to the number of code heap entries required.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 69th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpJitCodeHeapInfo Structure](dacpjitcodeheapinfo-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getcodeheaplist-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getcodeheaplist-method.md
@@ -60,3 +60,5 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpJitCodeHeapInfo Structure](dacpjitcodeheapinfo-structure.md)
+- [ISOSDacInterface::GetCodeHeaderData Method](isosdacinterface-getcodeheaderdata-method.md)
+- [ISOSDacInterface::GetJitManagerList Method](isosdacinterface-getjitmanagerlist-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getdomainlocalmoduledata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getdomainlocalmoduledata-method.md
@@ -54,3 +54,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpDomainLocalModuleData Structure](dacpdomainlocalmoduledata-structure.md)
+- [ISOSDacInterface::GetDomainLocalModuleDataFromAppDomain Method](isosdacinterface-getdomainlocalmoduledatafromappdomain-method.md)
+- [ISOSDacInterface::GetDomainLocalModuleDataFromModule Method](isosdacinterface-getdomainlocalmoduledatafrommodule-method.md)
+- [ISOSDacInterface::GetThreadLocalModuleData Method](isosdacinterface-getthreadlocalmoduledata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getdomainlocalmoduledata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getdomainlocalmoduledata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetDomainLocalModuleData Method"
+title: "ISOSDacInterface::GetDomainLocalModuleData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetDomainLocalModuleData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetDomainLocalModuleData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetDomainLocalModuleData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetDomainLocalModuleData Method
+
+Retrieves data for the domain-local module at the specified address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetDomainLocalModuleData(CLRDATA_ADDRESS addr, struct DacpDomainLocalModuleData *data);
+```
+
+## Parameters
+
+`addr`\
+[in] The address of the domain-local module to retrieve information for.
+
+`data`\
+[out] A pointer to a [DacpDomainLocalModuleData structure](dacpdomainlocalmoduledata-structure.md) that receives the domain-local module data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 56th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpDomainLocalModuleData Structure](dacpdomainlocalmoduledata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getdomainlocalmoduledatafromappdomain-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getdomainlocalmoduledatafromappdomain-method.md
@@ -1,0 +1,59 @@
+---
+description: "Learn more about: ISOSDacInterface::GetDomainLocalModuleDataFromAppDomain Method"
+title: "ISOSDacInterface::GetDomainLocalModuleDataFromAppDomain Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetDomainLocalModuleDataFromAppDomain Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetDomainLocalModuleDataFromAppDomain Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetDomainLocalModuleDataFromAppDomain Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetDomainLocalModuleDataFromAppDomain Method
+
+Retrieves domain-local module data for the specified application domain and module identifier.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetDomainLocalModuleDataFromAppDomain(CLRDATA_ADDRESS appDomainAddr, int moduleID, struct DacpDomainLocalModuleData *data);
+```
+
+## Parameters
+
+`appDomainAddr`\
+[in] The address of the application domain.
+
+`moduleID`\
+[in] The module identifier.
+
+`data`\
+[out] A pointer to a [DacpDomainLocalModuleData structure](dacpdomainlocalmoduledata-structure.md) that receives the domain-local module data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 57th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpDomainLocalModuleData Structure](dacpdomainlocalmoduledata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getdomainlocalmoduledatafromappdomain-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getdomainlocalmoduledatafromappdomain-method.md
@@ -57,3 +57,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpDomainLocalModuleData Structure](dacpdomainlocalmoduledata-structure.md)
+- [ISOSDacInterface::GetDomainLocalModuleData Method](isosdacinterface-getdomainlocalmoduledata-method.md)
+- [ISOSDacInterface::GetDomainLocalModuleDataFromModule Method](isosdacinterface-getdomainlocalmoduledatafrommodule-method.md)
+- [ISOSDacInterface::GetThreadLocalModuleData Method](isosdacinterface-getthreadlocalmoduledata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getdomainlocalmoduledatafrommodule-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getdomainlocalmoduledatafrommodule-method.md
@@ -54,3 +54,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpDomainLocalModuleData Structure](dacpdomainlocalmoduledata-structure.md)
+- [ISOSDacInterface::GetDomainLocalModuleData Method](isosdacinterface-getdomainlocalmoduledata-method.md)
+- [ISOSDacInterface::GetDomainLocalModuleDataFromAppDomain Method](isosdacinterface-getdomainlocalmoduledatafromappdomain-method.md)
+- [ISOSDacInterface::GetThreadLocalModuleData Method](isosdacinterface-getthreadlocalmoduledata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getdomainlocalmoduledatafrommodule-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getdomainlocalmoduledatafrommodule-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetDomainLocalModuleDataFromModule Method"
+title: "ISOSDacInterface::GetDomainLocalModuleDataFromModule Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetDomainLocalModuleDataFromModule Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetDomainLocalModuleDataFromModule Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetDomainLocalModuleDataFromModule Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetDomainLocalModuleDataFromModule Method
+
+Retrieves domain-local module data for the specified module.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetDomainLocalModuleDataFromModule(CLRDATA_ADDRESS moduleAddr, struct DacpDomainLocalModuleData *data);
+```
+
+## Parameters
+
+`moduleAddr`\
+[in] The address of the module.
+
+`data`\
+[out] A pointer to a [DacpDomainLocalModuleData structure](dacpdomainlocalmoduledata-structure.md) that receives the domain-local module data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 58th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpDomainLocalModuleData Structure](dacpdomainlocalmoduledata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getfielddescdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getfielddescdata-method.md
@@ -54,3 +54,7 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpFieldDescData Structure](dacpfielddescdata-structure.md)
+- [ISOSDacInterface::GetMethodTableData Method](isosdacinterface-getmethodtabledata-method.md)
+- [ISOSDacInterface::GetMethodTableSlot Method](isosdacinterface-getmethodtableslot-method.md)
+- [ISOSDacInterface::GetMethodTableFieldData Method](isosdacinterface-getmethodtablefielddata-method.md)
+- [ISOSDacInterface::GetMethodTableForEEClass Method](isosdacinterface-getmethodtableforeeclass-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getfielddescdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getfielddescdata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetFieldDescData Method"
+title: "ISOSDacInterface::GetFieldDescData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetFieldDescData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetFieldDescData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetFieldDescData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetFieldDescData Method
+
+Gets data for a FieldDesc address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetFieldDescData(CLRDATA_ADDRESS fieldDesc, struct DacpFieldDescData *data);
+```
+
+## Parameters
+
+`fieldDesc`\
+[in] The address of the FieldDesc.
+
+`data`\
+[out] A pointer to a [DacpFieldDescData structure](dacpfielddescdata-structure.md) that receives the FieldDesc data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 43rd slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpFieldDescData Structure](dacpfielddescdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheapdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheapdata-method.md
@@ -1,0 +1,53 @@
+---
+description: "Learn more about: ISOSDacInterface::GetGCHeapData Method"
+title: "ISOSDacInterface::GetGCHeapData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetGCHeapData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetGCHeapData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetGCHeapData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetGCHeapData Method
+
+Retrieves general information about the garbage-collected heap.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetGCHeapData(struct DacpGcHeapData *data);
+```
+
+## Parameters
+
+`data`\
+[out] A pointer to a [DacpGcHeapData structure](dacpgcheapdata-structure.md) that receives the GC heap data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 47th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpGcHeapData Structure](dacpgcheapdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheapdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheapdata-method.md
@@ -51,3 +51,7 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpGcHeapData Structure](dacpgcheapdata-structure.md)
+- [ISOSDacInterface::GetGCHeapList Method](isosdacinterface-getgcheaplist-method.md)
+- [ISOSDacInterface::GetGCHeapDetails Method](isosdacinterface-getgcheapdetails-method.md)
+- [ISOSDacInterface::GetGCHeapStaticData Method](isosdacinterface-getgcheapstaticdata-method.md)
+- [ISOSDacInterface::GetHeapSegmentData Method](isosdacinterface-getheapsegmentdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheapdetails-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheapdetails-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetGCHeapDetails Method"
+title: "ISOSDacInterface::GetGCHeapDetails Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetGCHeapDetails Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetGCHeapDetails Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetGCHeapDetails Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetGCHeapDetails Method
+
+Retrieves detailed information for the specified garbage collection heap.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetGCHeapDetails(CLRDATA_ADDRESS heap, struct DacpGcHeapDetails *details);
+```
+
+## Parameters
+
+`heap`\
+[in] The address of the GC heap to retrieve information for.
+
+`details`\
+[out] A pointer to a [DacpGcHeapDetails structure](dacpgcheapdetails-structure.md) that receives the heap details.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 49th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpGcHeapDetails Structure](dacpgcheapdetails-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheapdetails-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheapdetails-method.md
@@ -54,3 +54,7 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpGcHeapDetails Structure](dacpgcheapdetails-structure.md)
+- [ISOSDacInterface::GetGCHeapData Method](isosdacinterface-getgcheapdata-method.md)
+- [ISOSDacInterface::GetGCHeapList Method](isosdacinterface-getgcheaplist-method.md)
+- [ISOSDacInterface::GetGCHeapStaticData Method](isosdacinterface-getgcheapstaticdata-method.md)
+- [ISOSDacInterface::GetHeapSegmentData Method](isosdacinterface-getheapsegmentdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheaplist-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheaplist-method.md
@@ -58,3 +58,7 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::GetGCHeapData Method](isosdacinterface-getgcheapdata-method.md)
+- [ISOSDacInterface::GetGCHeapDetails Method](isosdacinterface-getgcheapdetails-method.md)
+- [ISOSDacInterface::GetGCHeapStaticData Method](isosdacinterface-getgcheapstaticdata-method.md)
+- [ISOSDacInterface::GetHeapSegmentData Method](isosdacinterface-getheapsegmentdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheaplist-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheaplist-method.md
@@ -1,0 +1,60 @@
+---
+description: "Learn more about: ISOSDacInterface::GetGCHeapList Method"
+title: "ISOSDacInterface::GetGCHeapList Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetGCHeapList Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetGCHeapList Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetGCHeapList Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetGCHeapList Method
+
+Retrieves the list of server garbage collection heap addresses.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetGCHeapList(unsigned int count, CLRDATA_ADDRESS heaps[], unsigned int *pNeeded);
+```
+
+## Parameters
+
+`count`\
+[in] The number of elements that the `heaps` array can hold.
+
+`heaps`\
+[out] An array of `CLRDATA_ADDRESS` values that receives the server GC heap addresses.
+
+`pNeeded`\
+[out] A pointer to the number of heap addresses required to contain the complete list.
+
+## Remarks
+
+This method applies to server GC, where the runtime can have multiple GC heaps.
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 48th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheapstaticdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheapstaticdata-method.md
@@ -1,0 +1,53 @@
+---
+description: "Learn more about: ISOSDacInterface::GetGCHeapStaticData Method"
+title: "ISOSDacInterface::GetGCHeapStaticData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetGCHeapStaticData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetGCHeapStaticData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetGCHeapStaticData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetGCHeapStaticData Method
+
+Retrieves static garbage collection heap details.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetGCHeapStaticData(struct DacpGcHeapDetails *data);
+```
+
+## Parameters
+
+`data`\
+[out] A pointer to a [DacpGcHeapDetails structure](dacpgcheapdetails-structure.md) that receives the heap details.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 50th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpGcHeapDetails Structure](dacpgcheapdetails-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheapstaticdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getgcheapstaticdata-method.md
@@ -51,3 +51,7 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpGcHeapDetails Structure](dacpgcheapdetails-structure.md)
+- [ISOSDacInterface::GetGCHeapData Method](isosdacinterface-getgcheapdata-method.md)
+- [ISOSDacInterface::GetGCHeapList Method](isosdacinterface-getgcheaplist-method.md)
+- [ISOSDacInterface::GetGCHeapDetails Method](isosdacinterface-getgcheapdetails-method.md)
+- [ISOSDacInterface::GetHeapSegmentData Method](isosdacinterface-getheapsegmentdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-gethandleenum-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-gethandleenum-method.md
@@ -1,0 +1,54 @@
+---
+description: "Learn more about: ISOSDacInterface::GetHandleEnum Method"
+title: "ISOSDacInterface::GetHandleEnum Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetHandleEnum Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetHandleEnum Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetHandleEnum Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetHandleEnum Method
+
+Retrieves an enumerator for runtime handles.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetHandleEnum(ISOSHandleEnum **ppHandleEnum);
+```
+
+## Parameters
+
+`ppHandleEnum`\
+[out] A pointer to an `ISOSHandleEnum` interface pointer that receives the handle enumerator.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 62nd slot of the virtual method table.
+
+The returned `ISOSHandleEnum` enumerator derives from `ISOSEnum` and provides a `Next` method that returns `SOSHandleData` entries for runtime handles.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-gethandleenum-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-gethandleenum-method.md
@@ -52,3 +52,5 @@ The returned `ISOSHandleEnum` enumerator derives from `ISOSEnum` and provides a 
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::GetHandleEnumForTypes Method](isosdacinterface-gethandleenumfortypes-method.md)
+- [ISOSDacInterface::GetStackReferences Method](isosdacinterface-getstackreferences-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-gethandleenumfortypes-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-gethandleenumfortypes-method.md
@@ -58,3 +58,5 @@ The returned `ISOSHandleEnum` enumerator derives from `ISOSEnum` and provides a 
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::GetHandleEnum Method](isosdacinterface-gethandleenum-method.md)
+- [ISOSDacInterface::GetStackReferences Method](isosdacinterface-getstackreferences-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-gethandleenumfortypes-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-gethandleenumfortypes-method.md
@@ -1,0 +1,60 @@
+---
+description: "Learn more about: ISOSDacInterface::GetHandleEnumForTypes Method"
+title: "ISOSDacInterface::GetHandleEnumForTypes Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetHandleEnumForTypes Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetHandleEnumForTypes Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetHandleEnumForTypes Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetHandleEnumForTypes Method
+
+Retrieves an enumerator for runtime handles whose types match the specified type values.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetHandleEnumForTypes(unsigned int types[], unsigned int count, ISOSHandleEnum **ppHandleEnum);
+```
+
+## Parameters
+
+`types`\
+[in] An array of handle type values to include in the enumeration.
+
+`count`\
+[in] The number of elements in the `types` array.
+
+`ppHandleEnum`\
+[out] A pointer to an `ISOSHandleEnum` interface pointer that receives the handle enumerator.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 63rd slot of the virtual method table.
+
+The returned `ISOSHandleEnum` enumerator derives from `ISOSEnum` and provides a `Next` method that returns `SOSHandleData` entries for runtime handles that match the requested handle types.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getheapanalyzedata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getheapanalyzedata-method.md
@@ -54,3 +54,4 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpGcHeapAnalyzeData Structure](dacpgcheapanalyzedata-structure.md)
+- [ISOSDacInterface::GetHeapAnalyzeStaticData Method](isosdacinterface-getheapanalyzestaticdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getheapanalyzedata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getheapanalyzedata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetHeapAnalyzeData Method"
+title: "ISOSDacInterface::GetHeapAnalyzeData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetHeapAnalyzeData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetHeapAnalyzeData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetHeapAnalyzeData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetHeapAnalyzeData Method
+
+Retrieves heap analysis data for the specified garbage collection heap.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetHeapAnalyzeData(CLRDATA_ADDRESS addr, struct  DacpGcHeapAnalyzeData *data);
+```
+
+## Parameters
+
+`addr`\
+[in] The address of the GC heap to retrieve analysis data for.
+
+`data`\
+[out] A pointer to a [DacpGcHeapAnalyzeData structure](dacpgcheapanalyzedata-structure.md) that receives the heap analysis data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 54th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpGcHeapAnalyzeData Structure](dacpgcheapanalyzedata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getheapanalyzestaticdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getheapanalyzestaticdata-method.md
@@ -1,0 +1,53 @@
+---
+description: "Learn more about: ISOSDacInterface::GetHeapAnalyzeStaticData Method"
+title: "ISOSDacInterface::GetHeapAnalyzeStaticData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetHeapAnalyzeStaticData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetHeapAnalyzeStaticData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetHeapAnalyzeStaticData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetHeapAnalyzeStaticData Method
+
+Retrieves static heap analysis data for the garbage collector.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetHeapAnalyzeStaticData(struct DacpGcHeapAnalyzeData *data);
+```
+
+## Parameters
+
+`data`\
+[out] A pointer to a [DacpGcHeapAnalyzeData structure](dacpgcheapanalyzedata-structure.md) that receives the heap analysis data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 55th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpGcHeapAnalyzeData Structure](dacpgcheapanalyzedata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getheapanalyzestaticdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getheapanalyzestaticdata-method.md
@@ -51,3 +51,4 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpGcHeapAnalyzeData Structure](dacpgcheapanalyzedata-structure.md)
+- [ISOSDacInterface::GetHeapAnalyzeData Method](isosdacinterface-getheapanalyzedata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getheapsegmentdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getheapsegmentdata-method.md
@@ -54,3 +54,7 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpHeapSegmentData Structure](dacpheapsegmentdata-structure.md)
+- [ISOSDacInterface::GetGCHeapData Method](isosdacinterface-getgcheapdata-method.md)
+- [ISOSDacInterface::GetGCHeapList Method](isosdacinterface-getgcheaplist-method.md)
+- [ISOSDacInterface::GetGCHeapDetails Method](isosdacinterface-getgcheapdetails-method.md)
+- [ISOSDacInterface::GetGCHeapStaticData Method](isosdacinterface-getgcheapstaticdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getheapsegmentdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getheapsegmentdata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetHeapSegmentData Method"
+title: "ISOSDacInterface::GetHeapSegmentData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetHeapSegmentData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetHeapSegmentData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetHeapSegmentData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetHeapSegmentData Method
+
+Retrieves information for the specified garbage collection heap segment.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetHeapSegmentData(CLRDATA_ADDRESS seg, struct DacpHeapSegmentData *data);
+```
+
+## Parameters
+
+`seg`\
+[in] The address of the heap segment to retrieve information for.
+
+`data`\
+[out] A pointer to a [DacpHeapSegmentData structure](dacpheapsegmentdata-structure.md) that receives the heap segment data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 51st slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpHeapSegmentData Structure](dacpheapsegmentdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getilformodule-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getilformodule-method.md
@@ -1,0 +1,58 @@
+---
+description: "Learn more about: ISOSDacInterface::GetILForModule Method"
+title: "ISOSDacInterface::GetILForModule Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetILForModule Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetILForModule Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetILForModule Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetILForModule Method
+
+Gets the intermediate language (IL) address that corresponds to a relative virtual address in a module.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetILForModule(CLRDATA_ADDRESS moduleAddr, DWORD rva, CLRDATA_ADDRESS *il);
+```
+
+## Parameters
+
+`moduleAddr`\
+[in] The address of the module.
+
+`rva`\
+[in] The relative virtual address in the module.
+
+`il`\
+[out] The address of the IL for the specified module address and relative virtual address.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 17th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getilformodule-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getilformodule-method.md
@@ -56,3 +56,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::GetModule Method](isosdacinterface-getmodule-method.md)
+- [ISOSDacInterface::GetModuleData Method](isosdacinterface-getmoduledata-method.md)
+- [ISOSDacInterface::TraverseModuleMap Method](isosdacinterface-traversemodulemap-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getjitmanagerlist-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getjitmanagerlist-method.md
@@ -52,7 +52,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
 
-
 ## See also
 
 - [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getjitmanagerlist-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getjitmanagerlist-method.md
@@ -1,0 +1,60 @@
+---
+description: "Learn more about: ISOSDacInterface::GetJitManagerList Method"
+title: "ISOSDacInterface::GetJitManagerList Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetJitManagerList Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetJitManagerList Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetJitManagerList Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetJitManagerList Method
+
+Retrieves the list of JIT managers known to the runtime.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetJitManagerList(unsigned int count, struct DacpJitManagerInfo *managers, unsigned int *pNeeded);
+```
+
+## Parameters
+
+`count`\
+[in] The number of elements available in the `managers` array.
+
+`managers`\
+[out] A pointer to an array of [DacpJitManagerInfo structures](dacpjitmanagerinfo-structure.md) that receives the JIT manager data.
+
+`pNeeded`\
+[out] A pointer to the number of JIT manager entries required.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 28th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpJitManagerInfo Structure](dacpjitmanagerinfo-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getjitmanagerlist-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getjitmanagerlist-method.md
@@ -57,3 +57,5 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpJitManagerInfo Structure](dacpjitmanagerinfo-structure.md)
+- [ISOSDacInterface::GetCodeHeaderData Method](isosdacinterface-getcodeheaderdata-method.md)
+- [ISOSDacInterface::GetCodeHeapList Method](isosdacinterface-getcodeheaplist-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescfromtoken-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescfromtoken-method.md
@@ -56,3 +56,7 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::GetMethodDescData Method](isosdacinterface-getmethoddescdata-method.md)
+- [ISOSDacInterface::GetMethodDescName Method](isosdacinterface-getmethoddescname-method.md)
+- [ISOSDacInterface::GetMethodDescPtrFromIP Method](isosdacinterface-getmethoddescptrfromip-method.md)
+- [ISOSDacInterface::GetMethodDescPtrFromFrame Method](isosdacinterface-getmethoddescptrfromframe-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescfromtoken-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescfromtoken-method.md
@@ -1,0 +1,58 @@
+---
+description: "Learn more about: ISOSDacInterface::GetMethodDescFromToken Method"
+title: "ISOSDacInterface::GetMethodDescFromToken Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetMethodDescFromToken Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetMethodDescFromToken Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetMethodDescFromToken Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetMethodDescFromToken Method
+
+Gets a MethodDesc address for a metadata token in a module.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetMethodDescFromToken(CLRDATA_ADDRESS moduleAddr, mdToken token, CLRDATA_ADDRESS *methodDesc);
+```
+
+## Parameters
+
+`moduleAddr`\
+[in] The address of the module that contains the metadata token.
+
+`token`\
+[in] The metadata token.
+
+`methodDesc`\
+[out] The MethodDesc address that corresponds to the metadata token.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 25th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescname-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescname-method.md
@@ -1,0 +1,61 @@
+---
+description: "Learn more about: ISOSDacInterface::GetMethodDescName Method"
+title: "ISOSDacInterface::GetMethodDescName Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetMethodDescName Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetMethodDescName Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetMethodDescName Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetMethodDescName Method
+
+Gets the name that corresponds to a MethodDesc address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetMethodDescName(CLRDATA_ADDRESS methodDesc, unsigned int count, wchar_t *name, unsigned int *pNeeded);
+```
+
+## Parameters
+
+`methodDesc`\
+[in] The address of the MethodDesc.
+
+`count`\
+[in] The size of the `name` buffer, in wide characters.
+
+`name`\
+[out] A buffer that receives the MethodDesc name.
+
+`pNeeded`\
+[out] The number of wide characters required for the MethodDesc name.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 23rd slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescname-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescname-method.md
@@ -59,3 +59,7 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::GetMethodDescData Method](isosdacinterface-getmethoddescdata-method.md)
+- [ISOSDacInterface::GetMethodDescPtrFromIP Method](isosdacinterface-getmethoddescptrfromip-method.md)
+- [ISOSDacInterface::GetMethodDescPtrFromFrame Method](isosdacinterface-getmethoddescptrfromframe-method.md)
+- [ISOSDacInterface::GetMethodDescFromToken Method](isosdacinterface-getmethoddescfromtoken-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescptrfromframe-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescptrfromframe-method.md
@@ -1,0 +1,55 @@
+---
+description: "Learn more about: ISOSDacInterface::GetMethodDescPtrFromFrame Method"
+title: "ISOSDacInterface::GetMethodDescPtrFromFrame Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetMethodDescPtrFromFrame Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetMethodDescPtrFromFrame Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetMethodDescPtrFromFrame Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetMethodDescPtrFromFrame Method
+
+Gets the MethodDesc pointer that corresponds to a frame address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetMethodDescPtrFromFrame(CLRDATA_ADDRESS frameAddr, CLRDATA_ADDRESS * ppMD);
+```
+
+## Parameters
+
+`frameAddr`\
+[in] The address of the frame.
+
+`ppMD`\
+[out] The MethodDesc pointer that corresponds to the frame.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 24th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescptrfromframe-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethoddescptrfromframe-method.md
@@ -53,3 +53,7 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::GetMethodDescData Method](isosdacinterface-getmethoddescdata-method.md)
+- [ISOSDacInterface::GetMethodDescName Method](isosdacinterface-getmethoddescname-method.md)
+- [ISOSDacInterface::GetMethodDescPtrFromIP Method](isosdacinterface-getmethoddescptrfromip-method.md)
+- [ISOSDacInterface::GetMethodDescFromToken Method](isosdacinterface-getmethoddescfromtoken-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtabledata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtabledata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetMethodTableData Method"
+title: "ISOSDacInterface::GetMethodTableData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetMethodTableData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetMethodTableData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetMethodTableData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetMethodTableData Method
+
+Gets data for a method table.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetMethodTableData(CLRDATA_ADDRESS mt, struct DacpMethodTableData *data);
+```
+
+## Parameters
+
+`mt`\
+[in] The address of the method table.
+
+`data`\
+[out] A pointer to a [DacpMethodTableData structure](dacpmethodtabledata-structure.md) that receives the method table data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 38th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpMethodTableData Structure](dacpmethodtabledata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtabledata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtabledata-method.md
@@ -54,3 +54,7 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpMethodTableData Structure](dacpmethodtabledata-structure.md)
+- [ISOSDacInterface::GetMethodTableSlot Method](isosdacinterface-getmethodtableslot-method.md)
+- [ISOSDacInterface::GetMethodTableFieldData Method](isosdacinterface-getmethodtablefielddata-method.md)
+- [ISOSDacInterface::GetMethodTableForEEClass Method](isosdacinterface-getmethodtableforeeclass-method.md)
+- [ISOSDacInterface::GetFieldDescData Method](isosdacinterface-getfielddescdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtablefielddata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtablefielddata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetMethodTableFieldData Method"
+title: "ISOSDacInterface::GetMethodTableFieldData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetMethodTableFieldData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetMethodTableFieldData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetMethodTableFieldData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetMethodTableFieldData Method
+
+Gets field data for a method table.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetMethodTableFieldData(CLRDATA_ADDRESS mt, struct DacpMethodTableFieldData *data);
+```
+
+## Parameters
+
+`mt`\
+[in] The address of the method table.
+
+`data`\
+[out] A pointer to a [DacpMethodTableFieldData structure](dacpmethodtablefielddata-structure.md) that receives the method table field data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 40th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpMethodTableFieldData Structure](dacpmethodtablefielddata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtablefielddata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtablefielddata-method.md
@@ -54,3 +54,7 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpMethodTableFieldData Structure](dacpmethodtablefielddata-structure.md)
+- [ISOSDacInterface::GetMethodTableData Method](isosdacinterface-getmethodtabledata-method.md)
+- [ISOSDacInterface::GetMethodTableSlot Method](isosdacinterface-getmethodtableslot-method.md)
+- [ISOSDacInterface::GetMethodTableForEEClass Method](isosdacinterface-getmethodtableforeeclass-method.md)
+- [ISOSDacInterface::GetFieldDescData Method](isosdacinterface-getfielddescdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtableforeeclass-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtableforeeclass-method.md
@@ -53,3 +53,7 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::GetMethodTableData Method](isosdacinterface-getmethodtabledata-method.md)
+- [ISOSDacInterface::GetMethodTableSlot Method](isosdacinterface-getmethodtableslot-method.md)
+- [ISOSDacInterface::GetMethodTableFieldData Method](isosdacinterface-getmethodtablefielddata-method.md)
+- [ISOSDacInterface::GetFieldDescData Method](isosdacinterface-getfielddescdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtableforeeclass-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtableforeeclass-method.md
@@ -1,0 +1,55 @@
+---
+description: "Learn more about: ISOSDacInterface::GetMethodTableForEEClass Method"
+title: "ISOSDacInterface::GetMethodTableForEEClass Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetMethodTableForEEClass Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetMethodTableForEEClass Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetMethodTableForEEClass Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetMethodTableForEEClass Method
+
+Gets the method table address that corresponds to an EEClass address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetMethodTableForEEClass(CLRDATA_ADDRESS eeClass, CLRDATA_ADDRESS *value);
+```
+
+## Parameters
+
+`eeClass`\
+[in] The address of the EEClass.
+
+`value`\
+[out] The method table address that corresponds to the EEClass.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 42nd slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtableslot-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtableslot-method.md
@@ -1,0 +1,58 @@
+---
+description: "Learn more about: ISOSDacInterface::GetMethodTableSlot Method"
+title: "ISOSDacInterface::GetMethodTableSlot Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetMethodTableSlot Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetMethodTableSlot Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetMethodTableSlot Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetMethodTableSlot Method
+
+Gets the value of a slot in a method table.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetMethodTableSlot(CLRDATA_ADDRESS mt, unsigned int slot, CLRDATA_ADDRESS *value);
+```
+
+## Parameters
+
+`mt`\
+[in] The address of the method table.
+
+`slot`\
+[in] The method table slot index.
+
+`value`\
+[out] The value stored in the specified method table slot.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 39th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtableslot-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmethodtableslot-method.md
@@ -56,3 +56,7 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::GetMethodTableData Method](isosdacinterface-getmethodtabledata-method.md)
+- [ISOSDacInterface::GetMethodTableFieldData Method](isosdacinterface-getmethodtablefielddata-method.md)
+- [ISOSDacInterface::GetMethodTableForEEClass Method](isosdacinterface-getmethodtableforeeclass-method.md)
+- [ISOSDacInterface::GetFieldDescData Method](isosdacinterface-getfielddescdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmodule-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmodule-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetModule Method"
+title: "ISOSDacInterface::GetModule Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetModule Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetModule Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetModule Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetModule Method
+
+Gets an `IXCLRDataModule` interface for a module address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetModule(CLRDATA_ADDRESS addr, IXCLRDataModule **mod);
+```
+
+## Parameters
+
+`addr`\
+[in] The address of the module.
+
+`mod`\
+[out] A pointer to the [IXCLRDataModule Interface](ixclrdatamodule-interface.md) for the module.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 13th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [IXCLRDataModule Interface](ixclrdatamodule-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getmodule-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getmodule-method.md
@@ -54,3 +54,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [IXCLRDataModule Interface](ixclrdatamodule-interface.md)
+- [ISOSDacInterface::GetModuleData Method](isosdacinterface-getmoduledata-method.md)
+- [ISOSDacInterface::TraverseModuleMap Method](isosdacinterface-traversemodulemap-method.md)
+- [ISOSDacInterface::GetILForModule Method](isosdacinterface-getilformodule-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getobjectdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getobjectdata-method.md
@@ -1,0 +1,57 @@
+---
+description: "Learn more about: ISOSDacInterface::GetObjectData Method"
+title: "ISOSDacInterface::GetObjectData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetObjectData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetObjectData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetObjectData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetObjectData Method
+
+Retrieves data for the object at the specified address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetObjectData(CLRDATA_ADDRESS objAddr, struct DacpObjectData *data);
+```
+
+## Parameters
+
+`objAddr`\
+[in] The address of the object to retrieve information for.
+
+`data`\
+[out] A pointer to a [DacpObjectData structure](dacpobjectdata-structure.md) that receives the object data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 34th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpObjectData Structure](dacpobjectdata-structure.md)
+- [DacpObjectType Enumeration](dacpobjecttype-enumeration.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getoomdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getoomdata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetOOMData Method"
+title: "ISOSDacInterface::GetOOMData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetOOMData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetOOMData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetOOMData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetOOMData Method
+
+Retrieves out-of-memory data for the specified garbage collection heap.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetOOMData(CLRDATA_ADDRESS oomAddr, struct DacpOomData *data);
+```
+
+## Parameters
+
+`oomAddr`\
+[in] The address of the out-of-memory data to retrieve.
+
+`data`\
+[out] A pointer to a [DacpOomData structure](dacpoomdata-structure.md) that receives the out-of-memory data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 52nd slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpOomData Structure](dacpoomdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getoomdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getoomdata-method.md
@@ -54,3 +54,4 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpOomData Structure](dacpoomdata-structure.md)
+- [ISOSDacInterface::GetOOMStaticData Method](isosdacinterface-getoomstaticdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getoomstaticdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getoomstaticdata-method.md
@@ -51,3 +51,4 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpOomData Structure](dacpoomdata-structure.md)
+- [ISOSDacInterface::GetOOMData Method](isosdacinterface-getoomdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getoomstaticdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getoomstaticdata-method.md
@@ -1,0 +1,53 @@
+---
+description: "Learn more about: ISOSDacInterface::GetOOMStaticData Method"
+title: "ISOSDacInterface::GetOOMStaticData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetOOMStaticData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetOOMStaticData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetOOMStaticData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetOOMStaticData Method
+
+Retrieves static out-of-memory data for the garbage collector.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetOOMStaticData(struct DacpOomData *data);
+```
+
+## Parameters
+
+`data`\
+[out] A pointer to a [DacpOomData structure](dacpoomdata-structure.md) that receives the out-of-memory data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 53rd slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpOomData Structure](dacpoomdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getrcwdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getrcwdata-method.md
@@ -54,3 +54,5 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpRCWData Structure](dacprcwdata-structure.md)
+- [ISOSDacInterface::GetRCWInterfaces Method](isosdacinterface-getrcwinterfaces-method.md)
+- [ISOSDacInterface::TraverseRCWCleanupList Method](isosdacinterface-traversercwcleanuplist-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getrcwdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getrcwdata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetRCWData Method"
+title: "ISOSDacInterface::GetRCWData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetRCWData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetRCWData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetRCWData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetRCWData Method
+
+Retrieves runtime callable wrapper (RCW) data for a COM wrapper address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetRCWData(CLRDATA_ADDRESS addr, struct DacpRCWData *data);
+```
+
+## Parameters
+
+`addr`\
+[in] The address of the RCW to retrieve information for.
+
+`data`\
+[out] A pointer to a [DacpRCWData structure](dacprcwdata-structure.md) that receives the RCW data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 75th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpRCWData Structure](dacprcwdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getrcwinterfaces-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getrcwinterfaces-method.md
@@ -1,0 +1,62 @@
+---
+description: "Learn more about: ISOSDacInterface::GetRCWInterfaces Method"
+title: "ISOSDacInterface::GetRCWInterfaces Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetRCWInterfaces Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetRCWInterfaces Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetRCWInterfaces Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetRCWInterfaces Method
+
+Retrieves COM interface pointer data for a runtime callable wrapper (RCW).
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetRCWInterfaces(CLRDATA_ADDRESS rcw, unsigned int count, struct DacpCOMInterfacePointerData *interfaces, unsigned int *pNeeded);
+```
+
+## Parameters
+
+`rcw`\
+[in] The address of the RCW to retrieve interface information for.
+
+`count`\
+[in] The number of elements that the `interfaces` array can hold.
+
+`interfaces`\
+[out] An array of [DacpCOMInterfacePointerData structures](dacpcominterfacepointerdata-structure.md) that receives interface pointer data.
+
+`pNeeded`\
+[out] A pointer to the number of interface pointer entries available.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 76th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpCOMInterfacePointerData Structure](dacpcominterfacepointerdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getrcwinterfaces-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getrcwinterfaces-method.md
@@ -60,3 +60,5 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpCOMInterfacePointerData Structure](dacpcominterfacepointerdata-structure.md)
+- [ISOSDacInterface::GetRCWData Method](isosdacinterface-getrcwdata-method.md)
+- [ISOSDacInterface::TraverseRCWCleanupList Method](isosdacinterface-traversercwcleanuplist-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getregistername-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getregistername-method.md
@@ -55,7 +55,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
 
-
 ## See also
 
 - [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getregistername-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getregistername-method.md
@@ -1,0 +1,62 @@
+---
+description: "Learn more about: ISOSDacInterface::GetRegisterName Method"
+title: "ISOSDacInterface::GetRegisterName Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetRegisterName Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetRegisterName Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetRegisterName Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetRegisterName Method
+
+Retrieves the display name for a runtime register identifier.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetRegisterName([in] int regName, [in] unsigned int count, [out] wchar_t *buffer, [out] unsigned int *pNeeded);
+```
+
+## Parameters
+
+`regName`\
+[in] The register identifier whose name to retrieve.
+
+`count`\
+[in] The number of characters available in `buffer`.
+
+`buffer`\
+[out] A pointer to a buffer that receives the register name.
+
+`pNeeded`\
+[out] A pointer to the number of characters required for the register name.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 81st slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getstackreferences-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getstackreferences-method.md
@@ -1,0 +1,57 @@
+---
+description: "Learn more about: ISOSDacInterface::GetStackReferences Method"
+title: "ISOSDacInterface::GetStackReferences Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetStackReferences Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetStackReferences Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetStackReferences Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetStackReferences Method
+
+Retrieves an enumerator for references on a thread call stack.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetStackReferences([in] DWORD osThreadID, [out] ISOSStackRefEnum **ppEnum);
+```
+
+## Parameters
+
+`osThreadID`\
+[in] The operating system thread ID for the stack to enumerate.
+
+`ppEnum`\
+[out] A pointer to an `ISOSStackRefEnum` interface pointer that receives the stack-reference enumerator.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 80th slot of the virtual method table.
+
+The returned `ISOSStackRefEnum` enumerator derives from `ISOSEnum` and provides a `Next` method that returns `SOSStackRefData` entries. It also provides an `EnumerateErrors` method that reports stack frames for which the runtime could not enumerate GC references.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getstackreferences-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getstackreferences-method.md
@@ -55,3 +55,5 @@ The returned `ISOSStackRefEnum` enumerator derives from `ISOSEnum` and provides 
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::GetHandleEnum Method](isosdacinterface-gethandleenum-method.md)
+- [ISOSDacInterface::GetHandleEnumForTypes Method](isosdacinterface-gethandleenumfortypes-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getstresslogaddress-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getstresslogaddress-method.md
@@ -46,7 +46,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
 
-
 ## See also
 
 - [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getstresslogaddress-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getstresslogaddress-method.md
@@ -1,0 +1,53 @@
+---
+description: "Learn more about: ISOSDacInterface::GetStressLogAddress Method"
+title: "ISOSDacInterface::GetStressLogAddress Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetStressLogAddress Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetStressLogAddress Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetStressLogAddress Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetStressLogAddress Method
+
+Retrieves the address of the runtime stress log.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetStressLogAddress(CLRDATA_ADDRESS *stressLog);
+```
+
+## Parameters
+
+`stressLog`\
+[out] A pointer to the address of the runtime stress log.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 67th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getsyncblockcleanupdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getsyncblockcleanupdata-method.md
@@ -54,3 +54,4 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpSyncBlockCleanupData Structure](dacpsyncblockcleanupdata-structure.md)
+- [ISOSDacInterface::GetSyncBlockData Method](isosdacinterface-getsyncblockdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getsyncblockcleanupdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getsyncblockcleanupdata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetSyncBlockCleanupData Method"
+title: "ISOSDacInterface::GetSyncBlockCleanupData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetSyncBlockCleanupData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetSyncBlockCleanupData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetSyncBlockCleanupData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetSyncBlockCleanupData Method
+
+Retrieves cleanup data for the sync block at the specified address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetSyncBlockCleanupData(CLRDATA_ADDRESS addr, struct DacpSyncBlockCleanupData *data);
+```
+
+## Parameters
+
+`addr`\
+[in] The address of the sync block cleanup data to retrieve. Pass `NULL` on the first request to start a traversal.
+
+`data`\
+[out] A pointer to a [DacpSyncBlockCleanupData structure](dacpsyncblockcleanupdata-structure.md) that receives the sync block cleanup data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 61st slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpSyncBlockCleanupData Structure](dacpsyncblockcleanupdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getsyncblockdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getsyncblockdata-method.md
@@ -54,3 +54,4 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpSyncBlockData Structure](dacpsyncblockdata-structure.md)
+- [ISOSDacInterface::GetSyncBlockCleanupData Method](isosdacinterface-getsyncblockcleanupdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getsyncblockdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getsyncblockdata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetSyncBlockData Method"
+title: "ISOSDacInterface::GetSyncBlockData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetSyncBlockData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetSyncBlockData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetSyncBlockData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetSyncBlockData Method
+
+Retrieves data for the sync block with the specified number.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetSyncBlockData(unsigned int number, struct DacpSyncBlockData *data);
+```
+
+## Parameters
+
+`number`\
+[in] The sync block number to retrieve information for.
+
+`data`\
+[out] A pointer to a [DacpSyncBlockData structure](dacpsyncblockdata-structure.md) that receives the sync block data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 60th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpSyncBlockData Structure](dacpsyncblockdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreaddata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreaddata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetThreadData Method"
+title: "ISOSDacInterface::GetThreadData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetThreadData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetThreadData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetThreadData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetThreadData Method
+
+Retrieves data for the managed thread at the specified address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetThreadData(CLRDATA_ADDRESS thread, struct DacpThreadData *data);
+```
+
+## Parameters
+
+`thread`\
+[in] The address of the thread to retrieve information for.
+
+`data`\
+[out] A pointer to a [DacpThreadData structure](dacpthreaddata-structure.md) that receives the thread data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 18th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpThreadData Structure](dacpthreaddata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreaddata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreaddata-method.md
@@ -54,3 +54,5 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpThreadData Structure](dacpthreaddata-structure.md)
+- [ISOSDacInterface::GetThreadStoreData Method](isosdacinterface-getthreadstoredata-method.md)
+- [ISOSDacInterface::GetThreadFromThinlockID Method](isosdacinterface-getthreadfromthinlockid-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadfromthinlockid-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadfromthinlockid-method.md
@@ -1,0 +1,55 @@
+---
+description: "Learn more about: ISOSDacInterface::GetThreadFromThinlockID Method"
+title: "ISOSDacInterface::GetThreadFromThinlockID Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetThreadFromThinlockID Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetThreadFromThinlockID Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetThreadFromThinlockID Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetThreadFromThinlockID Method
+
+Retrieves the managed thread address that corresponds to a thin-lock identifier.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetThreadFromThinlockID(UINT thinLockId, CLRDATA_ADDRESS *pThread);
+```
+
+## Parameters
+
+`thinLockId`\
+[in] The thin-lock identifier to resolve.
+
+`pThread`\
+[out] A pointer to a `CLRDATA_ADDRESS` value that receives the address of the thread.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 19th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadfromthinlockid-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadfromthinlockid-method.md
@@ -53,3 +53,5 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::GetThreadStoreData Method](isosdacinterface-getthreadstoredata-method.md)
+- [ISOSDacInterface::GetThreadData Method](isosdacinterface-getthreaddata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadlocalmoduledata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadlocalmoduledata-method.md
@@ -1,0 +1,59 @@
+---
+description: "Learn more about: ISOSDacInterface::GetThreadLocalModuleData Method"
+title: "ISOSDacInterface::GetThreadLocalModuleData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetThreadLocalModuleData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetThreadLocalModuleData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetThreadLocalModuleData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetThreadLocalModuleData Method
+
+Retrieves thread-local module data for the specified thread and module index.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetThreadLocalModuleData(CLRDATA_ADDRESS thread, unsigned int index, struct DacpThreadLocalModuleData *data);
+```
+
+## Parameters
+
+`thread`\
+[in] The address of the thread.
+
+`index`\
+[in] The module index.
+
+`data`\
+[out] A pointer to a [DacpThreadLocalModuleData structure](dacpthreadlocalmoduledata-structure.md) that receives the thread-local module data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 59th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpThreadLocalModuleData Structure](dacpthreadlocalmoduledata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadlocalmoduledata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadlocalmoduledata-method.md
@@ -57,3 +57,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpThreadLocalModuleData Structure](dacpthreadlocalmoduledata-structure.md)
+- [ISOSDacInterface::GetDomainLocalModuleData Method](isosdacinterface-getdomainlocalmoduledata-method.md)
+- [ISOSDacInterface::GetDomainLocalModuleDataFromAppDomain Method](isosdacinterface-getdomainlocalmoduledatafromappdomain-method.md)
+- [ISOSDacInterface::GetDomainLocalModuleDataFromModule Method](isosdacinterface-getdomainlocalmoduledatafrommodule-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadpooldata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadpooldata-method.md
@@ -1,0 +1,53 @@
+---
+description: "Learn more about: ISOSDacInterface::GetThreadpoolData Method"
+title: "ISOSDacInterface::GetThreadpoolData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetThreadpoolData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetThreadpoolData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetThreadpoolData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetThreadpoolData Method
+
+Retrieves data for the runtime thread pool.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetThreadpoolData(struct DacpThreadpoolData *data);
+```
+
+## Parameters
+
+`data`\
+[out] A pointer to a [DacpThreadpoolData structure](dacpthreadpooldata-structure.md) that receives the thread pool data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 31st slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpThreadpoolData Structure](dacpthreadpooldata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadpooldata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadpooldata-method.md
@@ -51,3 +51,4 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpThreadpoolData Structure](dacpthreadpooldata-structure.md)
+- [ISOSDacInterface::GetWorkRequestData Method](isosdacinterface-getworkrequestdata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadstoredata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadstoredata-method.md
@@ -51,3 +51,5 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpThreadStoreData Structure](dacpthreadstoredata-structure.md)
+- [ISOSDacInterface::GetThreadData Method](isosdacinterface-getthreaddata-method.md)
+- [ISOSDacInterface::GetThreadFromThinlockID Method](isosdacinterface-getthreadfromthinlockid-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadstoredata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getthreadstoredata-method.md
@@ -1,0 +1,53 @@
+---
+description: "Learn more about: ISOSDacInterface::GetThreadStoreData Method"
+title: "ISOSDacInterface::GetThreadStoreData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetThreadStoreData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetThreadStoreData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetThreadStoreData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetThreadStoreData Method
+
+Retrieves data about the runtime thread store.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetThreadStoreData(struct DacpThreadStoreData *data);
+```
+
+## Parameters
+
+`data`\
+[out] A pointer to a [DacpThreadStoreData structure](dacpthreadstoredata-structure.md) that receives the thread store data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 4th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpThreadStoreData Structure](dacpthreadstoredata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-gettlsindex-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-gettlsindex-method.md
@@ -46,7 +46,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
 
-
 ## See also
 
 - [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-gettlsindex-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-gettlsindex-method.md
@@ -1,0 +1,53 @@
+---
+description: "Learn more about: ISOSDacInterface::GetTLSIndex Method"
+title: "ISOSDacInterface::GetTLSIndex Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetTLSIndex Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetTLSIndex Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetTLSIndex Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetTLSIndex Method
+
+Retrieves the thread-local storage index used by the runtime.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetTLSIndex(unsigned long *pIndex);
+```
+
+## Parameters
+
+`pIndex`\
+[out] A pointer to the thread-local storage index used by the runtime.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 73rd slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getusefulglobals-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getusefulglobals-method.md
@@ -46,7 +46,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
 
-
 ## See also
 
 - [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getusefulglobals-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getusefulglobals-method.md
@@ -1,0 +1,54 @@
+---
+description: "Learn more about: ISOSDacInterface::GetUsefulGlobals Method"
+title: "ISOSDacInterface::GetUsefulGlobals Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetUsefulGlobals Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetUsefulGlobals Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetUsefulGlobals Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetUsefulGlobals Method
+
+Retrieves global runtime addresses that are commonly useful to diagnostic tools.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetUsefulGlobals(struct DacpUsefulGlobalsData *data);
+```
+
+## Parameters
+
+`data`\
+[out] A pointer to a [DacpUsefulGlobalsData structure](dacpusefulglobalsdata-structure.md) that receives the global runtime addresses.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 71st slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpUsefulGlobalsData Structure](dacpusefulglobalsdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getworkrequestdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getworkrequestdata-method.md
@@ -54,3 +54,4 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [DacpWorkRequestData Structure](dacpworkrequestdata-structure.md)
+- [ISOSDacInterface::GetThreadpoolData Method](isosdacinterface-getthreadpooldata-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-getworkrequestdata-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-getworkrequestdata-method.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: ISOSDacInterface::GetWorkRequestData Method"
+title: "ISOSDacInterface::GetWorkRequestData Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::GetWorkRequestData Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::GetWorkRequestData Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::GetWorkRequestData Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::GetWorkRequestData Method
+
+Retrieves data for the work request at the specified address.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetWorkRequestData(CLRDATA_ADDRESS addrWorkRequest, struct DacpWorkRequestData *data);
+```
+
+## Parameters
+
+`addrWorkRequest`\
+[in] The address of the work request to retrieve information for.
+
+`data`\
+[out] A pointer to a [DacpWorkRequestData structure](dacpworkrequestdata-structure.md) that receives the work request data.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 32nd slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [DacpWorkRequestData Structure](dacpworkrequestdata-structure.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-interface.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-interface.md
@@ -24,11 +24,63 @@ Provides helper methods to access data from `SOS`.
 
 ## Methods
 
-| Method                                                                                                               | Description                                                                                                                   |
-| -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Method | Description |
+| ------ | ----------- |
+| [GetAppDomainData](isosdacinterface-getappdomaindata-method.md) | Retrieves data for the application domain at the specified address. |
+| [GetAppDomainList](isosdacinterface-getappdomainlist-method.md) | Retrieves the list of application domains in the runtime. |
+| [GetAppDomainStoreData](isosdacinterface-getappdomainstoredata-method.md) | Retrieves data about the runtime application domain store. |
+| [GetAssemblyData](isosdacinterface-getassemblydata-method.md) | Retrieves data for the assembly at the specified address. |
+| [GetCCWData](isosdacinterface-getccwdata-method.md) | Retrieves COM callable wrapper (CCW) data for a COM wrapper address. |
+| [GetCCWInterfaces](isosdacinterface-getccwinterfaces-method.md) | Retrieves COM interface pointer data for a COM callable wrapper (CCW). |
+| [GetCodeHeaderData](isosdacinterface-getcodeheaderdata-method.md) | Retrieves code header data for the JIT-compiled method that contains the specified instruction pointer. |
+| [GetCodeHeapList](isosdacinterface-getcodeheaplist-method.md) | Retrieves the list of code heaps for the specified JIT manager. |
+| [GetDomainLocalModuleDataFromAppDomain](isosdacinterface-getdomainlocalmoduledatafromappdomain-method.md) | Retrieves domain-local module data for the specified application domain and module identifier. |
+| [GetDomainLocalModuleDataFromModule](isosdacinterface-getdomainlocalmoduledatafrommodule-method.md) | Retrieves domain-local module data for the specified module. |
+| [GetFieldDescData](isosdacinterface-getfielddescdata-method.md) | Gets data for a FieldDesc address. |
+| [GetGCHeapData](isosdacinterface-getgcheapdata-method.md) | Retrieves general information about the garbage-collected heap. |
+| [GetGCHeapDetails](isosdacinterface-getgcheapdetails-method.md) | Retrieves detailed information for the specified garbage collection heap. |
+| [GetGCHeapList](isosdacinterface-getgcheaplist-method.md) | Retrieves the list of server garbage collection heap addresses. |
+| [GetGCHeapStaticData](isosdacinterface-getgcheapstaticdata-method.md) | Retrieves static garbage collection heap details. |
+| [GetHandleEnum](isosdacinterface-gethandleenum-method.md) | Retrieves an enumerator for runtime handles. |
+| [GetHandleEnumForTypes](isosdacinterface-gethandleenumfortypes-method.md) | Retrieves an enumerator for runtime handles whose types match the specified type values. |
+| [GetHeapAnalyzeData](isosdacinterface-getheapanalyzedata-method.md) | Retrieves heap analysis data for the specified garbage collection heap. |
+| [GetHeapAnalyzeStaticData](isosdacinterface-getheapanalyzestaticdata-method.md) | Retrieves static heap analysis data for the garbage collector. |
+| [GetHeapSegmentData](isosdacinterface-getheapsegmentdata-method.md) | Retrieves information for the specified garbage collection heap segment. |
+| [GetILForModule](isosdacinterface-getilformodule-method.md) | Gets the intermediate language (IL) address that corresponds to a relative virtual address in a module. |
+| [GetJitManagerList](isosdacinterface-getjitmanagerlist-method.md) | Retrieves the list of JIT managers known to the runtime. |
 | [GetMethodDescData](isosdacinterface-getmethoddescdata-method.md) | Gets the data for the given MethodDesc pointer. |
+| [GetMethodDescFromToken](isosdacinterface-getmethoddescfromtoken-method.md) | Gets a MethodDesc address for a metadata token in a module. |
+| [GetMethodDescName](isosdacinterface-getmethoddescname-method.md) | Gets the name that corresponds to a MethodDesc address. |
+| [GetMethodDescPtrFromFrame](isosdacinterface-getmethoddescptrfromframe-method.md) | Gets the MethodDesc pointer that corresponds to a frame address. |
 | [GetMethodDescPtrFromIP](isosdacinterface-getmethoddescptrfromip-method.md) | Retrieves the pointer of the MethodDesc corresponding the method containing the given native instruction address. |
-| [GetModuleData](isosdacinterface-getmoduledata-method.md)| Fetches the data corresponding to the module loaded at a given address. |
+| [GetMethodTableData](isosdacinterface-getmethodtabledata-method.md) | Gets data for a method table. |
+| [GetMethodTableFieldData](isosdacinterface-getmethodtablefielddata-method.md) | Gets field data for a method table. |
+| [GetMethodTableForEEClass](isosdacinterface-getmethodtableforeeclass-method.md) | Gets the method table address that corresponds to an EEClass address. |
+| [GetMethodTableSlot](isosdacinterface-getmethodtableslot-method.md) | Gets the value of a slot in a method table. |
+| [GetModule](isosdacinterface-getmodule-method.md) | Gets an `IXCLRDataModule` interface for a module address. |
+| [GetModuleData](isosdacinterface-getmoduledata-method.md) | Fetches the data corresponding to the module loaded at a given address. |
+| [GetObjectData](isosdacinterface-getobjectdata-method.md) | Retrieves data for the object at the specified address. |
+| [GetOOMData](isosdacinterface-getoomdata-method.md) | Retrieves out-of-memory data for the specified garbage collection heap. |
+| [GetOOMStaticData](isosdacinterface-getoomstaticdata-method.md) | Retrieves static out-of-memory data for the garbage collector. |
+| [GetRCWData](isosdacinterface-getrcwdata-method.md) | Retrieves runtime callable wrapper (RCW) data for a COM wrapper address. |
+| [GetRCWInterfaces](isosdacinterface-getrcwinterfaces-method.md) | Retrieves COM interface pointer data for a runtime callable wrapper (RCW). |
+| [GetRegisterName](isosdacinterface-getregistername-method.md) | Retrieves the display name for a runtime register identifier. |
+| [GetStackReferences](isosdacinterface-getstackreferences-method.md) | Retrieves an enumerator for references on a thread call stack. |
+| [GetStressLogAddress](isosdacinterface-getstresslogaddress-method.md) | Retrieves the address of the runtime stress log. |
+| [GetSyncBlockCleanupData](isosdacinterface-getsyncblockcleanupdata-method.md) | Retrieves cleanup data for the sync block at the specified address. |
+| [GetSyncBlockData](isosdacinterface-getsyncblockdata-method.md) | Retrieves data for the sync block with the specified number. |
+| [GetThreadData](isosdacinterface-getthreaddata-method.md) | Retrieves data for the managed thread at the specified address. |
+| [GetThreadFromThinlockID](isosdacinterface-getthreadfromthinlockid-method.md) | Retrieves the managed thread address that corresponds to a thin-lock identifier. |
+| [GetThreadLocalModuleData](isosdacinterface-getthreadlocalmoduledata-method.md) | Retrieves thread-local module data for the specified thread and module index. |
+| [GetThreadpoolData](isosdacinterface-getthreadpooldata-method.md) | Retrieves data for the runtime thread pool. |
+| [GetThreadStoreData](isosdacinterface-getthreadstoredata-method.md) | Retrieves data about the runtime thread store. |
+| [GetTLSIndex](isosdacinterface-gettlsindex-method.md) | Retrieves the thread-local storage index used by the runtime. |
+| [GetUsefulGlobals](isosdacinterface-getusefulglobals-method.md) | Retrieves global runtime addresses that are commonly useful to diagnostic tools. |
+| [GetWorkRequestData](isosdacinterface-getworkrequestdata-method.md) | Retrieves data for the work request at the specified address. |
+| [TraverseLoaderHeap](isosdacinterface-traverseloaderheap-method.md) | Enumerates blocks in the specified loader heap. |
+| [TraverseModuleMap](isosdacinterface-traversemodulemap-method.md) | Traverses a module map and invokes a callback for each entry. |
+| [TraverseRCWCleanupList](isosdacinterface-traversercwcleanuplist-method.md) | Traverses the runtime callable wrapper (RCW) cleanup list and calls a visitor callback for each entry. |
+| [TraverseVirtCallStubHeap](isosdacinterface-traversevirtcallstubheap-method.md) | Enumerates blocks in a virtual call stub heap for the specified application domain. |
 
 ## Remarks
 

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-interface.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-interface.md
@@ -34,6 +34,7 @@ Provides helper methods to access data from `SOS`.
 | [GetCCWInterfaces](isosdacinterface-getccwinterfaces-method.md) | Retrieves COM interface pointer data for a COM callable wrapper (CCW). |
 | [GetCodeHeaderData](isosdacinterface-getcodeheaderdata-method.md) | Retrieves code header data for the JIT-compiled method that contains the specified instruction pointer. |
 | [GetCodeHeapList](isosdacinterface-getcodeheaplist-method.md) | Retrieves the list of code heaps for the specified JIT manager. |
+| [GetDomainLocalModuleData](isosdacinterface-getdomainlocalmoduledata-method.md) | Retrieves data for the domain-local module at the specified address. |
 | [GetDomainLocalModuleDataFromAppDomain](isosdacinterface-getdomainlocalmoduledatafromappdomain-method.md) | Retrieves domain-local module data for the specified application domain and module identifier. |
 | [GetDomainLocalModuleDataFromModule](isosdacinterface-getdomainlocalmoduledatafrommodule-method.md) | Retrieves domain-local module data for the specified module. |
 | [GetFieldDescData](isosdacinterface-getfielddescdata-method.md) | Gets data for a FieldDesc address. |

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-traverseloaderheap-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-traverseloaderheap-method.md
@@ -1,0 +1,58 @@
+---
+description: "Learn more about: ISOSDacInterface::TraverseLoaderHeap Method"
+title: "ISOSDacInterface::TraverseLoaderHeap Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::TraverseLoaderHeap Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::TraverseLoaderHeap Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::TraverseLoaderHeap Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::TraverseLoaderHeap Method
+
+Enumerates blocks in the specified loader heap.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT TraverseLoaderHeap(CLRDATA_ADDRESS loaderHeapAddr, VISITHEAP pCallback);
+```
+
+## Parameters
+
+`loaderHeapAddr`\
+[in] The address of the loader heap to traverse.
+
+`pCallback`\
+[in] A `VISITHEAP` callback function that receives each heap block.
+
+## Remarks
+
+The `VISITHEAP` callback has the signature `void (*VISITHEAP)(CLRDATA_ADDRESS blockData,size_t blockSize,BOOL blockIsCurrentBlock)`. The runtime calls the callback for each heap block and supplies the block address, block size, and a value that indicates whether the block is the current block.
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 68th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-traverseloaderheap-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-traverseloaderheap-method.md
@@ -55,3 +55,4 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::TraverseVirtCallStubHeap Method](isosdacinterface-traversevirtcallstubheap-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-traverseloaderheap-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-traverseloaderheap-method.md
@@ -51,7 +51,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
 
-
 ## See also
 
 - [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-traversemodulemap-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-traversemodulemap-method.md
@@ -1,0 +1,64 @@
+---
+description: "Learn more about: ISOSDacInterface::TraverseModuleMap Method"
+title: "ISOSDacInterface::TraverseModuleMap Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::TraverseModuleMap Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::TraverseModuleMap Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::TraverseModuleMap Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::TraverseModuleMap Method
+
+Traverses a module map and invokes a callback for each entry.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT TraverseModuleMap(ModuleMapType mmt, CLRDATA_ADDRESS moduleAddr, MODULEMAPTRAVERSE pCallback, LPVOID token);
+```
+
+## Parameters
+
+`mmt`\
+[in] A [ModuleMapType enumeration](modulemaptype-enumeration.md) value that indicates which module map to traverse.
+
+`moduleAddr`\
+[in] The address of the module whose map to traverse.
+
+`pCallback`\
+[in] A `MODULEMAPTRAVERSE` callback function to invoke for each map entry.
+
+`token`\
+[in] A caller-defined value that is passed to the callback function.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 15th slot of the virtual method table.
+
+The `MODULEMAPTRAVERSE` callback has the following signature: `typedef void (*MODULEMAPTRAVERSE)(UINT index, CLRDATA_ADDRESS methodTable,LPVOID token);`. The callback receives the map entry index, the method table address for that entry, and the caller-defined token.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ModuleMapType Enumeration](modulemaptype-enumeration.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-traversemodulemap-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-traversemodulemap-method.md
@@ -62,3 +62,6 @@ The `MODULEMAPTRAVERSE` callback has the following signature: `typedef void (*MO
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [ModuleMapType Enumeration](modulemaptype-enumeration.md)
+- [ISOSDacInterface::GetModule Method](isosdacinterface-getmodule-method.md)
+- [ISOSDacInterface::GetModuleData Method](isosdacinterface-getmoduledata-method.md)
+- [ISOSDacInterface::GetILForModule Method](isosdacinterface-getilformodule-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-traversercwcleanuplist-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-traversercwcleanuplist-method.md
@@ -1,0 +1,67 @@
+---
+description: "Learn more about: ISOSDacInterface::TraverseRCWCleanupList Method"
+title: "ISOSDacInterface::TraverseRCWCleanupList Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::TraverseRCWCleanupList Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::TraverseRCWCleanupList Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::TraverseRCWCleanupList Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::TraverseRCWCleanupList Method
+
+Traverses the runtime callable wrapper (RCW) cleanup list and calls a visitor callback for each entry.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT TraverseRCWCleanupList(CLRDATA_ADDRESS cleanupListPtr, VISITRCWFORCLEANUP pCallback, LPVOID token);
+```
+
+## Parameters
+
+`cleanupListPtr`\
+[in] The address of the RCW cleanup list to traverse.
+
+`pCallback`\
+[in] A `VISITRCWFORCLEANUP` callback function that the runtime calls for each cleanup-list entry.
+
+`token`\
+[in] A caller-supplied value that the runtime passes to `pCallback`.
+
+## Remarks
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 79th slot of the virtual method table.
+
+The `VISITRCWFORCLEANUP` callback has the following signature:
+
+```cpp
+typedef BOOL (*VISITRCWFORCLEANUP)(CLRDATA_ADDRESS RCW,CLRDATA_ADDRESS Context,CLRDATA_ADDRESS Thread, 
+    BOOL bIsFreeThreaded, LPVOID token);
+```
+
+The callback receives the RCW address, COM context address, thread address, a flag that indicates whether the RCW is free-threaded, and the caller-supplied `token` value.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-traversercwcleanuplist-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-traversercwcleanuplist-method.md
@@ -65,3 +65,5 @@ The callback receives the RCW address, COM context address, thread address, a fl
 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [ISOSDacInterface::GetRCWData Method](isosdacinterface-getrcwdata-method.md)
+- [ISOSDacInterface::GetRCWInterfaces Method](isosdacinterface-getrcwinterfaces-method.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-traversevirtcallstubheap-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-traversevirtcallstubheap-method.md
@@ -54,7 +54,6 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
 
-
 ## See also
 
 - [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-traversevirtcallstubheap-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-traversevirtcallstubheap-method.md
@@ -1,0 +1,62 @@
+---
+description: "Learn more about: ISOSDacInterface::TraverseVirtCallStubHeap Method"
+title: "ISOSDacInterface::TraverseVirtCallStubHeap Method"
+ms.date: "07/30/2026"
+api.name:
+  - "ISOSDacInterface::TraverseVirtCallStubHeap Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "ISOSDacInterface::TraverseVirtCallStubHeap Method"
+helpviewer.keywords:
+  - "ISOSDacInterface::TraverseVirtCallStubHeap Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ISOSDacInterface::TraverseVirtCallStubHeap Method
+
+Enumerates blocks in a virtual call stub heap for the specified application domain.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT TraverseVirtCallStubHeap(CLRDATA_ADDRESS pAppDomain, VCSHeapType heaptype, VISITHEAP pCallback);
+```
+
+## Parameters
+
+`pAppDomain`\
+[in] The address of the application domain that contains the virtual call stub heap.
+
+`heaptype`\
+[in] A [VCSHeapType enumeration](vcsheaptype-enumeration.md) value that identifies the virtual call stub heap to traverse.
+
+`pCallback`\
+[in] A `VISITHEAP` callback function that receives each heap block.
+
+## Remarks
+
+The `VISITHEAP` callback has the signature `void (*VISITHEAP)(CLRDATA_ADDRESS blockData,size_t blockSize,BOOL blockIsCurrentBlock)`. The runtime calls the callback for each heap block and supplies the block address, block size, and a value that indicates whether the block is the current block.
+
+The provided method is part of the `ISOSDacInterface` interface and corresponds to the 70th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging](index.md)
+- [ISOSDacInterface Interface](isosdacinterface-interface.md)
+- [VCSHeapType Enumeration](vcsheaptype-enumeration.md)

--- a/docs/framework/unmanaged-api/debugging/isosdacinterface-traversevirtcallstubheap-method.md
+++ b/docs/framework/unmanaged-api/debugging/isosdacinterface-traversevirtcallstubheap-method.md
@@ -59,3 +59,4 @@ The provided method is part of the `ISOSDacInterface` interface and corresponds 
 - [Debugging](index.md)
 - [ISOSDacInterface Interface](isosdacinterface-interface.md)
 - [VCSHeapType Enumeration](vcsheaptype-enumeration.md)
+- [ISOSDacInterface::TraverseLoaderHeap Method](isosdacinterface-traverseloaderheap-method.md)

--- a/docs/framework/unmanaged-api/debugging/ixclrdatamodule-getname-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatamodule-getname-method.md
@@ -60,3 +60,5 @@ The provided method is part of the `IXCLRDataModule` interface and corresponds t
 
 - [Debugging](index.md)
 - [IXCLRDataModule Interface](ixclrdatamodule-interface.md)
+- [IXCLRDataModule::GetFileName Method](ixclrdatamodule-getfilename-method.md)
+- [IXCLRDataModule::GetVersionId Method](ixclrdatamodule-getversionid-method.md)

--- a/docs/framework/unmanaged-api/debugging/ixclrdatamodule-getname-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatamodule-getname-method.md
@@ -1,0 +1,62 @@
+---
+description: "Learn more about: IXCLRDataModule::GetName Method"
+title: "IXCLRDataModule::GetName Method"
+ms.date: "07/30/2026"
+api.name:
+  - "IXCLRDataModule::GetName Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "IXCLRDataModule::GetName Method"
+helpviewer.keywords:
+  - "IXCLRDataModule::GetName Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+author: "leculver"
+ms.author: "leculver"
+ai-usage: ai-assisted
+---
+# IXCLRDataModule::GetName Method
+
+Gets the module's base name.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetName(
+    [in] ULONG32 bufLen,
+    [out] ULONG32 *nameLen,
+    [out, size_is(bufLen)] WCHAR name[]
+);
+```
+
+## Parameters
+
+`bufLen`\
+[in] The number of characters in the `name` buffer.
+
+`nameLen`\
+[out] A pointer to the number of characters actually written into the `name` buffer.
+
+`name`\
+[out, size_is(bufLen)] A pointer to a character array.
+
+## Remarks
+
+The provided method is part of the `IXCLRDataModule` interface and corresponds to the 30th slot of the virtual method table.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [IXCLRDataModule Interface](ixclrdatamodule-interface.md)

--- a/docs/framework/unmanaged-api/debugging/ixclrdatamodule-interface.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatamodule-interface.md
@@ -26,6 +26,7 @@ Provides methods for querying information about a loaded module.
 
 | Method                                                                                                                                | Description                                                         |
 | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| [GetName](ixclrdatamodule-getname-method.md) | Gets the module's base name. |
 | [StartEnumTypeDefinitions](ixclrdatamodule-startenumtypedefinitions-method.md)     | Provides a handle to enumerate the type definitions associated with the module. |
 | [EnumTypeDefinition](ixclrdatamodule-enumtypedefinition-method.md)                 | Enumerates the type definitions associated with the module. |
 | [EndEnumTypeDefinitions](ixclrdatamodule-endenumtypedefinitions-method.md)         | Releases the resources used by internal iterators used during type definition enumeration. |

--- a/docs/framework/unmanaged-api/debugging/ixclrdataprocess-flush-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdataprocess-flush-method.md
@@ -1,0 +1,53 @@
+---
+description: "Learn more about: IXCLRDataProcess::Flush Method"
+title: "IXCLRDataProcess::Flush Method"
+ms.date: "07/30/2026"
+api.name:
+  - "IXCLRDataProcess::Flush Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "IXCLRDataProcess::Flush Method"
+helpviewer.keywords:
+  - "IXCLRDataProcess::Flush Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+author: "leculver"
+ms.author: "leculver"
+ai-usage: ai-assisted
+---
+# IXCLRDataProcess::Flush Method
+
+Flushes cached data for the process.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT Flush();
+```
+
+## Parameters
+
+None.
+
+## Remarks
+
+The provided method is part of the `IXCLRDataProcess` interface and corresponds to the 4th slot of the virtual method table.
+
+All `ICLR*` interfaces obtained for this process become invalid after this method is called.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [IXCLRDataProcess Interface](ixclrdataprocess-interface.md)

--- a/docs/framework/unmanaged-api/debugging/ixclrdataprocess-interface.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdataprocess-interface.md
@@ -26,6 +26,7 @@ Provides methods for querying information about a process.
 
 | Method                                                                                                                                               | Description                                                                                     |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [Flush](ixclrdataprocess-flush-method.md) | Flushes cached data for the process. |
 | [GetRuntimeNameByAddress](ixclrdataprocess-getruntimenamebyaddress-method.md)                     | Gets a name for the given address.                                                               |
 | [GetAppDomainByUniqueId](ixclrdataprocess-getappdomainbyuniqueid-method.md)                       | Gets an `AppDomain` in a process by its unique id.                                              |
 | [StartEnumModules](ixclrdataprocess-startenummodules-method.md)                                   | Provides a handle to enumerate the modules of a process.                                        |

--- a/docs/framework/unmanaged-api/debugging/ixclrdatastackwalk-getcontext-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatastackwalk-getcontext-method.md
@@ -1,0 +1,68 @@
+---
+description: "Learn more about: IXCLRDataStackWalk::GetContext Method"
+title: "IXCLRDataStackWalk::GetContext Method"
+ms.date: "07/30/2026"
+api.name:
+  - "IXCLRDataStackWalk::GetContext Method"
+api.location:
+  - "mscordacwks.dll"
+api.type:
+  - "COM"
+f1.keywords:
+  - "IXCLRDataStackWalk::GetContext Method"
+helpviewer.keywords:
+  - "IXCLRDataStackWalk::GetContext Method [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+author: "leculver"
+ms.author: "leculver"
+ai-usage: ai-assisted
+---
+# IXCLRDataStackWalk::GetContext Method
+
+Gets the current context of this stack walk.
+
+[!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
+
+## Syntax
+
+```cpp
+HRESULT GetContext(
+    [in] ULONG32 contextFlags,
+    [in] ULONG32 contextBufSize,
+    [out] ULONG32* contextSize,
+    [out, size_is(contextBufSize)] BYTE contextBuf[]
+);
+```
+
+## Parameters
+
+`contextFlags`\
+[in] The flags that control which parts of the context to return.
+
+`contextBufSize`\
+[in] The size of the `contextBuf` buffer.
+
+`contextSize`\
+[out] A pointer to the number of bytes actually written into the `contextBuf` buffer.
+
+`contextBuf`\
+[out, size_is(contextBufSize)] A buffer that stores the context.
+
+## Remarks
+
+The provided method is part of the `IXCLRDataStackWalk` interface and corresponds to the 4th slot of the virtual method table.
+
+The context is the original context with any unwinding applied to it. As unwinding may restore only a subset of the registers, such as only non-volatile registers, the context may not exactly match the register state at the time of the actual call.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging](index.md)
+- [IXCLRDataStackWalk Interface](ixclrdatastackwalk-interface.md)

--- a/docs/framework/unmanaged-api/debugging/ixclrdatastackwalk-getcontext-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatastackwalk-getcontext-method.md
@@ -66,3 +66,6 @@ The context is the original context with any unwinding applied to it. As unwindi
 
 - [Debugging](index.md)
 - [IXCLRDataStackWalk Interface](ixclrdatastackwalk-interface.md)
+- [IXCLRDataStackWalk::SetContext Method](ixclrdatastackwalk-setcontext-method.md)
+- [IXCLRDataStackWalk::Next Method](ixclrdatastackwalk-next-method.md)
+- [IXCLRDataStackWalk::GetFrame Method](ixclrdatastackwalk-getframe-method.md)

--- a/docs/framework/unmanaged-api/debugging/ixclrdatastackwalk-interface.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatastackwalk-interface.md
@@ -27,6 +27,7 @@ Provides methods for walking the stack.
 
 | Method                                                                                                                  | Description                                 |
 | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| [GetContext](ixclrdatastackwalk-getcontext-method.md) | Gets the current context of this stack walk. |
 | [SetContext](ixclrdatastackwalk-setcontext-method.md) | Change the context of this stack walk. |
 | [GetFrameType](ixclrdatastackwalk-getframetype-method.md) | Gets information about the type of the current frame. |
 | [GetFrame](ixclrdatastackwalk-getframe-method.md) | Gets the current frame if it is recognized. |

--- a/docs/framework/unmanaged-api/debugging/modulemaptype-enumeration.md
+++ b/docs/framework/unmanaged-api/debugging/modulemaptype-enumeration.md
@@ -25,7 +25,7 @@ Indicates the kind of module map to traverse.
 ## Syntax
 
 ```cpp
-typedef enum ModuleMapType { TYPEDEFTOMETHODTABLE, TYPEREFTOMETHODTABLE };
+typedef enum ModuleMapType { TYPEDEFTOMETHODTABLE, TYPEREFTOMETHODTABLE } ModuleMapType;
 ```
 
 ## Members

--- a/docs/framework/unmanaged-api/debugging/modulemaptype-enumeration.md
+++ b/docs/framework/unmanaged-api/debugging/modulemaptype-enumeration.md
@@ -1,0 +1,52 @@
+---
+description: "Learn more about: ModuleMapType Enumeration"
+title: "ModuleMapType Enumeration"
+ms.date: "07/30/2026"
+api_name:
+  - "ModuleMapType"
+api_location:
+  - "mscordacwks.dll"
+api_type:
+  - "COM"
+f1_keywords:
+  - "ModuleMapType"
+helpviewer_keywords:
+  - "ModuleMapType enumeration [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# ModuleMapType Enumeration
+
+Indicates the kind of module map to traverse.
+
+## Syntax
+
+```cpp
+typedef enum ModuleMapType { TYPEDEFTOMETHODTABLE, TYPEREFTOMETHODTABLE };
+```
+
+## Members
+
+|Member|Description|
+|------------|-----------------|
+|`TYPEDEFTOMETHODTABLE`|The module map maps TypeDef tokens to method table addresses.|
+|`TYPEREFTOMETHODTABLE`|The module map maps TypeRef tokens to method table addresses.|
+
+## Remarks
+
+This enumeration lives inside the runtime and is not exposed through any headers or library files. To use it, define the enumeration as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+## See also
+
+- [Debugging Enumerations](debugging-enumerations.md)
+- [Debugging](index.md)

--- a/docs/framework/unmanaged-api/debugging/toc.yml
+++ b/docs/framework/unmanaged-api/debugging/toc.yml
@@ -126,12 +126,116 @@ items:
     - name: ISOSDacInterface interface
       href: isosdacinterface-interface.md
       items:
+        - name: GetAppDomainData
+          href: isosdacinterface-getappdomaindata-method.md
+        - name: GetAppDomainList
+          href: isosdacinterface-getappdomainlist-method.md
+        - name: GetAppDomainStoreData
+          href: isosdacinterface-getappdomainstoredata-method.md
+        - name: GetAssemblyData
+          href: isosdacinterface-getassemblydata-method.md
+        - name: GetCCWData
+          href: isosdacinterface-getccwdata-method.md
+        - name: GetCCWInterfaces
+          href: isosdacinterface-getccwinterfaces-method.md
+        - name: GetCodeHeaderData
+          href: isosdacinterface-getcodeheaderdata-method.md
+        - name: GetCodeHeapList
+          href: isosdacinterface-getcodeheaplist-method.md
+        - name: GetDomainLocalModuleDataFromAppDomain
+          href: isosdacinterface-getdomainlocalmoduledatafromappdomain-method.md
+        - name: GetDomainLocalModuleDataFromModule
+          href: isosdacinterface-getdomainlocalmoduledatafrommodule-method.md
+        - name: GetFieldDescData
+          href: isosdacinterface-getfielddescdata-method.md
+        - name: GetGCHeapData
+          href: isosdacinterface-getgcheapdata-method.md
+        - name: GetGCHeapDetails
+          href: isosdacinterface-getgcheapdetails-method.md
+        - name: GetGCHeapList
+          href: isosdacinterface-getgcheaplist-method.md
+        - name: GetGCHeapStaticData
+          href: isosdacinterface-getgcheapstaticdata-method.md
+        - name: GetHandleEnum
+          href: isosdacinterface-gethandleenum-method.md
+        - name: GetHandleEnumForTypes
+          href: isosdacinterface-gethandleenumfortypes-method.md
+        - name: GetHeapAnalyzeData
+          href: isosdacinterface-getheapanalyzedata-method.md
+        - name: GetHeapAnalyzeStaticData
+          href: isosdacinterface-getheapanalyzestaticdata-method.md
+        - name: GetHeapSegmentData
+          href: isosdacinterface-getheapsegmentdata-method.md
+        - name: GetILForModule
+          href: isosdacinterface-getilformodule-method.md
+        - name: GetJitManagerList
+          href: isosdacinterface-getjitmanagerlist-method.md
         - name: GetMethodDescData
           href: isosdacinterface-getmethoddescdata-method.md
+        - name: GetMethodDescFromToken
+          href: isosdacinterface-getmethoddescfromtoken-method.md
+        - name: GetMethodDescName
+          href: isosdacinterface-getmethoddescname-method.md
+        - name: GetMethodDescPtrFromFrame
+          href: isosdacinterface-getmethoddescptrfromframe-method.md
         - name: GetMethodDescPtrFromIP
           href: isosdacinterface-getmethoddescptrfromip-method.md
+        - name: GetMethodTableData
+          href: isosdacinterface-getmethodtabledata-method.md
+        - name: GetMethodTableFieldData
+          href: isosdacinterface-getmethodtablefielddata-method.md
+        - name: GetMethodTableForEEClass
+          href: isosdacinterface-getmethodtableforeeclass-method.md
+        - name: GetMethodTableSlot
+          href: isosdacinterface-getmethodtableslot-method.md
+        - name: GetModule
+          href: isosdacinterface-getmodule-method.md
         - name: GetModuleData
           href: isosdacinterface-getmoduledata-method.md
+        - name: GetObjectData
+          href: isosdacinterface-getobjectdata-method.md
+        - name: GetOOMData
+          href: isosdacinterface-getoomdata-method.md
+        - name: GetOOMStaticData
+          href: isosdacinterface-getoomstaticdata-method.md
+        - name: GetRCWData
+          href: isosdacinterface-getrcwdata-method.md
+        - name: GetRCWInterfaces
+          href: isosdacinterface-getrcwinterfaces-method.md
+        - name: GetRegisterName
+          href: isosdacinterface-getregistername-method.md
+        - name: GetStackReferences
+          href: isosdacinterface-getstackreferences-method.md
+        - name: GetStressLogAddress
+          href: isosdacinterface-getstresslogaddress-method.md
+        - name: GetSyncBlockCleanupData
+          href: isosdacinterface-getsyncblockcleanupdata-method.md
+        - name: GetSyncBlockData
+          href: isosdacinterface-getsyncblockdata-method.md
+        - name: GetThreadData
+          href: isosdacinterface-getthreaddata-method.md
+        - name: GetThreadFromThinlockID
+          href: isosdacinterface-getthreadfromthinlockid-method.md
+        - name: GetThreadLocalModuleData
+          href: isosdacinterface-getthreadlocalmoduledata-method.md
+        - name: GetThreadpoolData
+          href: isosdacinterface-getthreadpooldata-method.md
+        - name: GetThreadStoreData
+          href: isosdacinterface-getthreadstoredata-method.md
+        - name: GetTLSIndex
+          href: isosdacinterface-gettlsindex-method.md
+        - name: GetUsefulGlobals
+          href: isosdacinterface-getusefulglobals-method.md
+        - name: GetWorkRequestData
+          href: isosdacinterface-getworkrequestdata-method.md
+        - name: TraverseLoaderHeap
+          href: isosdacinterface-traverseloaderheap-method.md
+        - name: TraverseModuleMap
+          href: isosdacinterface-traversemodulemap-method.md
+        - name: TraverseRCWCleanupList
+          href: isosdacinterface-traversercwcleanuplist-method.md
+        - name: TraverseVirtCallStubHeap
+          href: isosdacinterface-traversevirtcallstubheap-method.md
     - name: IXCLRDataAppDomain interface
       href: ixclrdataappdomain-interface.md
     - name: IXCLRDataExceptionNotification interface
@@ -270,6 +374,8 @@ items:
           href: ixclrdatamodule-getfilename-method.md
         - name: GetMethodDefinitionByToken
           href: ixclrdatamodule-getmethoddefinitionbytoken-method.md
+        - name: GetName
+          href: ixclrdatamodule-getname-method.md
         - name: GetVersionId
           href: ixclrdatamodule-getversionid-method.md
         - name: Request
@@ -303,6 +409,8 @@ items:
           href: ixclrdataprocess-enummethodinstancebyaddress-method.md
         - name: EnumModule
           href: ixclrdataprocess-enummodule-method.md
+        - name: Flush
+          href: ixclrdataprocess-flush-method.md
         - name: FollowStub
           href: ixclrdataprocess-followstub-method.md
         - name: FollowStub2
@@ -336,6 +444,8 @@ items:
     - name: IXCLRDataStackWalk interface
       href: ixclrdatastackwalk-interface.md
       items:
+        - name: GetContext method
+          href: ixclrdatastackwalk-getcontext-method.md
         - name: GetFrame method
           href: ixclrdatastackwalk-getframe-method.md
         - name: GetFrameType method
@@ -480,6 +590,12 @@ items:
       href: clr-debugging-process-flags-enumeration.md
     - name: CorDebugJITCompilerFlagsDeprecated enumeration
       href: cordebugjitcompilerflagsdeprecated-enumeration.md
+    - name: DacpObjectType enumeration
+      href: dacpobjecttype-enumeration.md
+    - name: ModuleMapType enumeration
+      href: modulemaptype-enumeration.md
+    - name: VCSHeapType enumeration
+      href: vcsheaptype-enumeration.md
 - name: Debugging structures
   href: debugging-structures.md
   items:
@@ -493,17 +609,73 @@ items:
       href: clrdata-il-address-map-structure.md
     - name: CLR_DEBUGGING_VERSION structure
       href: clr-debugging-version-structure.md
+    - name: DacpAppDomainData structure
+      href: dacpappdomaindata-structure.md
+    - name: DacpAppDomainStoreData structure
+      href: dacpappdomainstoredata-structure.md
+    - name: DacpAssemblyData structure
+      href: dacpassemblydata-structure.md
+    - name: DacpCCWData structure
+      href: dacpccwdata-structure.md
+    - name: DacpCodeHeaderData structure
+      href: dacpcodeheaderdata-structure.md
+    - name: DacpCOMInterfacePointerData structure
+      href: dacpcominterfacepointerdata-structure.md
+    - name: DacpDomainLocalModuleData structure
+      href: dacpdomainlocalmoduledata-structure.md
+    - name: DacpFieldDescData structure
+      href: dacpfielddescdata-structure.md
+    - name: DacpGcHeapAnalyzeData structure
+      href: dacpgcheapanalyzedata-structure.md
+    - name: DacpGcHeapData structure
+      href: dacpgcheapdata-structure.md
+    - name: DacpGcHeapDetails structure
+      href: dacpgcheapdetails-structure.md
+    - name: DacpGenerationData structure
+      href: dacpgenerationdata-structure.md
     - name: DacpGetModuleAddress structure
       href: dacpgetmoduleaddress-structure.md
       items:
         - name: "DacpGetModuleAddress::Request method"
           href: dacpgetmoduleaddress-request-method.md
+    - name: DacpHeapSegmentData structure
+      href: dacpheapsegmentdata-structure.md
+    - name: DacpJitCodeHeapInfo structure
+      href: dacpjitcodeheapinfo-structure.md
+    - name: DacpJitManagerInfo structure
+      href: dacpjitmanagerinfo-structure.md
     - name: DacpMethodDescData structure
       href: dacpmethoddescdata-structure.md
+    - name: DacpMethodTableData structure
+      href: dacpmethodtabledata-structure.md
+    - name: DacpMethodTableFieldData structure
+      href: dacpmethodtablefielddata-structure.md
     - name: DacpModuleData structure
       href: dacpmoduledata-structure.md
+    - name: DacpObjectData structure
+      href: dacpobjectdata-structure.md
+    - name: DacpOomData structure
+      href: dacpoomdata-structure.md
+    - name: DacpRCWData structure
+      href: dacprcwdata-structure.md
     - name: DacpReJitData structure
       href: dacprejitdata-structure.md
+    - name: DacpSyncBlockCleanupData structure
+      href: dacpsyncblockcleanupdata-structure.md
+    - name: DacpSyncBlockData structure
+      href: dacpsyncblockdata-structure.md
+    - name: DacpThreadData structure
+      href: dacpthreaddata-structure.md
+    - name: DacpThreadLocalModuleData structure
+      href: dacpthreadlocalmoduledata-structure.md
+    - name: DacpThreadpoolData structure
+      href: dacpthreadpooldata-structure.md
+    - name: DacpThreadStoreData structure
+      href: dacpthreadstoredata-structure.md
+    - name: DacpUsefulGlobalsData structure
+      href: dacpusefulglobalsdata-structure.md
+    - name: DacpWorkRequestData structure
+      href: dacpworkrequestdata-structure.md
     - name: GcEvtArgs structure
       href: gcevtargs-structure.md
     - name: StackTrace_SimpleContext structure

--- a/docs/framework/unmanaged-api/debugging/toc.yml
+++ b/docs/framework/unmanaged-api/debugging/toc.yml
@@ -142,6 +142,8 @@ items:
           href: isosdacinterface-getcodeheaderdata-method.md
         - name: GetCodeHeapList
           href: isosdacinterface-getcodeheaplist-method.md
+        - name: GetDomainLocalModuleData
+          href: isosdacinterface-getdomainlocalmoduledata-method.md
         - name: GetDomainLocalModuleDataFromAppDomain
           href: isosdacinterface-getdomainlocalmoduledatafromappdomain-method.md
         - name: GetDomainLocalModuleDataFromModule

--- a/docs/framework/unmanaged-api/debugging/vcsheaptype-enumeration.md
+++ b/docs/framework/unmanaged-api/debugging/vcsheaptype-enumeration.md
@@ -25,7 +25,7 @@ Identifies a virtual call stub heap type.
 ## Syntax
 
 ```cpp
-typedef enum VCSHeapType {IndcellHeap, LookupHeap, ResolveHeap, DispatchHeap, CacheEntryHeap};
+typedef enum VCSHeapType { IndcellHeap, LookupHeap, ResolveHeap, DispatchHeap, CacheEntryHeap } VCSHeapType;
 ```
 
 ## Members
@@ -48,7 +48,6 @@ This enumeration lives inside the runtime and is not exposed through any headers
 **Header:** None  
 **Library:** None  
 **.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
-
 
 ## See also
 

--- a/docs/framework/unmanaged-api/debugging/vcsheaptype-enumeration.md
+++ b/docs/framework/unmanaged-api/debugging/vcsheaptype-enumeration.md
@@ -1,0 +1,56 @@
+---
+description: "Learn more about: VCSHeapType Enumeration"
+title: "VCSHeapType Enumeration"
+ms.date: "07/30/2026"
+api_name:
+  - "VCSHeapType"
+api_location:
+  - "mscordacwks.dll"
+api_type:
+  - "COM"
+f1_keywords:
+  - "VCSHeapType"
+helpviewer_keywords:
+  - "VCSHeapType Enumeration [.NET Framework debugging]"
+topic_type:
+  - "apiref"
+ai-usage: ai-assisted
+author: "leculver"
+ms.author: "leculver"
+---
+# VCSHeapType Enumeration
+
+Identifies a virtual call stub heap type.
+
+## Syntax
+
+```cpp
+typedef enum VCSHeapType {IndcellHeap, LookupHeap, ResolveHeap, DispatchHeap, CacheEntryHeap};
+```
+
+## Members
+
+| Member | Description |
+| ------ | ----------- |
+| `IndcellHeap` | The indirection cell heap. |
+| `LookupHeap` | The lookup stub heap. |
+| `ResolveHeap` | The resolve stub heap. |
+| `DispatchHeap` | The dispatch stub heap. |
+| `CacheEntryHeap` | The cache entry heap. |
+
+## Remarks
+
+This enumeration lives inside the runtime and is not exposed through any headers or library files. To use it, define the enumeration as specified above.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+**Header:** None  
+**Library:** None  
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+
+## See also
+
+- [Debugging Enumerations](debugging-enumerations.md)
+- [Debugging](index.md)


### PR DESCRIPTION
Adds reference documentation for the private DAC (mscordacwks.dll) APIs that ClrMD consumes on the desktop .NET Framework surface, so that consumers of ClrMD can be assured every API it takes a dependency on is either documented, or open source.

- 52 new ISOSDacInterface method pages (the subset ClrMD calls)
- 28 new Dacp* structure pages and 3 enumeration pages referenced by those methods
- Fills 3 IXCLRData* gaps missed by #41675: IXCLRDataProcess::Flush, IXCLRDataModule::GetName, IXCLRDataStackWalk::GetContext
- Expands the ISOSDacInterface interface method table, updates the debugging structures/enumerations indexes and the affected IXCLRData* interface pages, and registers every new page in toc.yml

All new pages follow the existing IXCLRData* style, include the prefer-ICorDebug (DBI) recommended note, and carry ai-usage: ai-assisted frontmatter per repo guidance.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| File | Preview link |
|:--|:--|
| [docs/framework/unmanaged-api/debugging/dacpappdomaindata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpappdomaindata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpappdomaindata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpappdomaindata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpappdomainstoredata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpappdomainstoredata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpappdomainstoredata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpappdomainstoredata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpassemblydata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpassemblydata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpassemblydata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpassemblydata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpccwdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpccwdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpccwdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpccwdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpcodeheaderdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpcodeheaderdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpcodeheaderdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpcodeheaderdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpcominterfacepointerdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpcominterfacepointerdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpcominterfacepointerdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpcominterfacepointerdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpdomainlocalmoduledata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpdomainlocalmoduledata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpdomainlocalmoduledata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpdomainlocalmoduledata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpfielddescdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpfielddescdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpfielddescdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpfielddescdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpgcheapanalyzedata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpgcheapanalyzedata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpgcheapanalyzedata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpgcheapanalyzedata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpgcheapdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpgcheapdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpgcheapdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpgcheapdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpgcheapdetails-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpgcheapdetails-structure.md) | [docs/framework/unmanaged-api/debugging/dacpgcheapdetails-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpgcheapdetails-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpgenerationdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpgenerationdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpgenerationdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpgenerationdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpheapsegmentdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpheapsegmentdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpheapsegmentdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpheapsegmentdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpjitcodeheapinfo-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpjitcodeheapinfo-structure.md) | [docs/framework/unmanaged-api/debugging/dacpjitcodeheapinfo-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpjitcodeheapinfo-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpjitmanagerinfo-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpjitmanagerinfo-structure.md) | [docs/framework/unmanaged-api/debugging/dacpjitmanagerinfo-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpjitmanagerinfo-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpmethodtabledata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpmethodtabledata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpmethodtabledata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpmethodtabledata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpmethodtablefielddata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpmethodtablefielddata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpmethodtablefielddata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpmethodtablefielddata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpobjectdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpobjectdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpobjectdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpobjectdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpobjecttype-enumeration.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpobjecttype-enumeration.md) | [docs/framework/unmanaged-api/debugging/dacpobjecttype-enumeration](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpobjecttype-enumeration?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpoomdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpoomdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpoomdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpoomdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacprcwdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacprcwdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacprcwdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacprcwdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpsyncblockcleanupdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpsyncblockcleanupdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpsyncblockcleanupdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpsyncblockcleanupdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpsyncblockdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpsyncblockdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpsyncblockdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpsyncblockdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpthreaddata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpthreaddata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpthreaddata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpthreaddata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpthreadlocalmoduledata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpthreadlocalmoduledata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpthreadlocalmoduledata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpthreadlocalmoduledata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpthreadpooldata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpthreadpooldata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpthreadpooldata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpthreadpooldata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpthreadstoredata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpthreadstoredata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpthreadstoredata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpthreadstoredata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpusefulglobalsdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpusefulglobalsdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpusefulglobalsdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpusefulglobalsdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/dacpworkrequestdata-structure.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/dacpworkrequestdata-structure.md) | [docs/framework/unmanaged-api/debugging/dacpworkrequestdata-structure](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/dacpworkrequestdata-structure?branch=pr-en-us-55194) |
| [docs/framework/unmanaged-api/debugging/debugging-enumerations.md](https://github.com/dotnet/docs/blob/2c5020684c25de896f7018390b3810b6abd23c96/docs/framework/unmanaged-api/debugging/debugging-enumerations.md) | [docs/framework/unmanaged-api/debugging/debugging-enumerations](https://review.learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/debugging/debugging-enumerations?branch=pr-en-us-55194) |

</details>

> [!NOTE]
> This table shows the first 30 preview links (sorted alphabetically by file path) found in the OPS build report. For the full list, select <strong>OpenPublishing.Build Details</strong> within [checks](https://github.com/dotnet/docs/pull/55194/checks).


<!-- PREVIEW-TABLE-END -->