### PR TITLE
Fix ECMA standard warnings

### DIFF
--- a/docs/csharp/language-reference/builtin-types/default-values.md
+++ b/docs/csharp/language-reference/builtin-types/default-values.md
@@ -57,8 +57,8 @@ For more information, see the following sections of the [C# language specificati
 
 - [Default values](~/_csharpstandard/standard/variables.md#93-default-values)
 - [Default constructors](~/_csharpstandard/standard/types.md#833-default-constructors)
-- [Parameterless struct constructors](~/_csharpstandard/standard/structs.md#1659-constructors)
-- [Auto default structs](~/_csharpstandard/standard/structs.md#16581-field-initializers)
+- [Parameterless struct constructors](~/_csharpstandard/standard/structs.md#1669-constructors)
+- [Auto default structs](~/_csharpstandard/standard/structs.md#16681-field-initializers)
 
 ## See also
 

--- a/docs/csharp/language-reference/builtin-types/record.md
+++ b/docs/csharp/language-reference/builtin-types/record.md
@@ -262,7 +262,7 @@ For more information, see the [Classes](~/_csharpstandard/standard/classes.md) s
 
 For more information about these features, see the following feature proposal notes:
 
-- [Records](~/_csharpstandard/standard/classes.md#1516-synthesized-record-class-members)
+- [Records](~/_csharpstandard/standard/classes.md#1516-record-classes)
 - [Init-only setters](~/_csharpstandard/standard/classes.md#15733-init-accessors)
 - [Covariant returns](~/_csharpstandard/standard/classes.md#1565-override-methods)
 

--- a/docs/csharp/language-reference/builtin-types/ref-struct.md
+++ b/docs/csharp/language-reference/builtin-types/ref-struct.md
@@ -85,9 +85,9 @@ The compiler enforces these restrictions. If you write `ref struct` types that i
 For more information, see the following sections of the [C# language specification](~/_csharpstandard/standard/README.md):
 
 - [Structs: Ref modifier](~/_csharpstandard/standard/structs.md#1623-ref-modifier)
-- [Safe context constraint for ref struct types](~/_csharpstandard/standard/structs.md#16515-safe-context-constraint)
+- [Safe context constraint for ref struct types](~/_csharpstandard/standard/structs.md#16615-safe-context-constraint)
 
-For more information about `ref` fields, see [Ref fields](~/_csharpstandard/standard/structs.md#16582-ref-fields) in the C# language specification.
+For more information about `ref` fields, see [Ref fields](~/_csharpstandard/standard/structs.md#16682-ref-fields) in the C# language specification.
 
 ## See also
 

--- a/docs/csharp/language-reference/builtin-types/struct.md
+++ b/docs/csharp/language-reference/builtin-types/struct.md
@@ -140,7 +140,7 @@ If you don't initialize all fields in a struct, the compiler adds code to the co
 
 :::code language="csharp" source="snippets/shared/StructType.cs" id="FieldInitializer":::
 
-Every `struct` has a `public` parameterless constructor. If you write a parameterless constructor, it must be public. If a struct declares any field initializers, it must explicitly declare a constructor. That constructor need not be parameterless. If a struct declares a field initializer but no constructors, the compiler reports an error. Any explicitly declared constructor (with parameters, or parameterless) executes all field initializers for that struct. All fields without a field initializer or an assignment in a constructor are set to the [default value](default-values.md). For more information, see the [C# language specification—Constructors](~/_csharpstandard/standard/structs.md#1659-constructors).
+Every `struct` has a `public` parameterless constructor. If you write a parameterless constructor, it must be public. If a struct declares any field initializers, it must explicitly declare a constructor. That constructor need not be parameterless. If a struct declares a field initializer but no constructors, the compiler reports an error. Any explicitly declared constructor (with parameters, or parameterless) executes all field initializers for that struct. All fields without a field initializer or an assignment in a constructor are set to the [default value](default-values.md). For more information, see the [C# language specification—Constructors](~/_csharpstandard/standard/structs.md#1669-constructors).
 
 Beginning with C# 12, `struct` types can define a [primary constructor](../../programming-guide/classes-and-structs/instance-constructors.md#primary-constructors) as part of its declaration. Primary constructors provide a concise syntax for constructor parameters that can be used throughout the `struct` body, in any member declaration for that struct.
 
@@ -176,11 +176,11 @@ For more information, see the [Structs](~/_csharpstandard/standard/structs.md) s
 
 - [Readonly structs](~/_csharpstandard/standard/structs.md#1622-struct-modifiers)
 - [Readonly instance members](~/_csharpstandard/standard/structs.md#163-struct-members)
-- [Parameterless struct constructors](~/_csharpstandard/standard/structs.md#1659-constructors)
+- [Parameterless struct constructors](~/_csharpstandard/standard/structs.md#1669-constructors)
 - [Allow `with` expression on structs](~/_csharpstandard/standard/expressions.md#1210-with-expressions)
-- [Record structs](~/_csharpstandard/standard/structs.md#164-synthesized-record-struct-members)
+- [Record structs](~/_csharpstandard/standard/structs.md#164-record-structs)
 
-You can also read about [Auto default structs](~/_csharpstandard/standard/structs.md#16581-field-initializers) in the C# language specification.
+You can also read about [Auto default structs](~/_csharpstandard/standard/structs.md#16681-field-initializers) in the C# language specification.
 
 ## See also
 

--- a/docs/csharp/language-reference/compiler-messages/record-declaration-errors.md
+++ b/docs/csharp/language-reference/compiler-messages/record-declaration-errors.md
@@ -97,7 +97,7 @@ In addition, this article covers the following warning:
 - **CS8879**: *Record member 'member' must be private.*
 - **CS8906**: *Record equality contract property 'member' must have a get accessor.*
 
-When you explicitly declare a member that the compiler would otherwise synthesize for a [record type](../builtin-types/record.md), your declaration must match the expected signature, accessibility, and modifiers. For the complete rules, see the [records specification](~/_csharpstandard/standard/classes.md#1516-synthesized-record-class-members) in the C# language specification.
+When you explicitly declare a member that the compiler would otherwise synthesize for a [record type](../builtin-types/record.md), your declaration must match the expected signature, accessibility, and modifiers. For the complete rules, see the [records specification](~/_csharpstandard/standard/classes.md#1516-record-classes) in the C# language specification.
 
 To correct these errors, apply the following changes to your explicitly declared record members:
 
@@ -119,7 +119,7 @@ To correct these errors, apply the following changes to your explicitly declared
 - **CS8908**: *The type 'type' may not be used for a field of a record.*
 - **CS8913**: *The positional member 'member' found corresponding to this parameter is hidden.*
 
-When you declare a [positional record](../builtin-types/record.md#positional-syntax-for-property-and-field-definition), the compiler synthesizes properties that correspond to each positional parameter. These diagnostics indicate that your explicit declarations conflict with those synthesized properties. For the complete rules, see the [records specification](~/_csharpstandard/standard/classes.md#1516-synthesized-record-class-members) in the C# language specification.
+When you declare a [positional record](../builtin-types/record.md#positional-syntax-for-property-and-field-definition), the compiler synthesizes properties that correspond to each positional parameter. These diagnostics indicate that your explicit declarations conflict with those synthesized properties. For the complete rules, see the [records specification](~/_csharpstandard/standard/classes.md#1516-record-classes) in the C# language specification.
 
 To correct these errors, apply the following changes to your positional record declarations:
 
@@ -147,7 +147,7 @@ To correct these errors, apply the following changes:
 - **CS8864**: *Records may only inherit from object or another record*
 - **CS8865**: *Only records may inherit from records.*
 
-[Record class types](../builtin-types/record.md) follow specific [inheritance](../builtin-types/record.md#equality-in-inheritance-hierarchies) rules. For the complete rules, see the [records specification](~/_csharpstandard/standard/classes.md#1516-synthesized-record-class-members) in the C# language specification.
+[Record class types](../builtin-types/record.md) follow specific [inheritance](../builtin-types/record.md#equality-in-inheritance-hierarchies) rules. For the complete rules, see the [records specification](~/_csharpstandard/standard/classes.md#1516-record-classes) in the C# language specification.
 
 To correct these errors, apply the following changes:
 
@@ -159,7 +159,7 @@ To correct these errors, apply the following changes:
 - **CS8859**: *Members named 'Clone' are disallowed in records.*
 - **CS8860**: *Types and aliases should not be named 'record'.*
 
-The compiler reserves certain names for use with [record types](../builtin-types/record.md). For the complete rules, see the [records specification](~/_csharpstandard/standard/classes.md#1516-synthesized-record-class-members) in the C# language specification.
+The compiler reserves certain names for use with [record types](../builtin-types/record.md). For the complete rules, see the [records specification](~/_csharpstandard/standard/classes.md#1516-record-classes) in the C# language specification.
 
 To correct these errors, apply the following changes:
 

--- a/docs/csharp/language-reference/compiler-messages/ref-modifiers-errors.md
+++ b/docs/csharp/language-reference/compiler-messages/ref-modifiers-errors.md
@@ -268,7 +268,7 @@ To correct these errors:
 - Remove the `unscoped` modifier or the <xref:System.Diagnostics.CodeAnalysis.UnscopedRefAttribute?displayProperty=nameWithType> attribute from struct constructors and init-only members. These members have special initialization semantics where the compiler must ensure that any references don't outlive the initialization phase, and allowing unscoped references would violate the guarantee that initialization completes before the struct becomes fully accessible (**CS9101**).
 - Remove the `unscoped` modifier from interface implementation methods when the corresponding interface method doesn't have it. The unscoped characteristic affects the method's contract regarding reference lifetime guarantees, and implementations must maintain the same contract as the interface they're implementing to ensure callers can rely on consistent lifetime behavior regardless of which implementation is invoked (**CS9102**).
 
-For more information about scoped and unscoped references, see [Method parameters](../keywords/method-parameters.md) and [Safe context constraint](~/_csharpstandard/standard/structs.md#16515-safe-context-constraint) in the C# language specification.
+For more information about scoped and unscoped references, see [Method parameters](../keywords/method-parameters.md) and [Safe context constraint](~/_csharpstandard/standard/structs.md#16615-safe-context-constraint) in the C# language specification.
 
 ## Reference variables require a referent
 

--- a/docs/csharp/language-reference/operators/equality-operators.md
+++ b/docs/csharp/language-reference/operators/equality-operators.md
@@ -106,7 +106,7 @@ public virtual bool Equals(T? other);
 
 For more information, see the [Relational and type-testing operators](~/_csharpstandard/standard/expressions.md#1215-relational-and-type-testing-operators) section of the [C# language specification](~/_csharpstandard/standard/README.md).
 
-For more information about equality of record types, see the [Equality members](~/_csharpstandard/standard/classes.md#15162-equality-members) section of the [C# language specification](~/_csharpstandard/standard/README.md).
+For more information about equality of record types, see the [Equality members](~/_csharpstandard/standard/classes.md#151663-equality-members) section of the [C# language specification](~/_csharpstandard/standard/README.md).
 
 ## See also
 

--- a/docs/csharp/language-reference/operators/with-expression.md
+++ b/docs/csharp/language-reference/operators/with-expression.md
@@ -37,7 +37,7 @@ You can't customize the copy semantics for structure types.
 For more information, see the following sections of the [C# language specification](~/_csharpstandard/standard/README.md):
 
 - [`with` expression](~/_csharpstandard/standard/expressions.md#1210-with-expressions)
-- [Copy and Clone members](~/_csharpstandard/standard/classes.md#15163-copy-and-clone-members)
+- [Copy and Clone members](~/_csharpstandard/standard/classes.md#151664-copy-and-clone-members)
 
 ## See also
 

--- a/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
+++ b/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
@@ -216,15 +216,7 @@ f1_keywords:
   - "CS8381"
   - "CS8383"
   - "CS8384"
-  # C# 8.0 diagnostics
-  ## Static local functions
-  ## Attributes
-  ## Index and range
-  ## Can't parse syntax
-  ## Default interface implementation
-  ## Patterns
-  ## Readonly struct members
-# Coming in C# 15
+  # Coming in C# 15
   - "CS9343" # misc
   - "CS9347"
   - "CS9348"

--- a/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
+++ b/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
@@ -169,7 +169,7 @@ The preceding syntax would require implementers to use [explicit interface imple
 The `allows ref struct` anti-constraint declares that the corresponding type argument can be a [`ref struct`](../../language-reference/builtin-types/ref-struct.md) type. Instances of that type parameter must obey the following rules:
 
 - It can't be boxed.
-- It participates in [ref safety rules](~/_csharpstandard/standard/structs.md#16515-safe-context-constraint).
+- It participates in [ref safety rules](~/_csharpstandard/standard/structs.md#16615-safe-context-constraint).
 - Instances can't be used where a `ref struct` type isn't allowed, such as `static` fields.
 - Instances can be marked with the `scoped` modifier.
 


### PR DESCRIPTION
Fix the warnings that crept in from the branch updates following the July ECMA meeting.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/csharp/language-reference/builtin-types/default-values.md](https://github.com/dotnet/docs/blob/77ef444725a386b7a7599831da13b8d99ec63db4/docs/csharp/language-reference/builtin-types/default-values.md) | [docs/csharp/language-reference/builtin-types/default-values](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/default-values?branch=pr-en-us-55344) |
| [docs/csharp/language-reference/builtin-types/record.md](https://github.com/dotnet/docs/blob/77ef444725a386b7a7599831da13b8d99ec63db4/docs/csharp/language-reference/builtin-types/record.md) | [docs/csharp/language-reference/builtin-types/record](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/record?branch=pr-en-us-55344) |
| [docs/csharp/language-reference/builtin-types/ref-struct.md](https://github.com/dotnet/docs/blob/77ef444725a386b7a7599831da13b8d99ec63db4/docs/csharp/language-reference/builtin-types/ref-struct.md) | [docs/csharp/language-reference/builtin-types/ref-struct](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/ref-struct?branch=pr-en-us-55344) |
| [docs/csharp/language-reference/builtin-types/struct.md](https://github.com/dotnet/docs/blob/77ef444725a386b7a7599831da13b8d99ec63db4/docs/csharp/language-reference/builtin-types/struct.md) | [docs/csharp/language-reference/builtin-types/struct](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/struct?branch=pr-en-us-55344) |
| [docs/csharp/language-reference/compiler-messages/record-declaration-errors.md](https://github.com/dotnet/docs/blob/77ef444725a386b7a7599831da13b8d99ec63db4/docs/csharp/language-reference/compiler-messages/record-declaration-errors.md) | [docs/csharp/language-reference/compiler-messages/record-declaration-errors](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/record-declaration-errors?branch=pr-en-us-55344) |
| [docs/csharp/language-reference/compiler-messages/ref-modifiers-errors.md](https://github.com/dotnet/docs/blob/77ef444725a386b7a7599831da13b8d99ec63db4/docs/csharp/language-reference/compiler-messages/ref-modifiers-errors.md) | [docs/csharp/language-reference/compiler-messages/ref-modifiers-errors](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/ref-modifiers-errors?branch=pr-en-us-55344) |
| [docs/csharp/language-reference/operators/equality-operators.md](https://github.com/dotnet/docs/blob/77ef444725a386b7a7599831da13b8d99ec63db4/docs/csharp/language-reference/operators/equality-operators.md) | [docs/csharp/language-reference/operators/equality-operators](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/equality-operators?branch=pr-en-us-55344) |
| [docs/csharp/language-reference/operators/with-expression.md](https://github.com/dotnet/docs/blob/77ef444725a386b7a7599831da13b8d99ec63db4/docs/csharp/language-reference/operators/with-expression.md) | [docs/csharp/language-reference/operators/with-expression](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/with-expression?branch=pr-en-us-55344) |
| [docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md](https://github.com/dotnet/docs/blob/77ef444725a386b7a7599831da13b8d99ec63db4/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md) | [docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error](https://review.learn.microsoft.com/en-us/dotnet/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error?branch=pr-en-us-55344) |
| [docs/csharp/programming-guide/generics/constraints-on-type-parameters.md](https://github.com/dotnet/docs/blob/77ef444725a386b7a7599831da13b8d99ec63db4/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md) | [docs/csharp/programming-guide/generics/constraints-on-type-parameters](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters?branch=pr-en-us-55344) |


<!-- PREVIEW-TABLE-END -->