### PR TITLE
Revert "[Diagnostics] Add EventPipe Buffer Mode and EventFilter"

### DIFF
--- a/docs/core/diagnostics/dotnet-gcdump.md
+++ b/docs/core/diagnostics/dotnet-gcdump.md
@@ -1,9 +1,8 @@
 ---
 title: dotnet-gcdump diagnostic tool - .NET CLI
 description: Learn how to install and use dotnet-gcdump CLI tool to collect GC (Garbage Collector) dumps of live .NET processes using the .NET EventPipe.
-ms.date: 07/09/2026
+ms.date: 06/03/2025
 ms.topic: reference
-ai-usage: ai-assisted
 ---
 # Heap analysis tool (dotnet-gcdump)
 
@@ -46,9 +45,6 @@ The `dotnet-gcdump` global tool collects GC (Garbage Collector) dumps of live .N
 - Comparing the number of objects on the heap at several points in time.
 - Analyzing roots of objects (answering questions like, "what still has a reference to this type?").
 - Collecting general statistics about the counts of objects on the heap.
-
-> [!NOTE]
-> `dotnet-gcdump` collects with non-lossy buffering so the GC dump is complete on large heaps. Non-lossy buffering requires a .NET 11+ target runtime; on older runtimes, the tool automatically falls back to lossy buffering. Non-lossy buffering is complete only up to the runtime's buffer capacity, not against host memory exhaustion. Under memory pressure, the runtime can still drop events.
 
 ### View the GC dump captured from dotnet-gcdump
 
