### PR TITLE
Fixed a typo in "API Gateway drawbacks" section

### DIFF
--- a/docs/architecture/microservices/architect-microservice-container-applications/direct-client-to-microservice-communication-versus-the-api-gateway-pattern.md
+++ b/docs/architecture/microservices/architect-microservice-container-applications/direct-client-to-microservice-communication-versus-the-api-gateway-pattern.md
@@ -152,7 +152,7 @@ After the initial architecture and patterns explanation sections, the next secti
 
 ## Drawbacks of the API Gateway pattern
 
-- The most important drawback is that when you implement an API Gateway, you're coupling that tier with the internal microservices. Coupling like this might introduce serious difficulties for your application. Clemens Vaster, architect at the Azure Service Bus team, refers to this potential difficulty as "the new ESB" in the "[Messaging and Microservices](https://www.youtube.com/watch?v=rXi5CLjIQ9k)" session at GOTO 2016.
+- The most important drawback is that when you implement an API Gateway, you're coupling that tier with the internal microservices. Coupling like this might introduce serious difficulties for your application. Clemens Vasters, architect at the Azure Service Bus team, refers to this potential difficulty as "the new ESB" in the "[Messaging and Microservices](https://www.youtube.com/watch?v=rXi5CLjIQ9k)" session at GOTO 2016.
 
 - Using a microservices API Gateway creates an additional possible single point of failure.
 


### PR DESCRIPTION
Corrected the name of Clemens Vasters in the "Drawbacks of the API Gateway pattern" section.

## Summary

Clemens Vasters' surname was typed without the trailing "s". Fixed the typo.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/architecture/microservices/architect-microservice-container-applications/direct-client-to-microservice-communication-versus-the-api-gateway-pattern.md](https://github.com/dotnet/docs/blob/5f7bc2642a8b2ffc2193dd192cc5d90e23725a72/docs/architecture/microservices/architect-microservice-container-applications/direct-client-to-microservice-communication-versus-the-api-gateway-pattern.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/architecture/microservices/architect-microservice-container-applications/direct-client-to-microservice-communication-versus-the-api-gateway-pattern?branch=pr-en-us-55440) |

<!-- PREVIEW-TABLE-END -->