### PR TITLE
Use xrefs instead of code fencing

### DIFF
--- a/docs/core/whats-new/dotnet-11/libraries.md
+++ b/docs/core/whats-new/dotnet-11/libraries.md
@@ -57,9 +57,9 @@ The full set of helpers includes:
 
 `System.Diagnostics.Process` adds finer control over starting and finding processes:
 
-- `ProcessStartInfo.StartSuspended` starts a process in a suspended state on Windows and macOS. Pair it with `SafeProcessHandle.Resume` to let it run once you've finished any setup, such as attaching a debugger or configuring job objects.
-- `Process.TryGetProcessById(System.Int32,System.Diagnostics.Process@)` returns `false` instead of throwing when no process with the given ID exists.
-- `SafeProcessHandle.Open()` and `SafeProcessHandle.TryOpen()` open a handle to an existing process by ID.
+- <xref:System.Diagnostics.ProcessStartInfo.StartSuspended?displayProperty=nameWithType> starts a process in a suspended state on Windows and macOS. Pair it with <xref:Microsoft.Win32.SafeHandles.SafeProcessHandle.Resume?displayProperty=nameWithType> to let it run once you've finished any setup, such as attaching a debugger or configuring job objects.
+- <xref:System.Diagnostics.Process.TryGetProcessById(System.Int32,System.Diagnostics.Process@)?displayProperty=nameWithType> returns `false` instead of throwing when no process with the given ID exists.
+- <xref:Microsoft.Win32.SafeHandles.SafeProcessHandle.Open(System.Int32)> and <xref:Microsoft.Win32.SafeHandles.SafeProcessHandle.TryOpen(System.Int32,Microsoft.Win32.SafeHandles.SafeProcessHandle@)> open a handle to an existing process by ID.
 
 ```csharp
 var startInfo = new ProcessStartInfo("worker.exe") { StartSuspended = true };
@@ -236,7 +236,7 @@ The new `JsonUnionAttribute` and `JsonUnionCaseInfo` APIs, along with type-class
 
 #### Closed-hierarchy polymorphism inference
 
-<xref:System.Text.Json.JsonSerializerOptions> adds `JsonSerializerOptions.InferClosedTypePolymorphism` so the serializer can infer polymorphic metadata for C# closed hierarchies without requiring explicit <xref:System.Text.Json.Serialization.JsonDerivedTypeAttribute> annotations on each base type. Explicit registrations still take precedence.
+<xref:System.Text.Json.JsonSerializerOptions> adds <xref:System.Text.Json.JsonSerializerOptions.InferClosedTypePolymorphism?displayProperty=nameWithType> so the serializer can infer polymorphic metadata for C# closed hierarchies without requiring explicit <xref:System.Text.Json.Serialization.JsonDerivedTypeAttribute> annotations on each base type. Explicit registrations still take precedence.
 
 ### Regular expression improvements
 
@@ -276,7 +276,7 @@ Additionally, a new <xref:System.IO.Compression.ZipArchiveEntry.CompressionMetho
 
 #### ZIP archive password support
 
-<xref:System.IO.Compression.ZipArchiveEntry> now supports password-protected entries for read and write operations. Use the new password-aware `Open` and `OpenAsync` overloads, and use password plus `ZipEncryptionMethod` when you create encrypted entries.
+<xref:System.IO.Compression.ZipArchiveEntry> now supports password-protected entries for read and write operations. Use the new password-aware <xref:System.IO.Compression.ZipArchiveEntry.Open(System.ReadOnlySpan{System.Char})?displayProperty=nameWithType> and <xref:System.IO.Compression.ZipArchiveEntry.OpenAsync(System.ReadOnlySpan{System.Char},System.Threading.CancellationToken)?displayProperty=nameWithType> overloads, and use password plus <xref:System.IO.Compression.ZipEncryptionMethod> when you create encrypted entries.
 
 #### DeflateStream and GZipStream behavior change
 
@@ -334,15 +334,15 @@ Because the three outer-join operations return tuples directly, you can work wit
 
 ### IEEE 754 decimal floating-point types
 
-<xref:System.Numerics> adds `Decimal32`, `Decimal64`, and `Decimal128`, which implement IEEE 754-2019 decimal floating-point semantics. These types support generic math, infinities, and NaN values, and can help when you need IEEE decimal behavior instead of <xref:System.Decimal>.
+<xref:System.Numerics> adds <xref:System.Numerics.Decimal32>, <xref:System.Numerics.Decimal64>, and <xref:System.Numerics.Decimal128>, which implement IEEE 754-2019 decimal floating-point semantics. These types support generic math, infinities, and NaN values, and can help when you need IEEE decimal behavior instead of <xref:System.Decimal>.
 
 ### Partial numeric parsing
 
-`System.Numerics.INumberBase<T>.TryParsePartial()` adds partial parsing overloads that report consumed input. Use this API to parse delimited formats, such as CSV, so you don't copy substrings.
+<xref:System.Numerics.INumberBase`1.TryParsePartial*?displayProperty=nameWithType> adds partial parsing overloads that report consumed input. Use this API to parse delimited formats, such as CSV, so you don't copy substrings.
 
 ### Generic Complex\<T>
 