@@ -257,7 +253,7 @@ dotnet-gcdump report [-h|--help] [-p|--process-id <pid>] [-t|--report-type <Heap
 
 - `dotnet-gcdump` is unable to generate a `.gcdump` file due to missing information, for example, **[Error] Exception during gcdump: System.ApplicationException: ETL file shows the start of a heap dump but not its completion.**. Or, the `.gcdump` file doesn't include the entire heap.
 
-   `dotnet-gcdump` works by collecting a trace of events emitted by the garbage collector during an induced generation 2 collection. If the heap is sufficiently large, or there isn't enough memory to scale the eventing buffers, then the events required to reconstruct the heap graph from the trace might be dropped. On a .NET 11+ target runtime, `dotnet-gcdump`'s non-lossy buffering prevents this by blocking event producers instead of dropping events, up to the buffer's capacity. On older runtimes, where the tool falls back to the lossy buffer, or as an alternative, collect a dump of the process to diagnose issues with the heap.
+   `dotnet-gcdump` works by collecting a trace of events emitted by the garbage collector during an induced generation 2 collection. If the heap is sufficiently large, or there isn't enough memory to scale the eventing buffers, then the events required to reconstruct the heap graph from the trace may be dropped. In this case, to diagnose issues with the heap, it's recommended to collect a dump of the process.
 
 - `dotnet-gcdump` appears to cause an Out Of Memory issue in a memory constrained environment.
 

--- a/docs/core/diagnostics/dotnet-trace.md
+++ b/docs/core/diagnostics/dotnet-trace.md
@@ -1,10 +1,9 @@
 ---
 title: dotnet-trace diagnostic tool - .NET CLI
 description: Learn how to install and use the dotnet-trace CLI tool to collect .NET traces of a running process without the native profiler, by using the .NET EventPipe.
-ms.date: 07/09/2026
+ms.date: 06/10/2026
 ms.topic: reference
 ms.custom: sfi-ropc-nochange
-ai-usage: ai-assisted
 ---
 # dotnet-trace performance analysis utility
 
@@ -86,7 +85,6 @@ Collects a diagnostic trace from a running process or launches a child process a
 
 ```dotnetcli
 dotnet-trace collect
-    [--buffering-mode <Drop|Block>]
     [--buffersize <size>]
     [--clreventlevel <clreventlevel>]
     [--clrevents <clrevents>]
@@ -109,13 +107,6 @@ dotnet-trace collect
 ```
 
 ### Options
-
-- **`--buffering-mode <Drop|Block>`**
-
-  Sets how the runtime buffers events. Accepts `0`/`Drop` or `1`/`Block` (case-insensitive), and defaults to `Drop`.
-
-  - `0` / `Drop` (default): the lossy circular buffer. Events are dropped when the buffer overflows.
-  - `1` / `Block`: non-lossy tracing. The runtime blocks the threads emitting events when the buffer is full instead of dropping events, which produces a complete trace. It's non-lossy only up to the buffer's capacity, not against host memory exhaustion. Under memory pressure, events can still be dropped. `Block` requires a .NET 11+ target runtime and can make the traced application slower because event-emitting threads pause while the buffer stays full. On older runtimes, starting the trace fails; retry with `Drop` (the default).
 
 - **`--buffersize <size>`**
 

--- a/docs/core/diagnostics/eventpipe.md
+++ b/docs/core/diagnostics/eventpipe.md
@@ -1,9 +1,8 @@
 ---
 title: EventPipe Overview
 description: Learn about EventPipe and how to use it for tracing your .NET applications to diagnose performance issues.
-ms.date: 07/09/2026
+ms.date: 03/19/2026
 ms.topic: overview
-ai-usage: ai-assisted
 ---
 
 # EventPipe
@@ -82,12 +81,6 @@ However, you can use the following environment variables to set up an EventPipe 
 
   > [!NOTE]
   > If the target process writes events too frequently, it can overflow this buffer and some events might be dropped. If too many events are getting dropped, increase the buffer size to see if the number of dropped events reduces. If the number of dropped events does not decrease with a larger buffer size, it may be due to a slow reader preventing the target process' buffers from being flushed.
-  >
-  > As of .NET 11, a streaming session can opt into non-lossy buffering with `DOTNET_EventPipeBufferingMode=1` (or `--buffering-mode Block` in [dotnet-trace](./dotnet-trace.md)) to block the threads emitting events when the buffer is full instead of dropping them. Non-lossy buffering trades application throughput for completeness. It's non-lossy only up to the buffer's capacity, not against host memory exhaustion. Under memory pressure, the runtime can still drop events.
-
-* `DOTNET_EventPipeBufferingMode`: Available in .NET 11 and later. Controls how the startup EventPipe session's buffer behaves when it fills faster than it's drained. Set it to `0` (default) for the lossy circular buffer that drops events on overflow, or `1` for non-lossy (Block) buffering, which pauses the threads that emit events when the buffer is full instead of dropping them. Only `0` and `1` are valid, and `1` requires a streaming session (see `DOTNET_EventPipeOutputStreaming`); any other value, or `1` for a non-streaming file session, starts no session.
-
-* `DOTNET_EventPipeOutputStreaming`: Set this to `1` to stream the startup EventPipe session's events continuously instead of buffering them and writing at process exit. A streaming session is required for `DOTNET_EventPipeBufferingMode=1` (non-lossy) to take effect.
 
 * `DOTNET_EventPipeProcNumbers`: Set this to `1` to enable capturing processor numbers in EventPipe event headers. The default value is `0`.
 

--- a/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md
+++ b/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md
@@ -1,11 +1,10 @@
 ---
 title: Microsoft.Diagnostics.NETCore.Client API
 description: In this article, you'll learn about the Microsoft.Diagnostics.NETCore.Client APIs.
-ms.date: 07/09/2026
+ms.date: 12/08/2025
 author: tommcdon
 ms.author: tommcdon
 ms.topic: reference
-ai-usage: ai-assisted
 ---
 
 # Microsoft.Diagnostics.NETCore.Client API
@@ -344,13 +343,6 @@ public sealed class EventPipeSessionConfiguration
         long rundownKeyword,
         bool requestStackwalk = true);
 
-    public EventPipeSessionConfiguration(
-        IEnumerable<EventPipeProvider> providers,
-        int circularBufferSizeMB,
-        long rundownKeyword,
-        bool requestStackwalk,
-        EventPipeBufferingMode bufferingMode);
-
     public bool RequestRundown { get; }
 
     public int CircularBufferSizeInMB { get; }
@@ -358,8 +350,6 @@ public sealed class EventPipeSessionConfiguration
     public bool RequestStackwalk { get; }
 
     public long RundownKeyword { get; }
-
-    public EventPipeBufferingMode BufferingMode { get; }
 
     public IReadOnlyCollection<EventPipeProvider> Providers { get; }
 }
@@ -372,9 +362,6 @@ Represents the configuration for an `EventPipeSession`.
 * `requestRundown` : If `true`, request rundown events from the runtime.
 * `requestStackwalk` : If `true`, record a stack trace for every emitted event.
 * `rundownKeyword` : The keyword mask used for rundown events.
