### PR TITLE
Update 07-14-july-cumulative-update.md

### DIFF
--- a/docs/framework/release-notes/2026/07-14-july-cumulative-update.md
+++ b/docs/framework/release-notes/2026/07-14-july-cumulative-update.md
@@ -82,10 +82,6 @@ This security update addresses a denial of service vulnerability detailed in [CV
 
 This security update addresses a tampering vulnerability detailed in [CVE-2026-50659](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-50659).
 
-#### CVE-2026-56158 – .NET Framework Remote Code Execution vulnerability
-
-This security update addresses a remote code execution vulnerability detailed in [CVE-2026-56158](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-56158).
-
 ### Quality and reliability improvements
 
 **.NET Libraries**


### PR DESCRIPTION
## Summary

Remove CVE-2026-56158 from the release notes.  Case was downgraded and not removed from the release notes prior to patch Tuesday. 

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/framework/release-notes/2026/07-14-july-cumulative-update.md](https://github.com/dotnet/docs/blob/2e6315572210bdca6f4e1f172c48b3e8e99538d3/docs/framework/release-notes/2026/07-14-july-cumulative-update.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/framework/release-notes/2026/07-14-july-cumulative-update?branch=pr-en-us-55445) |

<!-- PREVIEW-TABLE-END -->