-`System.Numerics.Complex<T>` is now available, so complex arithmetic can use several floating-point types, including `float`, `Half`, `BFloat16`, and the new decimal floating-point types.
+<xref:System.Numerics.Complex`1> is now available, so complex arithmetic can use several floating-point types, including `float`, `Half`, `BFloat16`, and the new decimal floating-point types.
 
 #### Tuple-returning Join and GroupJoin overloads
 
@@ -502,7 +502,7 @@ A new <xref:System.Uri.UriSchemeData?displayProperty=nameWithType> constant has 
 
 ### Assembly.Location override for AssemblyLoadContext
 
-`AssemblyLoadContext.SetAssemblyLocationOverride` is a set-once callback that can override the location reported by <xref:System.Reflection.Assembly.Location?displayProperty=nameWithType>. This API helps hosts that stage assemblies in temporary paths or virtualized locations report stable, meaningful locations to diagnostics and resource-loading code.
+<xref:System.Runtime.Loader.AssemblyLoadContext.SetAssemblyLocationOverride(System.Func{System.Reflection.Assembly,System.String,System.String})?displayProperty=nameWithType> is a set-once callback that can override the location reported by <xref:System.Reflection.Assembly.Location?displayProperty=nameWithType>. This API helps hosts that stage assemblies in temporary paths or virtualized locations report stable, meaningful locations to diagnostics and resource-loading code.
 
 ### Reduced contention in System.IO.Pipelines
 
@@ -681,15 +681,15 @@ Two <xref:System.Net.Security?displayProperty=fullName> items improve TLS (Trans
 
 ### HTTP request compression
 
-<xref:System.Net.Http?displayProperty=fullName> adds `GZipCompressedContent`, `BrotliCompressedContent`, and `ZstandardCompressedContent` wrappers for request bodies. These wrappers set the `Content-Encoding` header and stream compressed content as the request serializes.
+<xref:System.Net.Http?displayProperty=fullName> adds <xref:System.Net.Http.GZipCompressedContent>, <xref:System.Net.Http.BrotliCompressedContent>, and <xref:System.Net.Http.ZstandardCompressedContent> wrappers for request bodies. These wrappers set the `Content-Encoding` header and stream compressed content as the request serializes.
 
 ### Configurable HTTP connection eviction
 
-<xref:System.Net.Http.SocketsHttpHandler> now provides `ShouldEvictConnection` for per-connection eviction decisions. This callback lets you retire connections based on age, endpoint details, and DNS changes instead of fixed lifetime-only policies.
+<xref:System.Net.Http.SocketsHttpHandler> now provides <xref:System.Net.Http.SocketsHttpHandler.ShouldEvictConnection?displayProperty=nameWithType> for per-connection eviction decisions. This callback lets you retire connections based on age, endpoint details, and DNS changes instead of fixed lifetime-only policies.
 
 ### DNS record resolution APIs
 
-<xref:System.Net.Dns?displayProperty=fullName> adds typed record-resolution APIs, including `ResolveSrv()`, `ResolveMx()`, `ResolveTxt()`, `ResolveCName()`, `ResolvePtr()`, and `ResolveNs()`, together with `Async` variants. The results include records, response code, and negative-cache time-to-live (TTL) metadata through `DnsResult<T>`.
+<xref:System.Net.Dns?displayProperty=fullName> adds typed record-resolution APIs, including <xref:System.Net.Dns.ResolveSrv(System.String)?displayProperty=nameWithType>, <xref:System.Net.Dns.ResolveMx(System.String)?displayProperty=nameWithType>, <xref:System.Net.Dns.ResolveTxt(System.String)?displayProperty=nameWithType>, <xref:System.Net.Dns.ResolveCName(System.String)?displayProperty=nameWithType>, <xref:System.Net.Dns.ResolvePtr(System.String)?displayProperty=nameWithType>, and <xref:System.Net.Dns.ResolveNs(System.String)?displayProperty=nameWithType>, together with `Async` variants. The results include records, response code, and negative-cache time-to-live (TTL) metadata through <xref:System.Net.DnsResult`1>.
 
 ### HTTP/2 automatic downgrade for Windows authentication
 