-* `bufferingMode` : The [`EventPipeBufferingMode`](#eventpipebufferingmode-enum) for the session. Use `Block` to request non-lossy collection. Passing `Block` requires a .NET 11+ target runtime; on an older runtime, `StartEventPipeSession` throws [`UnsupportedCommandException`](#unsupportedcommandexception).
-
-The `BufferingMode` property returns the buffering mode for the session. The default value, `Drop`, keeps the runtime's lossy circular buffer.
 
 ## EventPipeProvider class
 
@@ -387,13 +374,6 @@ public class EventPipeProvider
         long keywords = 0,
         IDictionary<string, string> arguments = null)
 
-    public EventPipeProvider(
-        string name,
-        EventLevel eventLevel,
-        long keywords,
-        IDictionary<string, string> arguments,
-        EventPipeProviderEventFilter eventFilter)
-
     public string Name { get; }
 
     public EventLevel EventLevel { get; }
@@ -401,8 +381,6 @@ public class EventPipeProvider
     public long Keywords { get; }
 
     public IDictionary<string, string> Arguments { get; }
-
-    public EventPipeProviderEventFilter EventFilter { get; }
 
     public override string ToString();
 
@@ -424,16 +402,9 @@ public EventPipeProvider(
     EventLevel eventLevel,
     long keywords = 0,
     IDictionary<string, string> arguments = null)
-
-public EventPipeProvider(
-    string name,
-    EventLevel eventLevel,
-    long keywords,
-    IDictionary<string, string> arguments,
-    EventPipeProviderEventFilter eventFilter)
 ```
 
-Creates a new instance of `EventPipeProvider` with the given provider name, <xref:System.Diagnostics.Tracing.EventLevel>, keywords, and arguments. The second overload also takes an [`EventPipeProviderEventFilter`](#eventpipeprovidereventfilter-class) that filters which Event IDs the runtime enables for the provider. When you set an event filter, the session requires a .NET 10+ target runtime.
+Creates a new instance of `EventPipeProvider` with the given provider name, <xref:System.Diagnostics.Tracing.EventLevel>, keywords, and arguments.
 
 ### Name property
 
@@ -467,63 +438,9 @@ public IDictionary<string, string> Arguments { get; }
 
 Gets an `IDictionary` of key-value pair strings representing optional arguments to be passed to `EventSource` representing the given `EventPipeProvider`.
 
-### EventFilter property
-
-```csharp
-public EventPipeProviderEventFilter EventFilter { get; }
-```
-
-Gets the optional [`EventPipeProviderEventFilter`](#eventpipeprovidereventfilter-class) that the runtime applies to this provider's Event IDs after the keyword and level filter. When the value is `null`, the runtime enables every Event ID that the keyword and level filter allows.
-
 ### Remarks
 
 This class is immutable, because EventPipe does not allow a provider's configuration to be modified during an EventPipe session as of .NET Core 3.1.
-
-## EventPipeProviderEventFilter class
-
-```csharp
-public sealed class EventPipeProviderEventFilter
-{
-    public EventPipeProviderEventFilter(
-        bool enable,
-        IReadOnlyList<uint> eventIds);
-
-    public bool Enable { get; }
-
-    public IReadOnlyList<uint> EventIds { get; }
-}
-```
-
-Represents an optional per-provider filter on Event IDs. The runtime applies the filter after the keyword and level filter of the associated [`EventPipeProvider`](#eventpipeprovider-class). Event filters require a .NET 10+ target runtime.
-
-### Constructor
-
-```csharp
-public EventPipeProviderEventFilter(
-    bool enable,
-    IReadOnlyList<uint> eventIds);
-```
-
-Creates a new instance of `EventPipeProviderEventFilter`.
-
-* `enable` : If `true`, `eventIds` is an allow-list and the runtime enables only those Event IDs. If `false`, `eventIds` is a deny-list and the runtime enables every Event ID except those listed. An empty deny-list therefore enables all events.
-* `eventIds` : The Event IDs to enable or disable, as determined by `enable`.
-
-### Enable property
-
-```csharp
-public bool Enable { get; }
-```
-
-Gets a value that indicates whether [`EventIds`](#eventids-property) is an allow-list (`true`) or a deny-list (`false`).
-
-### EventIds property
-
-```csharp
-public IReadOnlyList<uint> EventIds { get; }
-```
-
-Gets the list of Event IDs that the filter enables or disables.
 
 ## EventPipeSession class
 
@@ -659,21 +576,6 @@ Represents the type of perf map behavior that can be enabled.
 * `JitDump` : Enable JIT dump perf map output.
 * `PerfMap` : Enable traditional perf map output.
 
-## EventPipeBufferingMode enum
-
-```csharp
-public enum EventPipeBufferingMode
-{
-    Drop = 0,
-    Block = 1
-}
-```
-
-Controls how the runtime's per-session event buffer behaves when it fills faster than the session drains it.
-
-* `Drop` : The runtime default. The session uses a circular buffer that drops events when it overflows, so collection is lossy.
-* `Block` : Non-lossy collection. The runtime blocks event producers when the buffer is full instead of dropping events. Use it for collections that must be complete, such as a heap snapshot on a large heap. `Block` is non-lossy only up to the buffer's capacity, not against host memory exhaustion: if the runtime can't allocate the memory it needs to reserve buffer space, or during session shutdown, it drops the event instead of blocking. `Block` requires a .NET 11+ target runtime; on an older runtime, starting the session throws [`UnsupportedCommandException`](#unsupportedcommandexception).
-
 ## Exceptions
 
 Exceptions that are thrown from the library are of type `DiagnosticsClientException` or a derived type.
@@ -681,6 +583,14 @@ Exceptions that are thrown from the library are of type `DiagnosticsClientExcept
 ```csharp
 public class DiagnosticsClientException : Exception
 ```
