### PR TITLE
Use testing team for docs ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -118,7 +118,7 @@
 # Config settings
 /docs/core/runtime-config/ @gewarren @dotnet/docs
 # Testing
-/docs/core/testing/ @meaghanlewis @nohwnd @Evangelink
+/docs/core/testing/ @meaghanlewis @dotnet/dotnet-testing
 # Tools
 /docs/core/tools/ @meaghanlewis @dotnet/docs
 # Tutorials


### PR DESCRIPTION
## Summary

- Replace the individual test-framework owners for `docs/core/testing/` with `@dotnet/dotnet-testing`.
- Keep `@meaghanlewis` as a testing docs owner.

## Prerequisite

Before this PR merges, grant `@dotnet/dotnet-testing` write access to `dotnet/docs`. The team currently has pull access only, so GitHub reports it as an unknown CODEOWNER.