--- a/docs/core/whats-new/dotnet-11/overview.md
+++ b/docs/core/whats-new/dotnet-11/overview.md
@@ -33,9 +33,9 @@ For more information, see [What's new in the .NET 11 runtime](runtime.md).
 
 The .NET 11 libraries include new APIs for:
 
-- <xref:System.Diagnostics.Process> expansion with run-and-capture helpers, fire-and-forget launches, `SafeProcessHandle` lifecycle methods, tighter handle control, and new `ProcessStartInfo.StartSuspended` for suspended starts and `Process.TryGetProcessById` for safe process lookup.
+- <xref:System.Diagnostics.Process> expansion with run-and-capture helpers, fire-and-forget launches, <xref:Microsoft.Win32.SafeHandles.SafeProcessHandle> lifecycle methods, tighter handle control, and new <xref:System.Diagnostics.ProcessStartInfo.StartSuspended?displayProperty=nameWithType> for suspended starts and <xref:System.Diagnostics.Process.TryGetProcessById(System.Int32,System.Diagnostics.Process@)?displayProperty=nameWithType> for safe process lookup.
 - Compression, including improved Base64 APIs, new methods for ZIP archive entries, Zstandard compression in <xref:System.IO.Compression?displayProperty=fullName>, and CRC32 validation when reading ZIP entries.
-- New numeric APIs, including IEEE 754 decimal floating-point types (`Decimal32`, `Decimal64`, and `Decimal128`), `INumberBase<TSelf>.TryParsePartial` for delimiter-aware parsing, and generic `System.Numerics.Complex<T>`.
+- New numeric APIs, including IEEE 754 decimal floating-point types (<xref:System.Numerics.Decimal32>, <xref:System.Numerics.Decimal64>, and <xref:System.Numerics.Decimal128>), <xref:System.Numerics.INumberBase`1.TryParsePartial*?displayProperty=nameWithType> for delimiter-aware parsing, and generic <xref:System.Numerics.Complex`1>.
 - System.Text.Json improvements, including generic type info retrieval, <xref:System.Text.Json.JsonNamingPolicy.PascalCase?displayProperty=nameWithType>, per-member naming policy overrides, type-level ignore conditions, F# discriminated union support, <xref:System.Text.Json.Utf8JsonWriter.Reset*?displayProperty=nameWithType> with options, `SerializeAsyncEnumerable` overloads for `PipeWriter` targets and top-level values (NDJSON) output, and serialization of C# union types.
 - Built-in OpenTelemetry metrics for <xref:Microsoft.Extensions.Caching.Memory.MemoryCache>.
 - Discriminated-union scaffolding (`UnionAttribute` and `IUnion`) in <xref:System.Runtime.CompilerServices>.

--- a/docs/core/whats-new/dotnet-11/runtime.md
+++ b/docs/core/whats-new/dotnet-11/runtime.md
@@ -157,7 +157,7 @@ The runtime now detects when a continuation has nothing to restore and skips the
 - **`Math.BigMul` on x64:** `Math.BigMul(long, long, out long)` is now significantly faster on x64. The JIT generates a single `MUL r/m64` instruction when both operands are 64-bit values and the caller requests the high half of the result, eliminating the previous helper call.
 - **Single-IG prolog restriction removed:** The JIT no longer requires the function prolog to fit in a single instruction group (IG). Complex prologues with many saved registers, large stack allocations, or runtime-async state setup no longer trigger fallback paths.
 - **`SELECT(cond, cns, cns)` folding:** The JIT now folds conditional selects whose two branches both produce the same constant into just that constant—for example, `condition ? 42 : 42` becomes `42`. This fold eliminates unnecessary comparisons that can appear after earlier optimizations unify branches.
-- **AVX-VNNI-512 intrinsics:** `AvxVnni.V51` adds 512-bit dot-product intrinsics for CPUs that support `AVX512-VNNI`.
+- **AVX-VNNI-512 intrinsics:** <xref:System.Runtime.Intrinsics.X86.AvxVnni.V512> adds 512-bit dot-product intrinsics for CPUs that support `AVX512-VNNI`.
 - **Saturating floating-point conversions:** Unchecked `float` and `double` conversions to small integer types now saturate to type bounds instead of wrapping through intermediate truncation.
 - **ARM64 `Vector<T>` by reference for SVE:** When the runtime is compiled with ARM SVE support, `Vector<T>` values are passed by reference rather than by value, aligning with the ARM calling convention for scalable types and enabling better code generation for SVE-intensive code.
 

--- a/docs/core/whats-new/dotnet-11/runtime.md
+++ b/docs/core/whats-new/dotnet-11/runtime.md
@@ -157,7 +157,7 @@ The runtime now detects when a continuation has nothing to restore and skips the
 - **`Math.BigMul` on x64:** `Math.BigMul(long, long, out long)` is now significantly faster on x64. The JIT generates a single `MUL r/m64` instruction when both operands are 64-bit values and the caller requests the high half of the result, eliminating the previous helper call.
 - **Single-IG prolog restriction removed:** The JIT no longer requires the function prolog to fit in a single instruction group (IG). Complex prologues with many saved registers, large stack allocations, or runtime-async state setup no longer trigger fallback paths.
 - **`SELECT(cond, cns, cns)` folding:** The JIT now folds conditional selects whose two branches both produce the same constant into just that constant—for example, `condition ? 42 : 42` becomes `42`. This fold eliminates unnecessary comparisons that can appear after earlier optimizations unify branches.
-- **AVX-VNNI-512 intrinsics:** <xref:System.Runtime.Intrinsics.X86.AvxVnni.V512> adds 512-bit dot-product intrinsics for CPUs that support `AVX512-VNNI`.
+- **AVX-VNNI-512 intrinsics:** <xref:System.Runtime.Intrinsics.X86.AvxVnni.V512?displayProperty=nameWithType> exposes 512-bit forms of the `AVX-VNNI` multiply-add intrinsics on CPUs with `AVX512-VNNI` support.
 - **Saturating floating-point conversions:** Unchecked `float` and `double` conversions to small integer types now saturate to type bounds instead of wrapping through intermediate truncation.
 - **ARM64 `Vector<T>` by reference for SVE:** When the runtime is compiled with ARM SVE support, `Vector<T>` values are passed by reference rather than by value, aligning with the ARM calling convention for scalable types and enabling better code generation for SVE-intensive code.
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/dotnet-api-docs/issues/12591.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-11/libraries.md](https://github.com/dotnet/docs/blob/9d73907af97befa3630f253895d067b5e9157b44/docs/core/whats-new/dotnet-11/libraries.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-11/libraries?branch=pr-en-us-55460) |
| [docs/core/whats-new/dotnet-11/overview.md](https://github.com/dotnet/docs/blob/9d73907af97befa3630f253895d067b5e9157b44/docs/core/whats-new/dotnet-11/overview.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-11/overview?branch=pr-en-us-55460) |
| [docs/core/whats-new/dotnet-11/runtime.md](https://github.com/dotnet/docs/blob/9d73907af97befa3630f253895d067b5e9157b44/docs/core/whats-new/dotnet-11/runtime.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-11/runtime?branch=pr-en-us-55460) |


<!-- PREVIEW-TABLE-END -->