### PR TITLE
Update breaking change issue template for .NET versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-breaking-change.yml
+++ b/.github/ISSUE_TEMPLATE/02-breaking-change.yml
@@ -22,9 +22,6 @@ body:
         - .NET 8
         - .NET 9
         - .NET 10
-        - .NET 11 Preview 1
-        - .NET 11 Preview 2
-        - .NET 11 Preview 3
         - .NET 11 Preview 4
         - .NET 11 Preview 5
         - .NET 11 Preview 6
@@ -87,6 +84,7 @@ body:
         - Cryptography
         - Debugger
         - Deployment
+        - dotnetup
         - Extensions
         - Globalization
         - Interop


### PR DESCRIPTION
Removed older .NET 11 preview options and added 'dotnetup' to the list.

Fixes #55312.