+
+### UnsupportedCommandException
+
+```csharp
+public class UnsupportedCommandException : DiagnosticsClientException
+```
+
+This may be thrown when the command is not supported by either the library or the target process's runtime.
 
 ### UnsupportedProtocolException
 
@@ -706,14 +616,6 @@ public class ServerErrorException : DiagnosticsClientException
 
 This may be thrown when the runtime responds with an error to a given command.
 
-### UnsupportedCommandException
-
-```csharp
-public class UnsupportedCommandException : ServerErrorException
-```
-
-This exception is thrown when the command is not supported by either the library or the target process's runtime.
-
 ### ProfilerAlreadyActiveException
 
 ```csharp
@@ -721,11 +623,3 @@ public class ProfilerAlreadyActiveException : ServerErrorException
 ```
 
 This exception is thrown when a profiler is already loaded into the target runtime and another attach is attempted.
-
-### BadEncodingException
-
-```csharp
-public class BadEncodingException : ServerErrorException
-```
-
-This exception is thrown when the target runtime can't decode the command payload and rejects it. From a well-formed client, it usually means the runtime is too old to understand a newer configured option value, so it rejects the request while parsing.


### PR DESCRIPTION
Reverts dotnet/docs#54631 - just read comment that it hasn't released yet.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/diagnostics/dotnet-gcdump.md](https://github.com/dotnet/docs/blob/dc378bc4eab9ecbed6da920951226b96a17f61f0/docs/core/diagnostics/dotnet-gcdump.md) | [docs/core/diagnostics/dotnet-gcdump](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-gcdump?branch=pr-en-us-55195) |
| [docs/core/diagnostics/dotnet-trace.md](https://github.com/dotnet/docs/blob/dc378bc4eab9ecbed6da920951226b96a17f61f0/docs/core/diagnostics/dotnet-trace.md) | [docs/core/diagnostics/dotnet-trace](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-trace?branch=pr-en-us-55195) |
| [docs/core/diagnostics/eventpipe.md](https://github.com/dotnet/docs/blob/dc378bc4eab9ecbed6da920951226b96a17f61f0/docs/core/diagnostics/eventpipe.md) | [docs/core/diagnostics/eventpipe](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/eventpipe?branch=pr-en-us-55195) |
| [docs/core/diagnostics/microsoft-diagnostics-netcore-client.md](https://github.com/dotnet/docs/blob/dc378bc4eab9ecbed6da920951226b96a17f61f0/docs/core/diagnostics/microsoft-diagnostics-netcore-client.md) | [docs/core/diagnostics/microsoft-diagnostics-netcore-client](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/microsoft-diagnostics-netcore-client?branch=pr-en-us-55195) |

<!-- PREVIEW-TABLE-END -->