### PR TITLE
Add telemetry section to dotnet-coverage doc,

### DIFF
--- a/docs/core/additional-tools/dotnet-coverage.md
+++ b/docs/core/additional-tools/dotnet-coverage.md
@@ -796,6 +796,10 @@ You can use the `merge` command to convert a code coverage report to another for
 dotnet-coverage merge -o output.xml -f xml input.coverage
 ```
 
+## Telemetry
+
+Starting with version 18.10.0, the `dotnet-coverage` tool collects telemetry data to help Microsoft understand how to improve the products. This usage data indicates which commands are used and which options are set when the tool runs. You can disable telemetry at any time. For more information about the data that's collected and how to opt out, see [Microsoft.CodeCoverage.Console telemetry](/visualstudio/test/microsoft-code-coverage-console-tool-telemetry?view=visualstudio).
+
 ## See also
 
 * [Customize code coverage analysis](/visualstudio/test/customizing-code-coverage-analysis)

--- a/docs/core/additional-tools/dotnet-coverage.md
+++ b/docs/core/additional-tools/dotnet-coverage.md
@@ -1,8 +1,9 @@
 ---
 title: dotnet-coverage code coverage tool - .NET CLI
 description: Learn how to install and use the dotnet-coverage CLI tool to collect code coverage data of a running process.
-ms.date: 10/21/2021
+ms.date: 08/05/2026
 ms.topic: reference
+ai-usage: ai-assisted
 ---
 # dotnet-coverage code coverage utility
 
@@ -798,7 +799,7 @@ dotnet-coverage merge -o output.xml -f xml input.coverage
 
 ## Telemetry
 
-Starting with version 18.10.0, the `dotnet-coverage` tool collects telemetry data to help Microsoft understand how to improve the products. This usage data indicates which commands are used and which options are set when the tool runs. You can disable telemetry at any time. For more information about the data that's collected and how to opt out, see [Microsoft.CodeCoverage.Console telemetry](/visualstudio/test/microsoft-code-coverage-console-tool-telemetry).
+Starting with version 18.10.0, the `dotnet-coverage` tool collects telemetry data to help Microsoft improve the code coverage tools. The data records which commands you run and which options you set when you run the tool. You can disable telemetry at any time. For more information about the data that's collected and how to opt out, see [Microsoft.CodeCoverage.Console telemetry](/visualstudio/test/microsoft-code-coverage-console-tool-telemetry).
 
 ## See also
 

--- a/docs/core/additional-tools/dotnet-coverage.md
+++ b/docs/core/additional-tools/dotnet-coverage.md
@@ -798,7 +798,7 @@ dotnet-coverage merge -o output.xml -f xml input.coverage
 
 ## Telemetry
 
-Starting with version 18.10.0, the `dotnet-coverage` tool collects telemetry data to help Microsoft understand how to improve the products. This usage data indicates which commands are used and which options are set when the tool runs. You can disable telemetry at any time. For more information about the data that's collected and how to opt out, see [Microsoft.CodeCoverage.Console telemetry](/visualstudio/test/microsoft-code-coverage-console-tool-telemetry?view=visualstudio).
+Starting with version 18.10.0, the `dotnet-coverage` tool collects telemetry data to help Microsoft understand how to improve the products. This usage data indicates which commands are used and which options are set when the tool runs. You can disable telemetry at any time. For more information about the data that's collected and how to opt out, see [Microsoft.CodeCoverage.Console telemetry](/visualstudio/test/microsoft-code-coverage-console-tool-telemetry).
 
 ## See also
 


### PR DESCRIPTION
## Summary

Adds a new **Telemetry** subsection to docs/core/additional-tools/dotnet-coverage.md.

- States that the `dotnet-coverage` tool collects telemetry starting from version 18.10.0.
- Links to the corresponding Visual Studio docs telemetry article (`/visualstudio/test/microsoft-code-coverage-console-tool-telemetry?view=visualstudio`).

> [!NOTE]
> The linked Visual Studio docs page is added in a companion PR in fhnaseer/visualstudio-docs. The link will resolve once that PR is merged and published.

This content was created with the assistance of AI.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/additional-tools/dotnet-coverage.md](https://github.com/dotnet/docs/blob/b0a83a4ed9f9474185db6f81d4a32f5cab18d396/docs/core/additional-tools/dotnet-coverage.md) | [docs/core/additional-tools/dotnet-coverage](https://review.learn.microsoft.com/en-us/dotnet/core/additional-tools/dotnet-coverage?branch=pr-en-us-55310) |


<!-- PREVIEW-TABLE-END -->