### PR TITLE
Document System.Text.Json features in .NET 11

### DIFF
--- a/docs/core/whats-new/dotnet-11/libraries.md
+++ b/docs/core/whats-new/dotnet-11/libraries.md
@@ -2,7 +2,7 @@
 title: What's new in .NET libraries for .NET 11
 description: Learn about the updates to the .NET libraries for .NET 11.
 titleSuffix: ""
-ms.date: 08/12/2026
+ms.date: 08/18/2026
 ai-usage: ai-assisted
 ms.update-cycle: 3650-days
 ---
@@ -166,77 +166,144 @@ These methods provide both high-level convenience methods (that allocate and ret
 
 ### System.Text.Json improvements
 
-#### Generic type info retrieval
+#### Union serialization
 
-A common pattern when working with `System.Text.Json` type metadata is to retrieve a <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo`1> from <xref:System.Text.Json.JsonSerializerOptions>.
-Previously, you had to manually downcast from the non-generic <xref:System.Text.Json.JsonSerializerOptions.GetTypeInfo(System.Type)> method.
-New generic <xref:System.Text.Json.JsonSerializerOptions.GetTypeInfo``1?displayProperty=nameWithType> and <xref:System.Text.Json.JsonSerializerOptions.TryGetTypeInfo``1(System.Text.Json.Serialization.Metadata.JsonTypeInfo{``0}@)?displayProperty=nameWithType> methods return strongly typed metadata directly, eliminating the cast.
+**C# union types.** `System.Text.Json` can serialize and deserialize C# union types through the new <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.Union?displayProperty=nameWithType> contract kind. Reflection-based serialization and source generation both support union contracts. The serializer writes the active case directly as JavaScript Object Notation (JSON):
 
-:::code language="csharp" source="./snippets/csharp/Libraries.cs" id="JsonTypeInfoGeneric":::
+| Union state | JSON output |
+| - | - |
+| `string` case with value `"hello"` | `"hello"` |
+| `int` case with value `42` | `42` |
+| Default struct union with no active case | `null` |
 
-This is particularly useful when working with source generation, NativeAOT, and polymorphic serialization scenarios where type metadata access is common.
+If a union declares separate `T` and `T?` cases, the serializer preserves both cases and selects the nullable case for a `null` payload. A non-null payload is ambiguous without a custom classifier because both cases use the same JSON shape. If no case accepts `null`, JSON `null` deserializes to the default union value, which also serializes as `null`.
 
-#### Naming and ignore defaults
+Use <xref:System.Text.Json.Serialization.JsonUnionAttribute> and <xref:System.Text.Json.Serialization.Metadata.JsonUnionCaseInfo> to customize union metadata. For custom case selection, derive from <xref:System.Text.Json.Serialization.JsonTypeClassifierFactory>, which creates a <xref:System.Text.Json.Serialization.JsonTypeClassifier> delegate. Register the factory per union through <xref:System.Text.Json.Serialization.JsonUnionAttribute.TypeClassifier?displayProperty=nameWithType>, for reflection-based serialization through <xref:System.Text.Json.JsonSerializerOptions.TypeClassifiers?displayProperty=nameWithType>, or for source generation through <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute.TypeClassifiers?displayProperty=nameWithType>.
 
-The naming and ignore options available in <xref:System.Text.Json?displayProperty=fullName> now include:
+<xref:System.Text.Json.Serialization.JsonUnionTypeStructuralClassifier> extends the default JSON-token-kind classification with object-shape classification. It compares root-level property names, without inspecting property values or nested content, and rejects configurations where it can't select one case unambiguously. Nested union cases, polymorphic cases, and reference-preserving deserialization aren't supported by this classifier.
 
-- **<xref:System.Text.Json.JsonNamingPolicy.PascalCase?displayProperty=nameWithType>**: A new built-in naming policy that converts property names to PascalCase. It joins the existing camelCase, snake_case, and kebab-case policies.
-- **Per-member naming policy**: The new <xref:System.Text.Json.Serialization.JsonNamingPolicyAttribute?displayProperty=nameWithType> attribute lets you override the naming policy on individual properties or fields, giving you fine-grained control without a custom converter.
-- **Type-level ignore conditions**: Applying <xref:System.Text.Json.Serialization.JsonIgnoreAttribute?displayProperty=nameWithType> at the class or struct level sets the default ignore behavior for all members, so you no longer need to repeat the attribute on every nullable property.
+C# union types are a preview language feature. For language syntax, see [C# 15 union types](../../../csharp/whats-new/csharp-15.md#union-types). For serialization guidance, see [Serialize union types](../../../standard/serialization/system-text-json/union-types.md).
 
-:::code language="csharp" source="./snippets/csharp/Libraries.cs" id="JsonNamingIgnore":::
-
-#### F# discriminated union support
-
-The serializer now understands F# discriminated unions out of the box. Apps that share types between F# producers and C# consumers no longer need a custom converter for the most common shapes:
+**F# discriminated unions.** The serializer represents cases without fields as JSON strings and cases with fields as JSON objects that contain a `$type` discriminator:
 
 ```fsharp
 type Shape =
+    | Point
     | Circle of radius: float
-    | Square of side: float
-
-let json = System.Text.Json.JsonSerializer.Serialize(Circle 1.5)
-// {"$type":"Circle","radius":1.5}
+    | Rectangle of height: float * length: float
 ```
 
-#### Utf8JsonWriter.Reset with options
+| F# value | JSON output |
+| - | - |
+| `Point` | `"Point"` |
+| `Circle 3.14` | `{"$type":"Circle","radius":3.14}` |
+| `Rectangle(10.0, 20.0)` | `{"$type":"Rectangle","height":10,"length":20}` |
 
-<xref:System.Text.Json.Utf8JsonWriter.Reset*> now accepts a <xref:System.Text.Json.JsonWriterOptions> parameter, so writer instances can be repooled with different options without allocating a new writer:
+For cases without fields, deserialization accepts both `"Point"` and `{"$type":"Point"}`. Class, struct, and recursive unions are supported. <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType> applies to case and field names, while <xref:System.Text.Json.Serialization.JsonPropertyNameAttribute> on a case takes precedence. You can also change the discriminator property through <xref:System.Text.Json.Serialization.JsonPolymorphicAttribute.TypeDiscriminatorPropertyName?displayProperty=nameWithType>.
 
-:::code language="csharp" source="./snippets/csharp/Libraries.cs" id="Utf8JsonWriterReset":::
+> [!IMPORTANT]
+> F# discriminated-union support uses reflection only. It doesn't support `System.Text.Json` source generation, trimming, or Native AOT.
 
-#### SerializeAsyncEnumerable improvements
+#### JSON Lines output
 
-<xref:System.Text.Json.JsonSerializer.SerializeAsyncEnumerable*?displayProperty=nameWithType> gains two new capabilities:
+Four <xref:System.Text.Json.JsonSerializer.SerializeAsyncEnumerable*?displayProperty=nameWithType> overloads serialize an <xref:System.Collections.Generic.IAsyncEnumerable`1> to either a <xref:System.IO.Stream> or <xref:System.IO.Pipelines.PipeWriter>. For each output type, one overload accepts <xref:System.Text.Json.JsonSerializerOptions> and one accepts <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo`1>.
 
-- **`PipeWriter` target:** For pipeline-based I/O scenarios, new overloads accept a <xref:System.IO.Pipelines.PipeWriter> as the output destination, making it easy to integrate JSON streaming directly.
-- **`topLevelValues` parameter:** For NDJSON output, set this parameter to `true` to write each item as a top-level JSON value separated by newlines instead of wrapping all items in a JSON array. Both `Stream` and `PipeWriter` overloads support the parameter.
+With the default `topLevelValues: false`, the output remains one JSON array. Set `topLevelValues: true` to write canonical JSON Lines (JSONL). The serializer writes each value compactly and follows it with a line feed (LF), `\n`, including the final value. JSONL output uses LF regardless of <xref:System.Text.Json.JsonSerializerOptions.NewLine?displayProperty=nameWithType> and ignores <xref:System.Text.Json.JsonSerializerOptions.WriteIndented?displayProperty=nameWithType> so that each value occupies one line.
 
 :::code language="csharp" source="./snippets/csharp/Libraries.cs" id="JsonSerializeAsyncEnumerablePipe":::
 
-#### C# union type serialization
+#### Polymorphic hierarchy support
 
-`System.Text.Json` can now serialize and deserialize C# union types. The serializer recognizes a union through the new `JsonTypeInfoKind.Union` contract kind, reads and writes the active case, and supports both the reflection-based serializer and the source generator. When you serialize a union, `System.Text.Json` writes the value of whichever case is active, so a union of `int` and `string` round-trips cleanly:
+For a C# `closed` hierarchy, the serializer can infer the derived types, including generic specializations, and assign deterministic discriminators. Configure inference at any of these scopes:
 
-```json
-{
-  "id": 1,
-  "payload": "hello"
-}
+```csharp
+[JsonPolymorphic(InferClosedTypePolymorphism = true)]
+closed record Shape;
+record Circle(double Radius) : Shape;
+record Square(double Length) : Shape;
 ```
 
-```json
-{
-  "id": 2,
-  "payload": 42
-}
+- Set <xref:System.Text.Json.JsonSerializerOptions.InferClosedTypePolymorphism?displayProperty=nameWithType> for reflection-based serialization or as a global runtime setting.
+- Set <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute.InferClosedTypePolymorphism?displayProperty=nameWithType> so the source generator creates the required metadata at compile time.
+- Set <xref:System.Text.Json.Serialization.JsonPolymorphicAttribute.InferClosedTypePolymorphism?displayProperty=nameWithType> to `true` on one hierarchy. Set it to `false` to opt that hierarchy out of a global setting.
+
+Explicit <xref:System.Text.Json.Serialization.JsonDerivedTypeAttribute> registrations take precedence and replace the inferred list instead of extending it. If source-generated metadata doesn't contain inferred or explicitly registered derived types, enabling only the runtime option fails fast. A per-type opt-in on a type that isn't `closed` throws <xref:System.InvalidOperationException> with reflection and produces a source-generation error. Combining a per-type opt-in with explicit derived-type registrations produces a source-generation warning because the explicit registrations replace inference.
+
+Open generic derived-type registrations are also supported. For example, one attribute registers `Derived<T>` for every compatible closed `Base<T>`:
+
+```csharp
+[JsonDerivedType(typeof(Derived<>), "derived")]
+public class Base<T> { }
+public class Derived<T> : Base<T> { }
 ```
 
-The new `JsonUnionAttribute` and `JsonUnionCaseInfo` APIs, along with type-classifier APIs (`JsonTypeClassifier` and `JsonSerializerOptions.TypeClassifiers`), let you customize how cases are discovered and named. Union types are a C# language preview feature. For more information, see [What's new in C# 15](../../../csharp/whats-new/csharp-15.md#union-types).
+The resolver supports these type-argument patterns:
 
-#### Closed-hierarchy polymorphism inference
+| Pattern | Example resolution |
+| - | - |
+| Direct binding | `Base<int>` resolves `Derived<T> : Base<T>` to `Derived<int>`. |
+| Reordered parameters | `Base<int, string>` resolves `Derived<U, V> : Base<V, U>` to `Derived<string, int>`. |
+| Partially concrete parameters | `Base<string, int>` resolves `Derived<T> : Base<T, int>` to `Derived<string>`. |
+| Nested or array parameters | `Base<List<int>>` resolves `Derived<T> : Base<List<T>>` to `Derived<int>`. |
 
-<xref:System.Text.Json.JsonSerializerOptions> adds <xref:System.Text.Json.JsonSerializerOptions.InferClosedTypePolymorphism?displayProperty=nameWithType> so the serializer can infer polymorphic metadata for C# closed hierarchies without requiring explicit <xref:System.Text.Json.Serialization.JsonDerivedTypeAttribute> annotations on each base type. Explicit registrations still take precedence.
+The same rules apply to generic interfaces and types nested in generic outer types. The registration must resolve to exactly one closed derived type and satisfy its generic constraints. A ground-type mismatch, an unbound parameter, a constraint violation, an ambiguous match, or an incompatible shape throws <xref:System.InvalidOperationException> with reflection. For source generation, an unresolved registration produces the [SYSLIB1229](../../../fundamentals/syslib-diagnostics/syslib1220-1229.md) warning, and the generated hierarchy still fails when the serializer configures it. Suppressing the warning doesn't make the registration valid.
+
+For serializer configuration guidance, see [Infer polymorphism from a closed hierarchy](../../../standard/serialization/system-text-json/polymorphism.md#infer-polymorphism-from-a-closed-hierarchy) and [Configure open generic derived types](../../../standard/serialization/system-text-json/polymorphism.md#configure-open-generic-derived-types). For more information about the language feature, see [C# 15 closed hierarchies](../../../csharp/whats-new/csharp-15.md#closed-hierarchies).
+
+#### Source-generation and contract metadata
+
+The `System.Text.Json` source generator supports more contract shapes:
+
+- Members marked with <xref:System.Text.Json.Serialization.JsonIncludeAttribute> can have `private`, `internal`, or `protected` accessors. Private, internal, and protected fields are also supported when they're marked with `[JsonInclude]`.
+- An inaccessible constructor marked with <xref:System.Text.Json.Serialization.JsonConstructorAttribute> can participate in deserialization.
+- An omitted `init`-only property retains its property-initializer value. The generated contract sets the property after construction only when the JSON payload contains that property.
+
+Reflection-based and source-generated deserialization also support constructors whose parameters use `in`, `ref`, `out`, or `ref readonly`. The serializer binds `in`, `ref`, and `ref readonly` parameters by their element type. An `out` parameter doesn't bind a JSON constructor argument; the constructor receives an initialized output location, and a matching writable property can receive the JSON value after construction.
+
+For more information, see [Source-generation modes in System.Text.Json](../../../standard/serialization/system-text-json/source-generation-modes.md) and [Use immutable types and properties](../../../standard/serialization/system-text-json/immutability.md).
+
+Generic <xref:System.Text.Json.JsonSerializerOptions.GetTypeInfo``1?displayProperty=nameWithType> and <xref:System.Text.Json.JsonSerializerOptions.TryGetTypeInfo``1(System.Text.Json.Serialization.Metadata.JsonTypeInfo{``0}@)?displayProperty=nameWithType> methods return <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo`1> without a manual cast. `GetTypeInfo<T>()` throws if the options can't resolve the type, while `TryGetTypeInfo<T>()` returns `false` in that case. Resolver and configuration exceptions can still propagate. These methods simplify metadata access in source-generation, Native AOT, and polymorphic serialization scenarios. For more information, see [Get strongly typed metadata](../../../standard/serialization/system-text-json/custom-contracts.md#get-strongly-typed-metadata).
+
+:::code language="csharp" source="./snippets/csharp/Libraries.cs" id="JsonTypeInfoGeneric":::
+
+#### Property names and ignore conditions
+
+<xref:System.Text.Json.JsonNamingPolicy.PascalCase?displayProperty=nameWithType> and <xref:System.Text.Json.Serialization.JsonKnownNamingPolicy.PascalCase?displayProperty=nameWithType> provide built-in PascalCase conversion. Apply <xref:System.Text.Json.Serialization.JsonNamingPolicyAttribute> to a class, struct, interface, property, or field to select a naming policy at the type or member level.
+
+Naming precedence, from highest to lowest, is <xref:System.Text.Json.Serialization.JsonPropertyNameAttribute>, a member-level `[JsonNamingPolicy]`, a type-level `[JsonNamingPolicy]`, <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType>, and the original member name.
+
+<xref:System.Text.Json.Serialization.JsonIgnoreAttribute> can now set a default ignore condition on classes, structs, and interfaces. A member-level `[JsonIgnore]` takes precedence over the type-level condition, which takes precedence over <xref:System.Text.Json.JsonSerializerOptions.DefaultIgnoreCondition?displayProperty=nameWithType>. <xref:System.Text.Json.Serialization.JsonIgnoreCondition.Always?displayProperty=nameWithType> isn't valid at the type level; reflection throws <xref:System.InvalidOperationException>, while source generation reports `SYSLIB1226` and ignores the type-level attribute.
+
+:::code language="csharp" source="./snippets/csharp/Libraries.cs" id="JsonNamingIgnore":::
+
+For more information, see [Apply a naming policy to a type or member](../../../standard/serialization/system-text-json/customize-properties.md#apply-a-naming-policy-to-a-type-or-member) and [Ignore properties based on a type-level condition](../../../standard/serialization/system-text-json/ignore-properties.md#ignore-properties-based-on-a-type-level-condition).
+
+#### Converters and collection contracts
+
+**Numeric converters.** The serializer includes built-in converters for <xref:System.Numerics.BFloat16>, <xref:System.Numerics.Decimal32>, <xref:System.Numerics.Decimal64>, and <xref:System.Numerics.Decimal128>. The converters work with reflection, source generation, number-handling options, dictionary keys, and JSON Schema export. For generated metadata, <xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices> exposes <xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices.BFloat16Converter?displayProperty=nameWithType>, <xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices.Decimal32Converter?displayProperty=nameWithType>, <xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices.Decimal64Converter?displayProperty=nameWithType>, and <xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices.Decimal128Converter?displayProperty=nameWithType>.
+
+**Open generic converters.** <xref:System.Text.Json.Serialization.JsonConverterAttribute> can reference an open generic converter on a generic type or member:
+
+```csharp
+[JsonConverter(typeof(OptionConverter<>))]
+public readonly struct Option<T> { }
+```
+
+The converter's total generic arity must match the target type's arity. The serializer closes the converter with the target type arguments in both reflection and source-generation modes, without requiring <xref:System.Text.Json.Serialization.JsonConverterFactory>. For supported nesting patterns, constraints, and error behavior, see [Use open generic converters with `JsonConverter`](../../../standard/serialization/system-text-json/converters-how-to.md#use-open-generic-converters-with-jsonconverter).
+
+**Extension data.** A member marked with <xref:System.Text.Json.Serialization.JsonExtensionDataAttribute> can use <xref:System.Collections.Generic.IReadOnlyDictionary`2> with `string` keys and either `object` or <xref:System.Text.Json.JsonElement> values. During deserialization, the serializer assigns a mutable <xref:System.Collections.Generic.Dictionary`2> implementation. If the property already contains entries, the serializer copies them first and then adds JSON properties, so an incoming value replaces an existing value with the same key. A <xref:System.Text.Json.Nodes.JsonObject> extension-data member writes its child properties directly into the containing object. For example, an `Id` property and a `JsonObject` entry named `nested` produce `{"Id":1,"nested":true}`. For more information, see [Handle overflow JSON](../../../standard/serialization/system-text-json/handle-overflow.md#handle-overflow-json).
+
+**Read-only sets.** <xref:System.Text.Json.JsonSerializer> serializes <xref:System.Collections.Generic.IReadOnlySet`1> as a JSON array and deserializes it into a <xref:System.Collections.Generic.HashSet`1> instance. For source-generated metadata, <xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateIReadOnlySetInfo*?displayProperty=nameWithType> creates the collection contract.
+
+For more information about built-in numeric and collection contracts, see [Supported types in System.Text.Json](../../../standard/serialization/system-text-json/supported-types.md).
+
+#### Writer reuse
+
+<xref:System.Text.Json.Utf8JsonWriter.Reset*> accepts a <xref:System.Text.Json.JsonWriterOptions> together with either a <xref:System.IO.Stream> or <xref:System.Buffers.IBufferWriter`1>. After you flush one JSON document, you can reuse or pool the writer with a different output target and different options instead of constructing another writer instance:
+
+:::code language="csharp" source="./snippets/csharp/Libraries.cs" id="Utf8JsonWriterReset":::
+
+For more information, see [Reuse a writer](../../../standard/serialization/system-text-json/use-utf8jsonwriter.md#reuse-a-writer).
 
 ### Regular expression improvements
 
@@ -432,16 +499,11 @@ On Windows, `Process` now uses overlapped I/O for redirected stdout/stderr, whic
 ### Collections improvements
 
 - [BitArray.PopCount](#bitarraypopcount)
-- [IReadOnlySet support in JSON serialization](#ireadonlyset-support-in-json-serialization)
 - [EqualityComparer\<T>.Create](#equalitycomparertcreate)
 
 #### BitArray.PopCount
 
 The <xref:System.Collections.BitArray> class now includes a <xref:System.Collections.BitArray.PopCount?displayProperty=nameWithType> method that returns the number of bits set to `true` in the array. This provides an efficient way to count set bits without manually iterating through the array.
-
-#### IReadOnlySet support in JSON serialization
-
-The <xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices> class now includes a <xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateIReadOnlySetInfo*?displayProperty=nameWithType> method, enabling JSON serialization support for <xref:System.Collections.Generic.IReadOnlySet`1> collections.
 
 #### EqualityComparer\<T>.Create
 

--- a/docs/core/whats-new/dotnet-11/overview.md
+++ b/docs/core/whats-new/dotnet-11/overview.md
@@ -2,7 +2,7 @@
 title: What's new in .NET 11
 description: Learn about the new features introduced in .NET 11 for the runtime, libraries, and SDK. Also find links to what's new in other areas, such as ASP.NET Core.
 titleSuffix: ""
-ms.date: 08/12/2026
+ms.date: 08/18/2026
 ai-usage: ai-assisted
 ms.update-cycle: 3650-days
 ---
@@ -36,7 +36,7 @@ The .NET 11 libraries include new APIs for:
 - <xref:System.Diagnostics.Process> expansion with run-and-capture helpers, fire-and-forget launches, <xref:Microsoft.Win32.SafeHandles.SafeProcessHandle> lifecycle methods, tighter handle control, and new <xref:System.Diagnostics.ProcessStartInfo.StartSuspended?displayProperty=nameWithType> for suspended starts and <xref:System.Diagnostics.Process.TryGetProcessById(System.Int32,System.Diagnostics.Process@)?displayProperty=nameWithType> for safe process lookup.
 - Compression, including improved Base64 APIs, new methods for ZIP archive entries, Zstandard compression in <xref:System.IO.Compression?displayProperty=fullName>, and CRC32 validation when reading ZIP entries.
 - New numeric APIs, including IEEE 754 decimal floating-point types (<xref:System.Numerics.Decimal32>, <xref:System.Numerics.Decimal64>, and <xref:System.Numerics.Decimal128>), <xref:System.Numerics.INumberBase`1.TryParsePartial*?displayProperty=nameWithType> for delimiter-aware parsing, and generic <xref:System.Numerics.Complex`1>.
-- System.Text.Json improvements, including generic type info retrieval, <xref:System.Text.Json.JsonNamingPolicy.PascalCase?displayProperty=nameWithType>, per-member naming policy overrides, type-level ignore conditions, F# discriminated union support, <xref:System.Text.Json.Utf8JsonWriter.Reset*?displayProperty=nameWithType> with options, `SerializeAsyncEnumerable` overloads for `PipeWriter` targets and top-level values (NDJSON) output, and serialization of C# union types.
+- System.Text.Json improvements, including C# and F# union support, JSON Lines (JSONL) output, expanded polymorphism and source generation, new naming and ignore controls, and built-in numeric converters and collection contracts.
 - Built-in OpenTelemetry metrics for <xref:Microsoft.Extensions.Caching.Memory.MemoryCache>.
 - Discriminated-union scaffolding (`UnionAttribute` and `IUnion`) in <xref:System.Runtime.CompilerServices>.
 - Tar archive format selection and GNU sparse format 1.0 support.

--- a/docs/core/whats-new/dotnet-11/snippets/csharp/Libraries.cs
+++ b/docs/core/whats-new/dotnet-11/snippets/csharp/Libraries.cs
@@ -77,7 +77,7 @@ public static class LibrariesExamples
         writer.WriteEndObject();
         writer.Flush();
 
-        // Reset with different options for next use — no new allocation needed
+        // Reuse the writer with different output options.
         stream.SetLength(0);
         writer.Reset(stream, new JsonWriterOptions { Indented = false });
         // </Utf8JsonWriterReset>
@@ -86,19 +86,20 @@ public static class LibrariesExamples
     static void JsonTypeInfoExample()
     {
         // <JsonTypeInfoGeneric>
-        JsonSerializerOptions options = new(JsonSerializerDefaults.Web);
-        options.MakeReadOnly();
+        JsonSerializerOptions options = new()
+        {
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+        };
 
-        // Before: manual downcast required
+        // Previously, a manual downcast was required.
         JsonTypeInfo<MyRecord> info1 = (JsonTypeInfo<MyRecord>)options.GetTypeInfo(typeof(MyRecord));
 
-        // After: generic method returns the right type directly
+        // The generic method returns the correct type directly.
         JsonTypeInfo<MyRecord> info2 = options.GetTypeInfo<MyRecord>();
 
-        // TryGetTypeInfo variant for cases where the type may not be registered
+        // TryGetTypeInfo reports whether the configured resolver handles the type.
         if (options.TryGetTypeInfo<MyRecord>(out JsonTypeInfo<MyRecord>? typeInfo))
         {
-            // Use typeInfo
             _ = typeInfo;
         }
         // </JsonTypeInfoGeneric>
@@ -107,18 +108,18 @@ public static class LibrariesExamples
     static void JsonNamingIgnoreExample()
     {
         // <JsonNamingIgnore>
-        // Type-level JsonIgnore: all members use WhenWritingNull by default
-        // Per-member JsonNamingPolicy: EventName uses camelCase even though the
-        // serializer options use PascalCase
+        // Type-level JsonIgnore omits null members by default. The type-level
+        // naming policy overrides the global policy, and the member policy wins
+        // for EventName.
         var options = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.PascalCase
         };
 
-        var data = new EventData { EventName = "Launch", Notes = null };
+        var data = new EventData { EventName = "Launch", ReleaseVersion = "11", Notes = null };
         string json = JsonSerializer.Serialize(data, options);
         Console.WriteLine(json);
-        // {"eventName":"Launch"}  -- Notes omitted (null), EventName camel-cased
+        // {"eventName":"Launch","release_version":"11"}
         // </JsonNamingIgnore>
     }
 
@@ -281,18 +282,25 @@ public static class LibrariesExamples
             }
         }
 
-        var pipe = new Pipe();
+        using var arrayStream = new MemoryStream();
+        PipeWriter arrayPipe = PipeWriter.Create(arrayStream);
 
-        // Write a JSON array: [0,1,2,3,4]
+        // Write a JavaScript Object Notation (JSON) array: [0,1,2,3,4]
         await JsonSerializer.SerializeAsyncEnumerable(
-            pipe.Writer,
+            arrayPipe,
             GenerateNumbers());
+        await arrayPipe.CompleteAsync();
 
-        // Write NDJSON (one value per line): 0\n1\n2\n3\n4\n
+        using var jsonlStream = new MemoryStream();
+        PipeWriter jsonlPipe = PipeWriter.Create(jsonlStream);
+
+        // Write canonical JSON Lines (JSONL). Each value is followed by \n.
+        // Output: 0\n1\n2\n3\n4\n
         await JsonSerializer.SerializeAsyncEnumerable(
-            pipe.Writer,
+            jsonlPipe,
             GenerateNumbers(),
             topLevelValues: true);
+        await jsonlPipe.CompleteAsync();
         // </JsonSerializeAsyncEnumerablePipe>
     }
 
@@ -327,11 +335,14 @@ public static class LibrariesExamples
 
 record MyRecord(string Name, int Value);
 
+[JsonNamingPolicy(JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 sealed class EventData
 {
     [JsonNamingPolicy(JsonKnownNamingPolicy.CamelCase)]
     public string EventName { get; set; } = "";
+
+    public string ReleaseVersion { get; set; } = "";
 
     public string? Notes { get; set; }
 }

--- a/docs/fundamentals/toc.yml
+++ b/docs/fundamentals/toc.yml
@@ -609,6 +609,8 @@ items:
                     href: ../standard/serialization/system-text-json/preserve-references.md
                   - name: Serialize polymorphic types
                     href: ../standard/serialization/system-text-json/polymorphism.md
+                  - name: Serialize union types
+                    href: ../standard/serialization/system-text-json/union-types.md
                   - name: Use extension methods on HttpClient
                     href: ../standard/serialization/system-text-json/httpclient-extensions.md
                   - name: Read/write JSON without using JsonSerializer

--- a/docs/standard/serialization/system-text-json/converters-how-to.md
+++ b/docs/standard/serialization/system-text-json/converters-how-to.md
@@ -1,7 +1,7 @@
 ---
 title: "How to write custom converters for JSON serialization - .NET"
 description: "Learn how to create custom converters for the JSON serialization classes that are provided in the System.Text.Json namespace."
-ms.date: 03/23/2026
+ms.date: 08/18/2026
 no-loc: [System.Text.Json, Newtonsoft.Json]
 helpviewer_keywords:
   - "JSON serialization"
@@ -89,11 +89,11 @@ The `Enum` type is similar to an open generic type: a converter for `Enum` has t
 
 ## Use open generic converters with [JsonConverter]
 
-Starting in .NET 11, <xref:System.Text.Json.Serialization.JsonConverterAttribute> supports open generic converter types on generic types when the total type parameter arity matches. This feature lets you apply a `[JsonConverter]` attribute directly using an open generic converter type (for example, `typeof(OptionConverter<>)`) without implementing a <xref:System.Text.Json.Serialization.JsonConverterFactory>. The serializer automatically constructs the closed generic converter at runtime.
+Starting in .NET 11, <xref:System.Text.Json.Serialization.JsonConverterAttribute> supports open generic converter types on generic types when the total type parameter arity matches. This feature lets you apply a `[JsonConverter]` attribute directly using an open generic converter type (for example, `typeof(OptionConverter<>)`) without implementing a <xref:System.Text.Json.Serialization.JsonConverterFactory>. The serializer automatically constructs the closed generic converter. Reflection-based serialization and source generation both support this feature.
 
 ### Define the generic type
 
-Annotate your generic type with `[JsonConverter]`, specifying the open generic converter type. The type parameter count on the converter must match the target type:
+Annotate your generic type with `[JsonConverter]`, specifying the open generic converter type. The converter and target type must have matching total generic arity:
 
 :::code language="csharp" source="snippets/converters-how-to/csharp/OpenGenericConverter.cs" id="OptionType":::
 
@@ -149,7 +149,7 @@ Continue to use <xref:System.Text.Json.Serialization.JsonConverterFactory> when:
 * You register the converter through <xref:System.Text.Json.JsonSerializerOptions.Converters?displayProperty=nameWithType> instead of the `[JsonConverter]` attribute.
 
 > [!NOTE]
-> If the type parameter count on the converter doesn't match the target type, an <xref:System.InvalidOperationException> is thrown at runtime.
+> At run time, using an open generic converter on a non-generic type or with mismatched total generic arity throws an <xref:System.InvalidOperationException>. The message identifies the converter and target type.
 
 ## The use of `Utf8JsonReader` in the `Read` method
 

--- a/docs/standard/serialization/system-text-json/custom-contracts.md
+++ b/docs/standard/serialization/system-text-json/custom-contracts.md
@@ -1,7 +1,8 @@
 ---
 title: Custom serialization and deserialization contracts
 description: "Learn how to write your own contract resolution logic to customize the JSON contract for a type."
-ms.date: 06/15/2023
+ms.date: 08/18/2026
+ai-usage: ai-assisted
 ---
 # Customize a JSON contract
 
@@ -45,15 +46,30 @@ There are two ways to plug into customization. Both involve obtaining a resolver
   - If a type isn't handled, <xref:System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver.GetTypeInfo*?displayProperty=nameWithType> should return `null` for that type.
   - You can also combine your custom resolver with others, for example, the default resolver. The resolvers will be queried in order until a non-null <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo> value is returned for the type.
 
+## Get strongly typed metadata
+
+Starting in .NET 11, use <xref:System.Text.Json.JsonSerializerOptions.GetTypeInfo``1?displayProperty=nameWithType> and <xref:System.Text.Json.JsonSerializerOptions.TryGetTypeInfo``1(System.Text.Json.Serialization.Metadata.JsonTypeInfo{``0}@)?displayProperty=nameWithType> as strongly typed alternatives to casting the result of <xref:System.Text.Json.JsonSerializerOptions.GetTypeInfo(System.Type)>:
+
+```csharp
+JsonTypeInfo<WeatherForecast> typeInfo =
+    options.GetTypeInfo<WeatherForecast>();
+
+bool found = options.TryGetTypeInfo<WeatherForecast>(
+    out JsonTypeInfo<WeatherForecast>? optionalTypeInfo);
+```
+
+`TryGetTypeInfo<T>` returns `false` when no resolver supplies metadata for `T`.
+
 ## Configurable aspects
 
-The <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.Kind?displayProperty=nameWithType> property indicates how the converter serializes a given type&mdash;for example, as an object or as an array, and whether its properties are serialized. You can query this property to determine which aspects of a type's JSON contract you can configure. There are four different kinds:
+The <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.Kind?displayProperty=nameWithType> property indicates how the converter serializes a given type&mdash;for example, as an object or as an array, and whether its properties are serialized. Query this property to determine which aspects of a type's JSON contract you can configure. The property has five possible values:
 
 | `JsonTypeInfo.Kind` | Description |
 |---------------------|-------------|
 | <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.Object?displayProperty=nameWithType> | The converter will serialize the type into a JSON object and uses its properties. **This kind is used for most class and struct types and allows for the most flexibility.** |
 | <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.Enumerable?displayProperty=nameWithType> | The converter will serialize the type into a JSON array. This kind is used for types like `List<T>` and array. |
 | <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.Dictionary?displayProperty=nameWithType> | The converter will serialize the type into a JSON object. This kind is used for types like `Dictionary<K, V>`. |
+| <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.Union?displayProperty=nameWithType> | The converter serializes the active case value from a union. Starting in .NET 11, this kind is used for C# union types and exposes case, classifier, constructor, and deconstructor metadata. |
 | <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.None?displayProperty=nameWithType> | The converter doesn't specify how it will serialize the type or what `JsonTypeInfo` properties it will use. This kind is used for types like <xref:System.Object?displayProperty=nameWithType>, `int`, and `string`, and for all types that use a custom converter. |
 
 ## Modifiers
@@ -68,6 +84,7 @@ The following table shows the modifications you can make and how to achieve them
 | Add or remove properties | `JsonTypeInfoKind.Object` | Add or remove items from the <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.Properties?displayProperty=nameWithType> list. | [Serialize private fields](#example-serialize-private-fields) |
 | Conditionally serialize a property | `JsonTypeInfoKind.Object` | Modify the <xref:System.Text.Json.Serialization.Metadata.JsonPropertyInfo.ShouldSerialize?displayProperty=nameWithType> predicate for the property. | [Ignore properties with a specific type](#example-ignore-properties-with-a-specific-type) |
 | Customize number handling for a specific type | `JsonTypeInfoKind.None` | Modify the <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.NumberHandling?displayProperty=nameWithType> value for the type. | [Allow int values to be strings](#example-allow-int-values-to-be-strings) |
+| Customize union cases or classification | `JsonTypeInfoKind.Union` | Modify the union cases, classifier, constructor, or deconstructor on <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo>. | [Serialize union types](union-types.md#customize-a-union-contract) |
 
 ## Example: Increment a property's value
 

--- a/docs/standard/serialization/system-text-json/customize-properties.md
+++ b/docs/standard/serialization/system-text-json/customize-properties.md
@@ -1,7 +1,7 @@
 ---
 title: How to customize property names and values with System.Text.Json
 description: "Learn how to customize property names and values when serializing with System.Text.Json in .NET."
-ms.date: 05/06/2025
+ms.date: 08/18/2026
 no-loc: [System.Text.Json, Newtonsoft.Json]
 dev_langs:
   - "csharp"
@@ -12,6 +12,7 @@ helpviewer_keywords:
   - "serialization"
   - "objects, serializing"
 ms.topic: how-to
+ai-usage: ai-assisted
 ---
 
 # How to customize property names and values with System.Text.Json
@@ -19,7 +20,8 @@ ms.topic: how-to
 By default, property names and dictionary keys are unchanged in the JSON output, including case. Enum values are represented as numbers. And properties are serialized in the order they're defined. However, you can customize these behaviors by:
 
 - Specifying specific serialized property and enum member names.
-- Using a built-in [naming policy](xref:System.Text.Json.JsonNamingPolicy), such as camelCase, snake_case, or kebab-case, for property names and dictionary keys.
+- Using a built-in [naming policy](xref:System.Text.Json.JsonNamingPolicy), such as camelCase, PascalCase, snake_case, or kebab-case, for property names and dictionary keys.
+- Applying a naming policy to a type or member.
 - Using a custom naming policy for property names and dictionary keys.
 - Serializing enum values as strings, with or without a naming policy.
 - Configuring the order of serialized properties.
@@ -60,12 +62,15 @@ The following table shows the built-in naming policies and how they affect prope
 | Naming policy                                             | Description | Original property name | Converted property name |
 |-----------------------------------------------------------|-|-----------------------|-------------------------|
 | <xref:System.Text.Json.JsonNamingPolicy.CamelCase>        | First word starts with a lower case character.<br/>Successive words start with an uppercase character. | `TempCelsius`          | `tempCelsius`           |
+| <xref:System.Text.Json.JsonNamingPolicy.PascalCase>\*\*   | First word starts with an uppercase character.<br/>Successive words start with an uppercase character. | `tempCelsius`          | `TempCelsius`           |
 | <xref:System.Text.Json.JsonNamingPolicy.KebabCaseLower>\* | Words are separated by hyphens.<br/>All characters are lowercase. | `TempCelsius`          | `temp-celsius`          |
 | <xref:System.Text.Json.JsonNamingPolicy.KebabCaseUpper>\* | Words are separated by hyphens.<br/>All characters are uppercase. | `TempCelsius`          | `TEMP-CELSIUS`          |
 | <xref:System.Text.Json.JsonNamingPolicy.SnakeCaseLower>\* | Words are separated by underscores.<br/>All characters are lowercase. | `TempCelsius`          | `temp_celsius`          |
 | <xref:System.Text.Json.JsonNamingPolicy.SnakeCaseUpper>\* | Words are separated by underscores.<br/>All characters are uppercase. |`TempCelsius`          | `TEMP_CELSIUS`          |
 
 \* Available in .NET 8 and later versions.
+
+\*\* Available in .NET 11 and later versions.
 
 The following example shows how to use camel case for all JSON property names by setting <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType> to <xref:System.Text.Json.JsonNamingPolicy.CamelCase?displayProperty=nameWithType>:
 
@@ -93,6 +98,43 @@ The naming policy:
 
 > [!NOTE]
 > None of the built-in naming policies support letters that are surrogate pairs. For more information, see [dotnet/runtime issue 90352](https://github.com/dotnet/runtime/issues/90352).
+
+## Apply a naming policy to a type or member
+
+Starting in .NET 11, apply <xref:System.Text.Json.Serialization.JsonNamingPolicyAttribute> to a class, struct, interface, property, or field. Pass a <xref:System.Text.Json.Serialization.JsonKnownNamingPolicy> value to select a built-in policy. A type-level attribute sets the naming policy for the type's properties and fields. A member-level attribute sets the policy for one property or field.
+
+The following example sets a type-level policy and overrides it for one property:
+
+```csharp
+[JsonNamingPolicy(JsonKnownNamingPolicy.CamelCase)]
+public class WeatherForecast
+{
+    public int TemperatureCelsius { get; set; }
+    [JsonNamingPolicy(JsonKnownNamingPolicy.SnakeCaseLower)] public string? SummaryText { get; set; }
+}
+```
+
+```vb
+<JsonNamingPolicy(JsonKnownNamingPolicy.CamelCase)>
+Public Class WeatherForecast
+    Public Property TemperatureCelsius As Integer
+    <JsonNamingPolicy(JsonKnownNamingPolicy.SnakeCaseLower)> Public Property SummaryText As String
+End Class
+```
+
+For `TemperatureCelsius = 25` and `SummaryText = "Hot"`, the resulting JSON is `{"temperatureCelsius":25,"summary_text":"Hot"}`.
+
+The serializer selects a JSON property name in this order, from highest to lowest precedence:
+
+- A <xref:System.Text.Json.Serialization.JsonPropertyNameAttribute> on the property or field.
+- A member-level <xref:System.Text.Json.Serialization.JsonNamingPolicyAttribute>.
+- A type-level <xref:System.Text.Json.Serialization.JsonNamingPolicyAttribute>.
+- <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType>.
+- The original member name.
+
+Reflection-based serialization and source generation both support `JsonNamingPolicyAttribute` with `JsonKnownNamingPolicy` values. The protected constructor lets a derived attribute supply a custom <xref:System.Text.Json.JsonNamingPolicy>. Reflection-based serialization evaluates the custom policy at run time.
+
+Source generation can't execute a custom policy at compile time. For affected members, it uses the original CLR name and doesn't apply the global <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType>.
 
 ## Use a custom JSON property naming policy
 

--- a/docs/standard/serialization/system-text-json/extract-schema.md
+++ b/docs/standard/serialization/system-text-json/extract-schema.md
@@ -1,34 +1,37 @@
 ---
 title: JSON schema exporter
 description: Learn how to use the JsonSchemaExporter class to extract JSON schema documents from .NET types.
-ms.date: 10/15/2024
+ms.date: 08/18/2026
+ai-usage: ai-assisted
 dev_langs:
   - "csharp"
 ---
 
 # JSON schema exporter
 
-The <xref:System.Text.Json.Schema.JsonSchemaExporter> class, introduced in .NET 9, lets you extract [JSON schema](https://json-schema.org/) documents from .NET types using either a <xref:System.Text.Json.JsonSerializerOptions> or <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo> instance. The resultant schema provides a specification of the JSON serialization contract for the .NET type. The schema describes the shape of what would be serialized and what can be deserialized.
+The <xref:System.Text.Json.Schema.JsonSchemaExporter> class, introduced in .NET 9, lets you extract [JSON schema](https://json-schema.org/) documents from .NET types. Use either a <xref:System.Text.Json.JsonSerializerOptions> or <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo> instance. The resulting schema describes the .NET type's JSON contract for serialization and deserialization.
 
 The following code snippet shows an example.
 
 :::code language="csharp" source="snippets/schema-exporter/ExportSchema.cs" id="1":::
 
-As can be seen in this example, the exporter distinguishes between nullable and non-nullable properties, and it populates the `required` keyword by virtue of a constructor parameter being optional or not.
+The exporter distinguishes between nullable and non-nullable properties. It sets the `required` keyword based on whether a constructor parameter is optional.
+
+Starting in .NET 11, the exporter recognizes the <xref:System.Numerics.BFloat16>, <xref:System.Numerics.Decimal32>, <xref:System.Numerics.Decimal64>, and <xref:System.Numerics.Decimal128> types. It exports schemas for their nullable forms and for named literals when you enable <xref:System.Text.Json.Serialization.JsonNumberHandling.AllowNamedFloatingPointLiterals>.
 
 ## Configure the schema output
 
-You can influence the schema output by configuration specified in the <xref:System.Text.Json.JsonSerializerOptions> or <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo> instance that you call the <xref:System.Text.Json.Schema.JsonSchemaExporter.GetJsonSchemaAsNode*> method on. The following example sets the naming policy to <xref:System.Text.Json.JsonNamingPolicy.KebabCaseUpper>, writes numbers as strings, and disallows unmapped properties.
+To control schema output, pass a configured <xref:System.Text.Json.JsonSerializerOptions> or <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo> instance to <xref:System.Text.Json.Schema.JsonSchemaExporter.GetJsonSchemaAsNode*>. The following example sets the naming policy to <xref:System.Text.Json.JsonNamingPolicy.KebabCaseUpper>, writes numbers as strings, and disallows unmapped properties.
 
 :::code language="csharp" source="snippets/schema-exporter/ExportSchema.cs" id="2":::
 
-You can further control the generated schema using the <xref:System.Text.Json.Schema.JsonSchemaExporterOptions> configuration type. The following example sets the <xref:System.Text.Json.Schema.JsonSchemaExporterOptions.TreatNullObliviousAsNonNullable> property to `true` to mark root-level types as non-nullable.
+To further control the generated schema, use <xref:System.Text.Json.Schema.JsonSchemaExporterOptions>. The following example sets <xref:System.Text.Json.Schema.JsonSchemaExporterOptions.TreatNullObliviousAsNonNullable> to `true` to mark root-level types as non-nullable.
 
 :::code language="csharp" source="snippets/schema-exporter/ExportSchema.cs" id="3":::
 
 ## Transform the generated schema
 
-You can apply your own transformations to generated schema nodes by specifying a <xref:System.Text.Json.Schema.JsonSchemaExporterOptions.TransformSchemaNode> delegate. The following example incorporates text from <xref:System.ComponentModel.DescriptionAttribute> annotations into the generated schema.
+To transform generated schema nodes, specify a <xref:System.Text.Json.Schema.JsonSchemaExporterOptions.TransformSchemaNode> delegate. The following example incorporates text from <xref:System.ComponentModel.DescriptionAttribute> annotations into the generated schema.
 
 :::code language="csharp" source="snippets/schema-exporter/TransformSchema.cs" id="1":::
 

--- a/docs/standard/serialization/system-text-json/handle-overflow.md
+++ b/docs/standard/serialization/system-text-json/handle-overflow.md
@@ -1,7 +1,7 @@
 ---
 title: How to handle overflow JSON or use JsonElement or JsonNode in System.Text.Json
 description: "Learn how to handle overflow JSON or use JsonElement or JsonNode while using System.Text.Json to serialize and deserialize JSON in .NET."
-ms.date: 07/21/2021
+ms.date: 08/18/2026
 no-loc: [System.Text.Json, Newtonsoft.Json]
 dev_langs:
   - "csharp"
@@ -12,6 +12,7 @@ helpviewer_keywords:
   - "serialization"
   - "objects, serializing"
 ms.topic: how-to
+ai-usage: ai-assisted
 ---
 
 # How to handle overflow JSON or use JsonElement or JsonNode
@@ -44,10 +45,20 @@ And the JSON to be deserialized is this:
 }
 ```
 
-If you deserialize the JSON shown into the type shown, the `DatesAvailable` and `SummaryWords` properties have nowhere to go and are lost. To capture extra data such as these properties, apply the [[JsonExtensionData]](xref:System.Text.Json.Serialization.JsonExtensionDataAttribute) attribute to a property of type `Dictionary<string,object>` or `Dictionary<string,JsonElement>`:
+If you deserialize the JSON shown into the type shown, the `DatesAvailable` and `SummaryWords` properties have nowhere to go and are lost. To capture extra data such as these properties, apply the [[JsonExtensionData]](xref:System.Text.Json.Serialization.JsonExtensionDataAttribute) attribute to a property or field. Use one of these supported declarations:
+
+* Declare the extension-data member as <xref:System.Text.Json.Nodes.JsonObject>.
+* Declare the extension-data member as [`IDictionary<string, object>`](xref:System.Collections.Generic.IDictionary`2).
+* Declare the extension-data member as [`IDictionary<string, JsonElement>`](xref:System.Collections.Generic.IDictionary`2).
+* Declare the extension-data member as [`IReadOnlyDictionary<string, object>`](xref:System.Collections.Generic.IReadOnlyDictionary`2) in .NET 11 and later.
+* Declare the extension-data member as [`IReadOnlyDictionary<string, JsonElement>`](xref:System.Collections.Generic.IReadOnlyDictionary`2) in .NET 11 and later.
+
+For mutable dictionary extension data, use any type assignable to one of the supported `IDictionary` interfaces, such as `Dictionary<string, JsonElement>`. The read-only declarations must use one of the exact `IReadOnlyDictionary` interface types listed above.
 
 :::code language="csharp" source="snippets/how-to/csharp/WeatherForecast.cs" id="WFWithExtensionData":::
 :::code language="vb" source="snippets/how-to/vb/WeatherForecast.vb" id="WFWithExtensionData":::
+
+For an `IReadOnlyDictionary` extension-data member, .NET 11 materializes a `Dictionary<string, object>` or `Dictionary<string, JsonElement>`. The member must be writable because the serializer seeds the new dictionary from existing values and assigns it back. If an incoming JSON property duplicates an existing key, the incoming value wins.
 
 The following table shows the result of deserializing the JSON shown earlier into this sample type. The extra data becomes key-value pairs of the `ExtensionData` property:
 
@@ -79,6 +90,8 @@ When the target object is serialized, the extension data key value pairs become 
 ```
 
 Notice that the `ExtensionData` property name doesn't appear in the JSON. This behavior lets the JSON make a round trip without losing any extra data that otherwise wouldn't be deserialized.
+
+Starting in .NET 11, serialization flattens `JsonObject` extension data into the containing JSON object. The `JsonObject` properties appear directly in the containing object, not under the extension-data member name.
 
 The following example shows a round trip from JSON to a deserialized object and back to JSON:
 

--- a/docs/standard/serialization/system-text-json/ignore-properties.md
+++ b/docs/standard/serialization/system-text-json/ignore-properties.md
@@ -1,7 +1,7 @@
 ---
 title: How to ignore properties with System.Text.Json
 description: "Learn how to ignore properties when serializing with System.Text.Json in .NET."
-ms.date: 10/22/2025
+ms.date: 08/18/2026
 ms.custom: devdivchpfy22
 no-loc: [System.Text.Json, Newtonsoft.Json]
 dev_langs:
@@ -21,6 +21,7 @@ ai-usage: ai-assisted
 When serializing C# objects to JavaScript Object Notation (JSON), by default, all public properties are serialized. If you don't want some of them to appear in the resulting JSON, you have several options. In this article, you learn how to ignore properties based on various criteria:
 
 * [Individual properties](#ignore-individual-properties)
+* [Properties based on a type-level condition](#ignore-properties-based-on-a-type-level-condition)
 * [All read-only properties](#ignore-all-read-only-properties)
 * [All null-value properties](#ignore-all-null-value-properties)
 * [All default-value properties](#ignore-all-default-value-properties)
@@ -52,6 +53,35 @@ The following example illustrates the use of the [[JsonIgnore]](xref:System.Text
 
 :::code language="csharp" source="snippets/how-to-contd/csharp/JsonIgnoreAttributeExample.cs" highlight="8,11,14":::
 :::code language="vb" source="snippets/how-to-contd/vb/JsonIgnoreAttributeExample.vb" :::
+
+## Ignore properties based on a type-level condition
+
+Starting in .NET 11, apply `[JsonIgnore(Condition = ...)]` to a class, struct, or interface to set the default ignore condition for its properties and fields:
+
+```csharp
+[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+public class Forecast
+{
+    public string? Summary { get; set; }
+}
+```
+
+```vb
+<JsonIgnore(Condition:=JsonIgnoreCondition.WhenWritingNull)>
+Public Class Forecast
+    Public Property Summary As String
+End Class
+```
+
+The serializer applies ignore settings in this order, from highest to lowest precedence:
+
+* A member-level <xref:System.Text.Json.Serialization.JsonIgnoreAttribute>.
+* A type-level <xref:System.Text.Json.Serialization.JsonIgnoreAttribute>.
+* <xref:System.Text.Json.JsonSerializerOptions.DefaultIgnoreCondition?displayProperty=nameWithType>.
+
+At the type level, <xref:System.Text.Json.Serialization.JsonIgnoreCondition.Always> is invalid. Reflection-based serialization throws an <xref:System.InvalidOperationException>, and source generation reports `SYSLIB1226`. Because `Always` is the default condition, specify `Condition` when you apply `[JsonIgnore]` to a type.
+
+A type-level <xref:System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull> condition doesn't ignore non-nullable value-type members. The type-level condition still overrides the global `DefaultIgnoreCondition`, so those members remain in the JSON even when the global condition is `WhenWritingDefault`.
 
 ## Ignore all read-only properties
 

--- a/docs/standard/serialization/system-text-json/immutability.md
+++ b/docs/standard/serialization/system-text-json/immutability.md
@@ -1,7 +1,8 @@
 ---
 title: Use immutable types and properties
 description: "Learn how to deserialize JSON to immutable types and properties in .NET."
-ms.date: 10/20/2023
+ms.date: 08/18/2026
+ai-usage: ai-assisted
 no-loc: [System.Text.Json, Newtonsoft.Json]
 dev_langs:
   - "csharp"
@@ -11,23 +12,25 @@ ms.topic: how-to
 
 # Use immutable types and properties
 
-An immutable *type* is one that prevents you from changing any property or field values of an object after it's instantiated. The type might be a record, have no public properties or fields, have read-only properties, or have properties with private or init-only setters. <xref:System.String?displayProperty=nameWithType> is an example of an immutable type. <xref:System.Text.Json> provides different ways that you can deserialize JSON to immutable types.
+An immutable *type* prevents changes to property or field values after construction. Examples include records, types with no public properties or fields, read-only properties, and properties with private or init-only setters. <xref:System.String?displayProperty=nameWithType> is an immutable type. <xref:System.Text.Json> provides several ways to deserialize JSON to immutable types.
 
 ## Parameterized constructors
 
-By default, `System.Text.Json` uses the default public parameterless constructor. However, you can tell it to use a parameterized constructor, which makes it possible to deserialize an immutable class or struct.
+By default, `System.Text.Json` uses the public parameterless constructor. To deserialize an immutable class or struct, configure the serializer to use a parameterized constructor.
 
-- For a class, if the only constructor is a parameterized one, that constructor will be used.
-- For a struct, or a class with multiple constructors, specify the one to use by applying the [[JsonConstructor]](xref:System.Text.Json.Serialization.JsonConstructorAttribute) attribute. When the attribute is not used, a public parameterless constructor is always used if present.
+- For a class whose only constructor is parameterized, `System.Text.Json` uses that constructor.
+- For a struct or a class with multiple constructors, apply the [[JsonConstructor]](xref:System.Text.Json.Serialization.JsonConstructorAttribute) attribute to the constructor to use. Without the attribute, the serializer uses a public parameterless constructor when one exists.
 
   The following example uses the `[JsonConstructor]` attribute:
 
   :::code language="csharp" source="snippets/how-to-contd/csharp/ImmutableTypes.cs" highlight="12":::
   :::code language="vb" source="snippets/how-to-contd/vb/ImmutableTypes.vb" :::
 
-  In .NET 7 and earlier versions, the `[JsonConstructor]` attribute can only be used with public constructors.
+  In .NET 7 and earlier versions, apply the `[JsonConstructor]` attribute only to public constructors.
 
-The parameter names of a parameterized constructor must match the property names and types. Matching is case-insensitive, and the constructor parameter must match the actual property name even if you use [[JsonPropertyName]](xref:System.Text.Json.Serialization.JsonPropertyNameAttribute) to rename a property. In the following example, the name for the `TemperatureC` property is changed to `celsius` in the JSON, but the constructor parameter is still named `temperatureC`:
+In .NET 8 and later versions, reflection mode supports non-public constructors marked with `[JsonConstructor]`. Starting in .NET 11, source-generation mode supports them too.
+
+The parameter names of a parameterized constructor must match the property names and types. Matching is case-insensitive. A constructor parameter must match the actual property name even when [[JsonPropertyName]](xref:System.Text.Json.Serialization.JsonPropertyNameAttribute) renames the property. In the following example, `[JsonPropertyName]` changes `TemperatureC` to `celsius` in the JSON, but the constructor parameter remains `temperatureC`:
 
 :::code language="csharp" source="snippets/how-to-contd/csharp/ImmutableTypesCtorParms.cs" highlight="9,13-15":::
 
@@ -38,31 +41,64 @@ Besides `[JsonPropertyName]`, the following attributes support deserialization w
 - [[JsonInclude]](xref:System.Text.Json.Serialization.JsonIncludeAttribute)
 - [[JsonNumberHandling]](xref:System.Text.Json.Serialization.JsonNumberHandlingAttribute)
 
+## By-reference constructor parameters
+
+Starting in .NET 11, both reflection mode and source-generation mode deserialize types whose constructor parameters use the `in`, `ref`, `out`, and `ref readonly` modifiers.
+
+| Parameter modifier | Deserialization behavior |
+|--------------------|--------------------------|
+| `in`, `ref`, and `ref readonly` | The serializer binds each parameter by name and uses its underlying element type for type matching. |
+| `out` | The serializer doesn't bind the parameter to JSON. It discards the value that the constructor assigns. |
+
+In the following constructor, the serializer binds `temperatureC` from JSON. It doesn't bind `isValid`:
+
+```csharp
+public Forecast(in int temperatureC, out bool isValid)
+{
+    TemperatureC = temperatureC;
+    isValid = true;
+}
+```
+
+In Visual Basic, a `ByRef` constructor parameter follows the `ref` behavior shown in the table:
+
+```vb
+Public Sub New(ByRef temperatureC As Integer)
+    TemperatureC = temperatureC
+End Sub
+```
+
 ## Records
 
-Records are also supported for both serialization and deserialization, as shown in the following example:
+`System.Text.Json` supports records for both serialization and deserialization, as shown in the following example:
 
 :::code language="csharp" source="snippets/how-to-contd/csharp/Records.cs":::
 
-You can apply any of the attributes to the property names, using the `property:` target on the attribute. For more information on positional records, see the article on [records](../../../csharp/language-reference/builtin-types/record.md#positional-syntax-for-property-and-field-definition) in the C# language reference.
+Apply any of the attributes to property names by using the `property:` target. For more information about positional records, see [records](../../../csharp/language-reference/builtin-types/record.md#positional-syntax-for-property-and-field-definition) in the C# language reference.
 
 ## Non-public members and property accessors
 
-You can enable use of a non-public *accessor* on a property by using the [[JsonInclude]](xref:System.Text.Json.Serialization.JsonIncludeAttribute) attribute, as shown in the following example:
+Apply the [[JsonInclude]](xref:System.Text.Json.Serialization.JsonIncludeAttribute) attribute to use a non-public property *accessor*, as shown in the following example:
 
 :::code language="csharp" source="snippets/how-to-contd/csharp/NonPublicAccessors.cs" highlight="10,13":::
 :::code language="vb" source="snippets/how-to-contd/vb/NonPublicAccessors.vb" :::
 
-By including a property with a private setter, you can still deserialize that property.
+To deserialize a property with a private setter, mark the property with `[JsonInclude]`.
 
-In .NET 8 and later versions, you can also use the [[JsonInclude]](xref:System.Text.Json.Serialization.JsonIncludeAttribute) attribute to opt non-public *members* into the serialization contract for a given type.
+In .NET 8 and later versions, apply `[JsonInclude]` to add non-public *members* to a type's serialization contract.
+
+Starting in .NET 11, source generation supports `private`, `internal`, and `protected` members that you mark with `[JsonInclude]`. It also supports `private`, `internal`, and `protected` accessors on properties that you mark with `[JsonInclude]`. Source generation also supports inaccessible constructors marked with [[JsonConstructor]](xref:System.Text.Json.Serialization.JsonConstructorAttribute).
 
 > [!NOTE]
-> In source-generation mode, you can't serialize `private` members or use `private` accessors by annotating them with the [[JsonInclude]](xref:System.Text.Json.Serialization.JsonIncludeAttribute) attribute. And you can only serialize `internal` members or use `internal` accessors if they're in the same assembly as the generated <xref:System.Text.Json.Serialization.JsonSerializerContext>.
+> In .NET 10 and earlier versions, source generation doesn't support `private` or `protected` members or accessors. Applying the [[JsonInclude]](xref:System.Text.Json.Serialization.JsonIncludeAttribute) attribute to the member or property doesn't remove this limitation. Source generation supports `internal` members and accessors only when they're in the same assembly as the generated <xref:System.Text.Json.Serialization.JsonSerializerContext>. It doesn't support inaccessible constructors, even when you mark them with `[JsonConstructor]`.
+
+## Init-only properties
+
+`System.Text.Json` deserializes `init`-only properties like any other settable property. Starting in .NET 11, a source-generated setter runs only when the JSON payload contains the property. An omitted property retains its initializer value.
 
 ## Read-only properties
 
-In .NET 8 and later versions, read-only properties, or those that have no setter either private or public, can also be deserialized. While you can't change the instance that the property references, if the type of the property is mutable, you can modify it. For example, you can add an element to a list. To deserialize a read-only property, you need to set its object creation handling behavior to *populate* instead of *replace*. For example, you can annotate the property with the <xref:System.Text.Json.Serialization.JsonObjectCreationHandlingAttribute> attribute.
+In .NET 8 and later versions, `System.Text.Json` can deserialize read-only properties that have no public or private setter. You can't replace the instance that the property references, but you can modify a mutable instance. For example, add an element to a list. To deserialize a read-only property, set its object creation handling behavior to *populate* instead of *replace*. For example, apply the <xref:System.Text.Json.Serialization.JsonObjectCreationHandlingAttribute> attribute.
 
   ```csharp
   class A

--- a/docs/standard/serialization/system-text-json/polymorphism.md
+++ b/docs/standard/serialization/system-text-json/polymorphism.md
@@ -1,7 +1,7 @@
 ---
 title: How to serialize properties of derived classes with System.Text.Json
 description: "Learn how to serialize polymorphic objects while serializing to and deserializing from JSON in .NET."
-ms.date: 10/18/2024
+ms.date: 08/18/2026
 no-loc: [System.Text.Json, Newtonsoft.Json]
 dev_langs:
   - "csharp"
@@ -12,6 +12,7 @@ helpviewer_keywords:
   - "serialization"
   - "objects, serializing"
 ms.topic: how-to
+ai-usage: ai-assisted
 ---
 
 # How to serialize properties of derived classes with System.Text.Json
@@ -560,6 +561,68 @@ JsonSerializer.Serialize<IPoint>(new BasePointWithTimeSeries());
 JsonSerializer.Serialize(Of IPoint)(New BasePointWithTimeSeries())
 ```
 
+## Infer polymorphism from a closed hierarchy
+
+Starting in .NET 11, `System.Text.Json` can infer derived types from a C# [closed hierarchy](../../../csharp/language-reference/keywords/closed.md). Enable inference on one hierarchy through <xref:System.Text.Json.Serialization.JsonPolymorphicAttribute.InferClosedTypePolymorphism?displayProperty=nameWithType>:
+
+> [!IMPORTANT]
+> Closed hierarchies are a C# 15 preview feature. Set `<LangVersion>preview</LangVersion>` in your project to use the `closed` modifier.
+
+```csharp
+[JsonPolymorphic(InferClosedTypePolymorphism = true)]
+public closed class Shape;
+public sealed class Circle : Shape;
+public sealed class Square : Shape;
+```
+
+The serializer registers each derived type and uses its simple type name as a string discriminator. For example, a `Circle` payload contains `"$type":"Circle"`.
+
+To enable inference for every closed hierarchy that an options instance handles, set <xref:System.Text.Json.JsonSerializerOptions.InferClosedTypePolymorphism?displayProperty=nameWithType>:
+
+```csharp
+var options = new JsonSerializerOptions
+{
+    InferClosedTypePolymorphism = true
+};
+```
+
+For source generation, set <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute.InferClosedTypePolymorphism?displayProperty=nameWithType>:
+
+```csharp
+[JsonSourceGenerationOptions(InferClosedTypePolymorphism = true)]
+[JsonSerializable(typeof(Shape))]
+internal partial class AppJsonContext : JsonSerializerContext;
+```
+
+Set inference on the source-generation attribute when you use a generated context. Enabling only the runtime `JsonSerializerOptions` property can't add derived-type metadata that the source generator didn't emit.
+
+The type-level attribute takes precedence over the global setting. Set `InferClosedTypePolymorphism = false` on <xref:System.Text.Json.Serialization.JsonPolymorphicAttribute> to opt one hierarchy out of a global setting.
+
+Explicit <xref:System.Text.Json.Serialization.JsonDerivedTypeAttribute> registrations replace inference for that hierarchy. They don't extend the inferred list. Applying `InferClosedTypePolymorphism = true` to a type that isn't `closed` throws an <xref:System.InvalidOperationException> with reflection-based serialization and produces a source-generation error. Inferred types with duplicate simple names produce discriminator collisions, and every inferred type must be at least as accessible as the closed base.
+
+## Configure open generic derived types
+
+Starting in .NET 11, <xref:System.Text.Json.Serialization.JsonDerivedTypeAttribute> accepts an open generic derived type when the serializer can resolve a unique closed type from the serialized base type:
+
+```csharp
+[JsonDerivedType(typeof(Derived<>), "derived")]
+public class Base<T>;
+public class Derived<T> : Base<T>;
+```
+
+```vb
+<JsonDerivedType(GetType(Derived(Of )), "derived")>
+Public Class Base(Of T)
+End Class
+Public Class Derived(Of T)
+    Inherits Base(Of T)
+End Class
+```
+
+For `Base<int>`, the serializer registers `Derived<int>`. The same resolution supports generic interfaces, reordered type parameters, nested generic arguments, arrays, and derived types that fix some base type arguments to concrete types.
+
+Every derived type parameter must be inferable from the closed base type, the substitution must be unambiguous, and the resulting type must satisfy its generic constraints. Reflection-based serialization throws <xref:System.InvalidOperationException> for an unsupported specialization. Source generation reports `SYSLIB1229`, and the generated hierarchy still fails when the serializer configures it. Suppressing the warning doesn't make the registration valid.
+
 ## Configure polymorphism with the contract model
 
 For use cases where attribute annotations are impractical or impossible (such as large domain models, cross-assembly hierarchies, or hierarchies in third-party dependencies), to configure polymorphism use the [contract model](custom-contracts.md). The contract model is a set of APIs that can be used to configure polymorphism in a type hierarchy by creating a custom <xref:System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver> subclass that dynamically provides polymorphic configuration per type, as shown in the following example:
@@ -633,3 +696,4 @@ End Class
 
 * [System.Text.Json overview](overview.md)
 * [How to serialize and deserialize JSON](how-to.md)
+* [Serialize union types](union-types.md)

--- a/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md
+++ b/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md
@@ -1,7 +1,8 @@
 ---
 title: How to choose reflection or source generation in System.Text.Json
 description: "Learn how to choose reflection or source generation in System.Text.Json."
-ms.date: 10/30/2023
+ms.date: 08/18/2026
+ai-usage: ai-assisted
 no-loc: [System.Text.Json]
 ---
 
@@ -15,20 +16,20 @@ To serialize or deserialize a type, <xref:System.Text.Json.JsonSerializer> needs
 
 * How to access property getters and fields for serialization.
 * How to access a constructor, property setters, and fields for deserialization.
-* Information about which attributes have been used to customize serialization or deserialization.
+* Which attributes customize serialization or deserialization.
 * Runtime configuration from <xref:System.Text.Json.JsonSerializerOptions>.
 
-This information is referred to as *metadata*.
+The term *metadata* refers to this information.
 
 ## Reflection
 
-By default, <xref:System.Text.Json.JsonSerializer> collects metadata at runtime by using [reflection](../../../csharp/advanced-topics/reflection-and-attributes/index.md). Whenever `JsonSerializer` has to serialize or deserialize a type for the first time, it collects and caches this metadata. The metadata collection process takes time and uses memory.
+By default, <xref:System.Text.Json.JsonSerializer> collects metadata at run time by using [reflection](../../../csharp/advanced-topics/reflection-and-attributes/index.md). The first time `JsonSerializer` serializes or deserializes a type, it collects and caches this metadata. Metadata collection takes time and uses memory.
 
 ## Source generation
 
-As an alternative, `System.Text.Json` can use the C# [source generation](../../../csharp/roslyn-sdk/index.md#source-generators) feature to improve performance, reduce private memory usage, and facilitate [assembly trimming](../../../core/deploying/trimming/trim-self-contained.md), which reduces app size. In addition, certain reflection APIs can't be used in [Native AOT applications](../../../core/deploying/native-aot/index.md), so you must use source generation for those apps.
+As an alternative, `System.Text.Json` can use the C# [source generation](../../../csharp/roslyn-sdk/index.md#source-generators) feature. Source generation improves performance, reduces private memory usage, and facilitates [assembly trimming](../../../core/deploying/trimming/trim-self-contained.md) to reduce app size. [Native AOT applications](../../../core/deploying/native-aot/index.md) don't support certain reflection APIs, so use source generation for those apps.
 
-Source generation can be used in two modes:
+Source generation provides two modes:
 
 * **Metadata-based mode**
 
@@ -38,9 +39,12 @@ Source generation can be used in two modes:
 
   <xref:System.Text.Json.JsonSerializer> features that customize the output of serialization, such as naming policies and reference preservation, carry a performance overhead. In serialization-optimization mode, System.Text.Json generates optimized serialization code that uses [`Utf8JsonWriter`](use-utf8jsonwriter.md) directly. This optimized or *fast path* code increases serialization throughput.
 
-  Fast-path *deserialization* isn't currently available. For more information, see [dotnet/runtime issue 55043](https://github.com/dotnet/runtime/issues/55043).
+  `System.Text.Json` doesn't currently provide fast-path *deserialization*. For more information, see [dotnet/runtime issue 55043](https://github.com/dotnet/runtime/issues/55043).
 
 Source generation for `System.Text.Json` requires C# 9.0 or a later version.
+
+> [!NOTE]
+> F# discriminated union support works only in reflection mode. It requires dynamic code and untrimmed reflection metadata. You can't use it with source generation or Native AOT. For more information, see [F# discriminated unions](supported-types.md#f-discriminated-unions).
 
 ## Feature comparison
 
@@ -50,7 +54,7 @@ Choose reflection or source-generation modes based on the following benefits tha
 |------------------------------------------------------|------------|---------------------|----------------------------|
 | Simpler to code.                                     | ✔️        | ❌                  | ❌                        |
 | Simpler to debug.                                    | ❌        | ✔️                  | ✔️                        |
-| Supports non-public members.                         | ✔️        | ✔️<sup>*</sup>      | ✔️<sup>*</sup>            |
+| Supports `[JsonInclude]` on non-public members.      | ✔️        | ✔️<sup>*</sup>      | ✔️<sup>*</sup>            |
 | Supports all available serialization customizations. | ✔️        | ❌<sup>†</sup>      | ❌<sup>†</sup>            |
 | Reduces start-up time.                               | ❌        | ✔️                  | ✔️                        |
 | Reduces private memory usage.                        | ❌        | ✔️                  | ✔️                        |
@@ -58,5 +62,5 @@ Choose reflection or source-generation modes based on the following benefits tha
 | Facilitates trim-safe app size reduction.            | ❌        | ✔️                  | ✔️                        |
 | Increases serialization throughput.                  | ❌        | ❌                  | ✔️                        |
 
-\* The source generator supports *some* non-public members, for example, internal types in the same assembly.
-† Source-generated contracts can be modified using the contract customization API.
+\* Starting in .NET 11, source generation supports `private`, `internal`, and `protected` members that you explicitly mark with [[JsonInclude]](xref:System.Text.Json.Serialization.JsonIncludeAttribute). It also supports `private`, `internal`, and `protected` accessors on properties that you mark with `[JsonInclude]`. Metadata-based source generation supports inaccessible constructors that you mark with [[JsonConstructor]](xref:System.Text.Json.Serialization.JsonConstructorAttribute). Generated setters run only for `init`-only properties that appear in the JSON, so omitted properties keep their initializer values. In .NET 10 and earlier versions, source generation doesn't support `private` or `protected` members or accessors, or inaccessible constructors. The generated context can access `internal` members and accessors only when they share an assembly. For more information, see [Non-public members and constructors](source-generation-modes.md#non-public-members-and-constructors).
+† Use the contract customization API to modify source-generated contracts.

--- a/docs/standard/serialization/system-text-json/source-generation-modes.md
+++ b/docs/standard/serialization/system-text-json/source-generation-modes.md
@@ -1,7 +1,8 @@
 ---
 title: Source-generation modes in System.Text.Json
 description: Learn about the two different source-generation modes in System.Text.Json.
-ms.date: 02/21/2025
+ms.date: 08/18/2026
+ai-usage: ai-assisted
 no-loc: [System.Text.Json]
 helpviewer_keywords:
   - "JSON serialization"
@@ -12,31 +13,45 @@ helpviewer_keywords:
 
 # Source-generation modes in System.Text.Json
 
-Source generation can be used in two modes: *metadata-based* and *serialization optimization*. This article describes the different modes.
+`System.Text.Json` source generation provides two modes: *metadata-based* and *serialization optimization*. This article describes both modes.
 
-For information about how to use source generation modes, see [How to use source generation in System.Text.Json](source-generation.md).
+To use source-generation modes, see [How to use source generation in System.Text.Json](source-generation.md).
 
 ## Metadata-based mode
 
-You can use source generation to move the metadata collection process from runtime to compile time. During compilation, the metadata is collected and source code files are generated. The generated source code files are automatically compiled as an integral part of the application. This technique eliminates runtime metadata collection, which improves performance of both serialization and deserialization.
+Use source generation to move metadata collection from run time to compile time. During compilation, `System.Text.Json` collects metadata and generates source files. The compiler includes the generated files in your app. Compile-time metadata collection improves serialization and deserialization performance.
 
-The performance improvements provided by source generation can be substantial. For example, [test results](https://devblogs.microsoft.com/dotnet/try-the-new-system-text-json-source-generator/#how-source-generation-provides-benefits) have shown up to 40% or more startup time reduction, private memory reduction, throughput speed increase (in serialization optimization mode), and app size reduction.
+The performance improvements from source generation can be substantial. For example, [test results](https://devblogs.microsoft.com/dotnet/try-the-new-system-text-json-source-generator/#how-source-generation-provides-benefits) show up to 40% or more startup time reduction, private memory reduction, throughput increase in serialization-optimization mode, and app size reduction.
+
+### Non-public members and constructors
+
+By default, both reflection mode and source-generation mode include only `public` properties and fields in the serialization contract.
+
+Starting in .NET 11, source generation supports members that you explicitly mark with the [[JsonInclude]](xref:System.Text.Json.Serialization.JsonIncludeAttribute) attribute. The member can be `private`, `internal`, or `protected`. It also supports `private`, `internal`, and `protected` accessors on properties that you mark with `[JsonInclude]`. Source generation also supports inaccessible constructors marked with [[JsonConstructor]](xref:System.Text.Json.Serialization.JsonConstructorAttribute).
+
+On .NET 11, the generated accessors use <xref:System.Runtime.CompilerServices.UnsafeAccessorAttribute>.
+
+A source-generated setter for an `init`-only property runs only when the JSON payload contains that property. An `init`-only property that the payload omits keeps the value from its property initializer.
+
+In .NET 10 and earlier versions, source generation has the following limitations:
+
+* Source generation doesn't support `private` or `protected` members or accessors. If you mark such a member with `[JsonInclude]`, the serializer throws a <xref:System.NotSupportedException> at runtime.
+* Source generation supports `internal` members and accessors only when they're accessible to the generated <xref:System.Text.Json.Serialization.JsonSerializerContext> in the same assembly.
+* Source generation doesn't support constructors that are inaccessible to the generated context, even when you mark them with `[JsonConstructor]`.
 
 ### Known issues
 
-Only `public` properties and fields are supported by default in either serialization mode (reflection or source-generation). However, reflection mode supports the use of `private` members, while source-generation mode doesn't. For example, if you apply the [JsonInclude attribute](xref:System.Text.Json.Serialization.JsonIncludeAttribute) to a `private` property or a property that has a `private` setter or getter, it will be serialized in reflection mode. Source-generation mode supports only `public` or `internal` members and `public` or `internal` accessors of `public` properties. If you set `[JsonInclude]` on `private` members or accessors and choose source-generation mode, a `NotSupportedException` will be thrown at runtime.
-
-For information about other known issues with source generation, see the [GitHub issues that are labeled "source-generator"](https://github.com/dotnet/runtime/issues?q=is%3Aopen+is%3Aissue+label%3Aarea-System.Text.Json+label%3Asource-generator) in the *dotnet/runtime* repository.
+For other known issues, see [`source-generator` issues](https://github.com/dotnet/runtime/issues?q=is%3Aopen+is%3Aissue+label%3Aarea-System.Text.Json+label%3Asource-generator) in the *dotnet/runtime* repository.
 
 ## Serialization-optimization (fast path) mode
 
 `JsonSerializer` has many features that customize the output of serialization, such as [naming policies](customize-properties.md#use-a-built-in-naming-policy) and [preserving references](preserve-references.md#preserve-references-and-handle-circular-references). Support for all those features causes some performance overhead. Source generation can improve serialization performance by generating optimized code that uses [`Utf8JsonWriter`](use-utf8jsonwriter.md) directly.
 
-Serialization-optimization mode emits fast-path serialization methods but not serialization metadata. Fast-path serialization is restricted in what it can do; it doesn't support asynchronous serialization or any mode of deserialization.
+Serialization-optimization mode emits fast-path serialization methods but not serialization metadata. Fast-path serialization supports fewer scenarios and doesn't support asynchronous serialization or deserialization.
 
-In addition, the optimized code doesn't support all of the serialization features that `JsonSerializer` supports. The serializer detects whether the optimized code can be used and falls back to default serialization code if unsupported options are specified. For example, <xref:System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString?displayProperty=nameWithType> isn't applicable to writing, so specifying this option doesn't cause a fallback to default code.
+The optimized code doesn't support every `JsonSerializer` feature. The serializer uses optimized code when the configuration supports it and falls back to default code for unsupported options. For example, <xref:System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString?displayProperty=nameWithType> doesn't apply to writing, so the option doesn't cause a fallback.
 
-The following table shows which options in `JsonSerializerOptions` are supported by fast-path serialization:
+The following table lists the `JsonSerializerOptions` options that fast-path serialization supports:
 
 | Serialization option                                                   | Supported for fast-path |
 |------------------------------------------------------------------------|-------------------------|
@@ -57,9 +72,9 @@ The following table shows which options in `JsonSerializerOptions` are supported
 | <xref:System.Text.Json.JsonSerializerOptions.TypeInfoResolver>         | ✔️                      |
 | <xref:System.Text.Json.JsonSerializerOptions.WriteIndented>            | ✔️                      |
 
-(The following options aren't supported because they apply only to *de*serialization: <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive>, <xref:System.Text.Json.JsonSerializerOptions.ReadCommentHandling>, and <xref:System.Text.Json.JsonSerializerOptions.UnknownTypeHandling>.)
+Fast-path serialization doesn't support the following options because they apply only to *de*serialization: <xref:System.Text.Json.JsonSerializerOptions.PropertyNameCaseInsensitive>, <xref:System.Text.Json.JsonSerializerOptions.ReadCommentHandling>, and <xref:System.Text.Json.JsonSerializerOptions.UnknownTypeHandling>.
 
-The following table shows which attributes are supported by fast-path serialization:
+The following table lists the attributes that fast-path serialization supports:
 
 | Attribute                                                         | Supported for fast-path |
 |-------------------------------------------------------------------|-------------------------|
@@ -75,7 +90,7 @@ The following table shows which attributes are supported by fast-path serializat
 | <xref:System.Text.Json.Serialization.JsonPropertyOrderAttribute>  | ✔️                      |
 | <xref:System.Text.Json.Serialization.JsonRequiredAttribute>       | ✔️                      |
 
-If a non-supported option or attribute is specified for a type, the serializer falls back to [metadata mode](#metadata-based-mode), assuming that the source generator has been configured to generate metadata. In that case, the optimized code isn't used when serializing that type, but it might be used for other types. Therefore it's important to do performance testing with your options and workloads to determine how much benefit you can actually get from serialization-optimization mode. Also, the ability to fall back to `JsonSerializer` code requires [metadata mode](#metadata-based-mode). If you select only serialization-optimization mode, serialization might fail for types or options that need to fall back to `JsonSerializer` code.
+If you specify an unsupported option or attribute for a type, the serializer falls back to [metadata mode](#metadata-based-mode) when the source generator includes metadata. The serializer skips optimized code for that type but might use it for other types. Test your options and workloads to measure the benefit of serialization-optimization mode. Fallback to `JsonSerializer` code requires [metadata mode](#metadata-based-mode). If you select only serialization-optimization mode, serialization might fail for types or options that require fallback.
 
 ## See also
 

--- a/docs/standard/serialization/system-text-json/supported-types.md
+++ b/docs/standard/serialization/system-text-json/supported-types.md
@@ -1,14 +1,15 @@
 ---
 title: "Supported types in System.Text.Json"
-description: "Learn which types are supported for serialization by the APIs in the System.Text.Json namespace."
-ms.date: 11/25/2024
+description: "Learn which types the APIs in the System.Text.Json namespace support for serialization."
+ms.date: 08/18/2026
+ai-usage: ai-assisted
 no-loc: [System.Text.Json]
 ms.topic: reference
 ---
 
 # Supported types in System.Text.Json
 
-This article gives an overview of which types are supported for serialization and deserialization.
+This article lists the types that `System.Text.Json` supports for serialization and deserialization.
 
 ## Types that serialize as JSON objects
 
@@ -19,7 +20,7 @@ The following types serialize as JSON objects:
 * Interfaces
 * Records and struct records
 
-\* Non-dictionary types that implement <xref:System.Collections.Generic.IEnumerable`1> serialize as JSON arrays. Dictionary types, which do implement <xref:System.Collections.Generic.IEnumerable`1>, serialize as JSON objects.
+\* Non-dictionary types that implement <xref:System.Collections.Generic.IEnumerable`1> serialize as JSON arrays. Dictionary types also implement <xref:System.Collections.Generic.IEnumerable`1> but serialize as JSON objects.
 
 The following code snippet shows the serialization of a simple struct.
 
@@ -34,9 +35,9 @@ The following code snippet shows the serialization of a simple struct.
 
 The serializer calls the <xref:System.Collections.IEnumerable.GetEnumerator> method and writes the elements.
 
-Deserialization is more complicated and is not supported for some collection types.
+Deserialization has more constraints, and the serializer doesn't support it for some collection types.
 
-The following sections are organized by namespace and show which types are supported for serialization and deserialization.
+The following sections group types by namespace and show their serialization and deserialization support.
 
 * [System.Array namespace](#systemarray-namespace)
 * [System.Collections namespace](#systemcollections-namespace)
@@ -55,7 +56,7 @@ The following sections are organized by namespace and show which types are suppo
 | [Multi-dimensional arrays](../../../csharp/language-reference/builtin-types/arrays.md#multidimensional-arrays)    | ❌  | ❌     |
 | [Jagged arrays](../../../csharp/language-reference/builtin-types/arrays.md#jagged-arrays)                         | ✔️  | ✔️     |
 
-\* `byte[]` is handled specially and serializes as a base64 string, not a JSON array.
+\* `JsonSerializer` handles `byte[]` specially and serializes it as a base64 string, not a JSON array.
 
 ### System.Collections namespace
 
@@ -89,6 +90,7 @@ The following sections are organized by namespace and show which types are suppo
 | <xref:System.Collections.Generic.IReadOnlyCollection`1> | ✔️           | ✔️              |
 | <xref:System.Collections.Generic.IReadOnlyDictionary`2> \* | ✔️        | ✔️              |
 | <xref:System.Collections.Generic.IReadOnlyList`1>       | ✔️           | ✔️              |
+| <xref:System.Collections.Generic.IReadOnlySet`1> §       | ✔️           | ✔️              |
 | <xref:System.Collections.Generic.ISet`1>                | ✔️           | ✔️              |
 | <xref:System.Collections.Generic.KeyValuePair`2>        | ✔️           | ✔️              |
 | <xref:System.Collections.Generic.LinkedList`1>          | ✔️           | ✔️              |
@@ -106,31 +108,42 @@ The following sections are organized by namespace and show which types are suppo
 
 ‡ See [Support round trip for `Stack` types](converters-how-to.md#support-round-trip-for-stack-types).
 
+§ `System.Text.Json` supports <xref:System.Collections.Generic.IReadOnlySet`1> in .NET 11 and later versions. When you deserialize the interface, the serializer creates a <xref:System.Collections.Generic.HashSet`1> instance. Source generation supports the type, and the generated metadata calls <xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices.CreateIReadOnlySetInfo*?displayProperty=nameWithType>.
+
 #### IAsyncEnumerable\<T>
 
-The following examples use streams as a representation of any async source of data. The source could be files on a local machine, or results from a database query or web service API call.
+The following examples use streams to represent asynchronous data sources. Sources include local files, database query results, and web service API responses.
 
-##### Stream serialization
+##### Streaming serialization
 
 `System.Text.Json` supports serializing <xref:System.Collections.Generic.IAsyncEnumerable`1> values as JSON arrays, as shown in the following example:
 
 :::code language="csharp" source="snippets/supported-types/csharp/IAsyncEnumerableSerialize.cs" highlight="15":::
 
-`IAsyncEnumerable<T>` values are only supported by the asynchronous serialization methods, such as <xref:System.Text.Json.JsonSerializer.SerializeAsync*?displayProperty=nameWithType>.
+Only asynchronous serialization methods, such as <xref:System.Text.Json.JsonSerializer.SerializeAsync*?displayProperty=nameWithType>, support `IAsyncEnumerable<T>` values.
 
-##### Stream deserialization
+In .NET 11 and later versions, <xref:System.Text.Json.JsonSerializer.SerializeAsyncEnumerable*?displayProperty=nameWithType> writes an `IAsyncEnumerable<T>` sequence to either a <xref:System.IO.Stream> or a <xref:System.IO.Pipelines.PipeWriter>. With the default `topLevelValues: false`, the method writes a single root-level JSON array. Set `topLevelValues: true` to write [JSON Lines](https://jsonlines.org/) instead, where each element is a separate top-level value:
+
+```json
+{"id":1,"name":"apple"}
+{"id":2,"name":"banana"}
+```
+
+The method writes a single line feed (LF), `\n`, after every value, including the last. It always uses LF, regardless of <xref:System.Text.Json.JsonSerializerOptions.NewLine?displayProperty=nameWithType>. The method ignores <xref:System.Text.Json.JsonSerializerOptions.WriteIndented?displayProperty=nameWithType>, so each value remains on one line.
+
+##### Streaming deserialization
 
 The `DeserializeAsyncEnumerable` method supports streaming deserialization, as shown in the following example:
 
 :::code language="csharp" source="snippets/supported-types/csharp/IAsyncEnumerableDeserialize.cs" highlight="11":::
 
-The `DeserializeAsyncEnumerable` method only supports reading from root-level JSON arrays.
+By default, <xref:System.Text.Json.JsonSerializer.DeserializeAsyncEnumerable*?displayProperty=nameWithType> reads elements from a single root-level JSON array. Set `topLevelValues: true` to read a sequence of whitespace-separated top-level values instead. This input format is a superset of JSON Lines. Overloads accept either a <xref:System.IO.Stream> or a <xref:System.IO.Pipelines.PipeReader>.
 
 The <xref:System.Text.Json.JsonSerializer.DeserializeAsync*> method supports `IAsyncEnumerable<T>`, but its signature doesn't allow streaming. It returns the final result as a single value, as shown in the following example.
 
 :::code language="csharp" source="snippets/supported-types/csharp/IAsyncEnumerableDeserializeNonStreaming.cs" highlight="16":::
 
-In this example, the deserializer buffers all `IAsyncEnumerable<T>` contents in memory before returning the deserialized object. This behavior is necessary because the deserializer needs to read the entire JSON payload before returning a result.
+In this example, the deserializer buffers all `IAsyncEnumerable<T>` contents in memory because it must read the entire JSON payload before returning a result.
 
 ### System.Collections.Immutable namespace
 
@@ -165,7 +178,7 @@ In this example, the deserializer buffers all `IAsyncEnumerable<T>` contents in 
 | <xref:System.Collections.Specialized.StringCollection>    | ✔️           | ❌              |
 | <xref:System.Collections.Specialized.StringDictionary>    | ✔️           | ❌              |
 
-\* When <xref:System.Collections.Specialized.BitVector32> is deserialized, the <xref:System.Collections.Specialized.BitVector32.Data> property is skipped because it doesn't have a public setter. No exception is thrown.
+\* When you deserialize <xref:System.Collections.Specialized.BitVector32>, the serializer skips the <xref:System.Collections.Specialized.BitVector32.Data> property because it doesn't have a public setter. The serializer doesn't throw an exception.
 
 ### System.Collections.Concurrent namespace
 
@@ -192,21 +205,21 @@ In this example, the deserializer buffers all `IAsyncEnumerable<T>` contents in 
 | <xref:System.Collections.ObjectModel.ReadOnlyDictionary`2>   | ✔️            | ❌             |
 | <xref:System.Collections.ObjectModel.ReadOnlyObservableCollection`1> | ✔️    | ❌             |
 
-\* Non-`string` keys are not supported.
+\* `JsonSerializer` doesn't support non-`string` keys.
 
 ### Custom collections
 
-Any collection type that isn't in one of the preceding namespaces is considered a custom collection. Such types include user-defined types and types defined by ASP.NET Core. For example, <xref:Microsoft.Extensions.Primitives?displayProperty=fullName> is in this group.
+`System.Text.Json` treats any collection type outside the preceding namespaces as a custom collection. This group includes user-defined types and ASP.NET Core types. For example, <xref:Microsoft.Extensions.Primitives?displayProperty=fullName> is in this group.
 
-All custom collections (everything that derives from `IEnumerable`) are supported for serialization, as long as their element types are supported.
+`JsonSerializer` supports all custom collections that derive from `IEnumerable` when it also supports their element types.
 
 #### Deserialization support
 
-A custom collection is supported for deserialization if it:
+`JsonSerializer` can deserialize a custom collection when the collection:
 
 * Isn't an interface or abstract.
 * Has a parameterless constructor.
-* Contains element types that are supported by <xref:System.Text.Json.JsonSerializer>.
+* Contains element types that <xref:System.Text.Json.JsonSerializer> supports.
 * Implements or inherits one or more of the following interfaces or classes:
   * <xref:System.Collections.Concurrent.ConcurrentQueue`1>
   * <xref:System.Collections.Concurrent.ConcurrentStack`1> \*
@@ -226,7 +239,7 @@ A custom collection is supported for deserialization if it:
 
 #### Known issues
 
-There are known issues with the following custom collections:
+The following custom collections have known issues:
 
 * <xref:System.Dynamic.ExpandoObject>: See [dotnet/runtime#29690](https://github.com/dotnet/runtime/issues/29690).
 * <xref:System.Dynamic.DynamicObject>: See [dotnet/runtime#1808](https://github.com/dotnet/runtime/issues/1808).
@@ -238,13 +251,17 @@ For more information about known issues, see the [open issues in System.Text.Jso
 
 ### Supported key types
 
-When used as the keys of `Dictionary` and `SortedList` types, the following types have built-in support:
+The following types have built-in support as keys for `Dictionary` and `SortedList` types:
 
+* <xref:System.Numerics.BFloat16> (.NET 11 and later)
 * `Boolean`
 * `Byte`
 * `DateTime`
 * `DateTimeOffset`
 * `Decimal`
+* <xref:System.Numerics.Decimal32> (.NET 11 and later)
+* <xref:System.Numerics.Decimal64> (.NET 11 and later)
+* <xref:System.Numerics.Decimal128> (.NET 11 and later)
 * `Double`
 * `Enum`
 * `Guid`
@@ -262,11 +279,41 @@ When used as the keys of `Dictionary` and `SortedList` types, the following type
 * <xref:System.Uri>
 * <xref:System.Version>
 
-In addition, the <xref:System.Text.Json.Serialization.JsonConverter`1.WriteAsPropertyName(System.Text.Json.Utf8JsonWriter,`0,System.Text.Json.JsonSerializerOptions)?displayProperty=nameWithType> and <xref:System.Text.Json.Serialization.JsonConverter`1.ReadAsPropertyName(System.Text.Json.Utf8JsonReader@,System.Type,System.Text.Json.JsonSerializerOptions)?displayProperty=nameWithType> methods let you add dictionary key support for any type of your choosing.
+The <xref:System.Text.Json.Serialization.JsonConverter`1.WriteAsPropertyName(System.Text.Json.Utf8JsonWriter,`0,System.Text.Json.JsonSerializerOptions)?displayProperty=nameWithType> and <xref:System.Text.Json.Serialization.JsonConverter`1.ReadAsPropertyName(System.Text.Json.Utf8JsonReader@,System.Type,System.Text.Json.JsonSerializerOptions)?displayProperty=nameWithType> methods also let you add dictionary key support for any type.
+
+## BFloat16 and decimal floating-point types
+
+Starting in .NET 11, `System.Text.Json` includes built-in converters for the <xref:System.Numerics.BFloat16>, <xref:System.Numerics.Decimal32>, <xref:System.Numerics.Decimal64>, and <xref:System.Numerics.Decimal128> types. Finite values serialize as JSON numbers.
+
+These types behave like the other built-in numeric types:
+
+* Source generation supports them without extra configuration.
+* Dictionary-key conversion supports all four types.
+* They honor <xref:System.Text.Json.Serialization.JsonNumberHandling>, including the `"NaN"`, `"Infinity"`, and `"-Infinity"` literals through <xref:System.Text.Json.Serialization.JsonNumberHandling.AllowNamedFloatingPointLiterals>.
+
+<xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices> exposes converter properties for source-generated metadata. The properties are <xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices.BFloat16Converter?displayProperty=nameWithType>, <xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices.Decimal32Converter?displayProperty=nameWithType>, <xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices.Decimal64Converter?displayProperty=nameWithType>, and <xref:System.Text.Json.Serialization.Metadata.JsonMetadataServices.Decimal128Converter?displayProperty=nameWithType>.
+
+## F# discriminated unions
+
+Starting in .NET 11, `System.Text.Json` serializes and deserializes F# discriminated unions, including class, struct, and recursive unions:
+
+```fsharp
+type Shape =
+    | Point
+    | Circle of radius: float
+```
+
+* A case without fields serializes as a JSON string that contains the case name, such as `"Point"`.
+* A case that has fields serializes as a JSON object. The object contains a `$type` discriminator followed by the case's named fields, such as `{"$type":"Circle","radius":3.14}`.
+
+<xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy?displayProperty=nameWithType> applies to case names and field names. A case-level <xref:System.Text.Json.Serialization.JsonPropertyNameAttribute> takes precedence. To use a discriminator property name other than `$type`, set <xref:System.Text.Json.Serialization.JsonPolymorphicAttribute.TypeDiscriminatorPropertyName?displayProperty=nameWithType>.
+
+> [!IMPORTANT]
+> F# discriminated union support is reflection-only. It requires dynamic code and untrimmed reflection metadata. You can't use it with `System.Text.Json` source generation or Native AOT.
 
 ## Unsupported types
 
-The following types aren't supported for serialization:
+`JsonSerializer` doesn't support the following types for serialization:
 
 * <xref:System.Type?displayProperty=fullName> and <xref:System.Reflection.MemberInfo?displayProperty=fullName>
 * <xref:System.ReadOnlySpan`1>, <xref:System.Span`1>, and ref structs in general
@@ -275,7 +322,7 @@ The following types aren't supported for serialization:
 
 ### System.Data namespace
 
-There are no built-in converters for <xref:System.Data.DataSet>, <xref:System.Data.DataTable>, and related types in the <xref:System.Data> namespace. Deserializing these types from untrusted input is not safe, as explained in [the security guidance](../../../framework/data/adonet/dataset-datatable-dataview/security-guidance.md#safety-with-regard-to-untrusted-input). However, you can write a custom converter to support these types. For sample custom converter code that serializes and deserializes a `DataTable`, see [RoundtripDataTable.cs](https://github.com/dotnet/docs/blob/main/docs/standard/serialization/system-text-json/snippets/how-to/csharp/RoundtripDataTable.cs).
+`System.Text.Json` doesn't provide built-in converters for <xref:System.Data.DataSet>, <xref:System.Data.DataTable>, and related types in the <xref:System.Data> namespace. Don't deserialize these types from untrusted input. For more information, see [the security guidance](../../../framework/data/adonet/dataset-datatable-dataview/security-guidance.md#safety-with-regard-to-untrusted-input). To support these types, write a custom converter. For a `DataTable` converter sample, see [RoundtripDataTable.cs](https://github.com/dotnet/docs/blob/main/docs/standard/serialization/system-text-json/snippets/how-to/csharp/RoundtripDataTable.cs).
 
 ## See also
 

--- a/docs/standard/serialization/system-text-json/union-types.md
+++ b/docs/standard/serialization/system-text-json/union-types.md
@@ -1,0 +1,119 @@
+---
+title: Serialize union types with System.Text.Json
+description: Learn how System.Text.Json serializes and deserializes C# union types in .NET 11.
+ms.date: 08/18/2026
+no-loc: [System.Text.Json]
+dev_langs:
+  - "csharp"
+ms.topic: how-to
+ai-usage: ai-assisted
+---
+
+# Serialize union types with System.Text.Json
+
+Starting in .NET 11, <xref:System.Text.Json.JsonSerializer> supports [C# union types](../../../csharp/language-reference/builtin-types/union.md). A union contract describes its case types and how the serializer constructs and deconstructs union values. Reflection-based serialization and source-generated metadata both support union contracts.
+
+> [!IMPORTANT]
+> C# union types are a preview feature. Set `<LangVersion>preview</LangVersion>` in your project to use them.
+
+## Serialize and deserialize union values
+
+Declare a union whose cases have distinct JSON token types:
+
+```csharp
+public union Payload(int, string, Message);
+public sealed record Message(string Text);
+```
+
+You don't need to annotate a C# union with <xref:System.Text.Json.Serialization.JsonUnionAttribute>. The serializer recognizes the compiler-generated union shape:
+
+```csharp
+Payload payload = new Message("Ready");
+string json = JsonSerializer.Serialize(payload);
+Payload copy = JsonSerializer.Deserialize<Payload>(json);
+```
+
+The serialized JSON contains the active case value rather than a wrapper or discriminator:
+
+```json
+{"Text":"Ready"}
+```
+
+By default, the serializer classifies incoming JSON by token type. In the preceding union, a JSON number selects `int`, a JSON string selects `string`, and a JSON object selects `Message`.
+
+The union's <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.Kind?displayProperty=nameWithType> value is <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.Union?displayProperty=nameWithType>. Its contract exposes the cases through <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.UnionCases?displayProperty=nameWithType> and uses union constructor and deconstructor delegates to convert between a case value and the union value.
+
+`JsonUnionAttribute` configures an existing union contract. Applying the attribute to an ordinary type doesn't turn that type into a union.
+
+## Distinguish cases with the same JSON token type
+
+Token classification can't distinguish two cases that both serialize as JSON objects. Apply <xref:System.Text.Json.Serialization.JsonUnionAttribute> and select <xref:System.Text.Json.Serialization.JsonUnionTypeStructuralClassifier> to classify object cases by their property names:
+
+```csharp
+[JsonUnion(TypeClassifier = typeof(JsonUnionTypeStructuralClassifier))]
+public union Pet(Dog, Cat);
+public sealed record Dog(string Name, string Breed);
+public sealed record Cat(string Name, int Lives);
+```
+
+The classifier selects `Dog` when the payload contains `Breed` and selects `Cat` when it contains `Lives`:
+
+```csharp
+Pet pet = JsonSerializer.Deserialize<Pet>(
+    """{"Name":"Rex","Breed":"Husky"}""");
+```
+
+For JSON objects, the structural classifier starts with the compatible object cases and narrows that set as it reads recognized root-level property names. Required properties remove cases when they're absent. <xref:System.Text.Json.Serialization.JsonUnmappedMemberHandling.Disallow?displayProperty=nameWithType> removes a case when the payload contains a property that the case doesn't declare. Classification succeeds only when one case remains.
+
+The structural classifier doesn't inspect property values, nested objects, string contents, or array elements. Keep these consequences in mind:
+
+* A payload that leaves zero or multiple candidates throws <xref:System.Text.Json.JsonException>.
+* Overlapping or shadowed object contracts might be rejected when the classifier is created.
+* Multiple non-object cases that use the same JSON token type aren't supported. For example, `Guid` and `string` both use JSON strings.
+* A plain object case can't be mixed with a dictionary, `JsonObject`, or another non-POCO object-shaped case.
+* Nested union cases and polymorphic cases aren't supported.
+* <xref:System.Text.Json.Serialization.ReferenceHandler.Preserve?displayProperty=nameWithType> isn't supported.
+* A configuration that can't distinguish its cases throws <xref:System.NotSupportedException> when the serializer builds the classifier.
+
+## Provide a custom classifier
+
+Derive from <xref:System.Text.Json.Serialization.JsonTypeClassifierFactory> when token and structural classification don't meet your requirements. Register the factory in one of these locations:
+
+* Assign a delegate to <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.TypeClassifier?displayProperty=nameWithType> when you customize the contract.
+* Set <xref:System.Text.Json.Serialization.JsonUnionAttribute.TypeClassifier?displayProperty=nameWithType> for one union.
+* Add the factory to <xref:System.Text.Json.JsonSerializerOptions.TypeClassifiers?displayProperty=nameWithType> for reflection-based serialization.
+* Set <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute.TypeClassifiers?displayProperty=nameWithType> for a source-generation context.
+
+A classifier reads the current JSON value and returns one of the case types from <xref:System.Text.Json.Serialization.JsonTypeClassifierContext.UnionCases?displayProperty=nameWithType>. The serializer checks the contract delegate first, followed by the per-union factory, the options-level factories, and built-in token classification.
+
+## Use source generation
+
+Add the union type to a <xref:System.Text.Json.Serialization.JsonSerializerContext> as you would any other serializable type:
+
+```csharp
+[JsonSerializable(typeof(Payload))]
+internal partial class AppJsonContext : JsonSerializerContext;
+```
+
+The source generator emits the union cases and constructor and deconstructor delegates. It also reports a diagnostic when the cases can't be classified unambiguously and no classifier is configured. Register a classifier through <xref:System.Text.Json.Serialization.JsonSourceGenerationOptionsAttribute.TypeClassifiers?displayProperty=nameWithType> when the source generator must account for it during analysis.
+
+## Handle null and default union values
+
+A union can declare nullable case types. JSON `null` selects the first nullable case. If the union has no nullable case, JSON `null` produces the default union value. For a compiler-generated struct union, the default value has no active case and serializes as JSON `null`.
+
+## Customize a union contract
+
+For advanced scenarios, customize the union metadata through <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo>. A union contract exposes:
+
+* <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.UnionCases?displayProperty=nameWithType>, which contains <xref:System.Text.Json.Serialization.Metadata.JsonUnionCaseInfo> entries.
+* <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.UnionConstructor?displayProperty=nameWithType>, which creates a union from a case type and value.
+* <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.UnionDeconstructor?displayProperty=nameWithType>, which returns the active case type and value.
+* <xref:System.Text.Json.Serialization.Metadata.JsonTypeInfo.TypeClassifier?displayProperty=nameWithType>, which selects a case during deserialization.
+
+For more information about modifying `JsonTypeInfo`, see [Customize a JSON contract](custom-contracts.md).
+
+## See also
+
+* [Union types (C# reference)](../../../csharp/language-reference/builtin-types/union.md)
+* [Serialize polymorphic types](polymorphism.md)
+* [Use source generation](source-generation.md)

--- a/docs/standard/serialization/system-text-json/use-utf8jsonwriter.md
+++ b/docs/standard/serialization/system-text-json/use-utf8jsonwriter.md
@@ -1,12 +1,13 @@
 ---
 title: How to use Utf8JsonWriter in System.Text.Json
 description: "Learn how to use Utf8JsonWriter."
-ms.date: 03/29/2022
+ms.date: 08/18/2026
 no-loc: [System.Text.Json, Newtonsoft.Json]
 dev_langs:
   - "csharp"
   - "vb"
 ms.topic: how-to
+ai-usage: ai-assisted
 ---
 
 # How to use Utf8JsonWriter in System.Text.Json
@@ -19,6 +20,26 @@ The following example shows how to use the <xref:System.Text.Json.Utf8JsonWriter
 
 :::code language="csharp" source="snippets/how-to/csharp/Utf8WriterToStream.cs" id="Serialize":::
 :::code language="vb" source="snippets/how-to/vb/Utf8WriterToStream.vb" id="Serialize":::
+
+## Reuse a writer
+
+Starting in .NET 11, call <xref:System.Text.Json.Utf8JsonWriter.Reset(System.IO.Stream,System.Text.Json.JsonWriterOptions)> or <xref:System.Text.Json.Utf8JsonWriter.Reset(System.Buffers.IBufferWriter{System.Byte},System.Text.Json.JsonWriterOptions)> to reuse a writer. These overloads change the destination and options without allocating another `Utf8JsonWriter`.
+
+Before you reset the writer, finish the current JSON payload and call <xref:System.Text.Json.Utf8JsonWriter.Flush*>. `Reset` clears the writer state and doesn't flush pending output:
+
+```csharp
+writer.WriteEndObject();
+writer.Flush();
+
+writer.Reset(nextStream, new JsonWriterOptions { Indented = true });
+```
+
+```vb
+writer.WriteEndObject()
+writer.Flush()
+
+writer.Reset(nextStream, New JsonWriterOptions With {.Indented = True})
+```
 
 ## Write with UTF-8 text
 


### PR DESCRIPTION
## Summary

Documents the 15 `System.Text.Json` work items tracked by #55465. The change adds a conceptual article for C# union serialization, expands polymorphism and source-generation guidance, updates the supported-type and customization references, and completes the .NET 11 library highlights.

Fixes #55465

## Content source breakdown

| Documentation area | Implementation sources | Treatment |
|---|---|---|
| C# union serialization and classifiers | [dotnet/runtime#128162](https://github.com/dotnet/runtime/pull/128162), [#128900](https://github.com/dotnet/runtime/pull/128900), [#131797](https://github.com/dotnet/runtime/pull/131797), [#131879](https://github.com/dotnet/runtime/pull/131879), and [#132411](https://github.com/dotnet/runtime/pull/132411) | New conceptual article. The examples and limitations are adapted from the runtime union and structural-classifier tests; no prose was copied verbatim. |
| JSON Lines serialization | [dotnet/runtime#127567](https://github.com/dotnet/runtime/pull/127567) | Adapted into the supported-types article and What's New. The LF, indentation, `Stream`, and `PipeWriter` behavior follows the implementation tests. |
| F# discriminated unions | [dotnet/runtime#125610](https://github.com/dotnet/runtime/pull/125610) | Adapted into supported-types, reflection/source-generation guidance, and What's New. The wire-format example follows the runtime test shape. |
| Closed-hierarchy inference | [dotnet/runtime#130808](https://github.com/dotnet/runtime/pull/130808) and [#131623](https://github.com/dotnet/runtime/pull/131623) | New polymorphism guidance based on the API proposals and reflection/source-generation tests. |
| Inaccessible source-generated members | [dotnet/runtime#124650](https://github.com/dotnet/runtime/pull/124650), [#126507](https://github.com/dotnet/runtime/pull/126507), and [#130163](https://github.com/dotnet/runtime/pull/130163) | Existing source-generation and immutability guidance updated for the final .NET 11 behavior. |
| Naming policies | [dotnet/runtime#124645](https://github.com/dotnet/runtime/pull/124645) and [#124644](https://github.com/dotnet/runtime/pull/124644) | New type/member attribute guidance and PascalCase reference entry, adapted from API proposal examples. |
| Type-level ignore conditions | [dotnet/runtime#124646](https://github.com/dotnet/runtime/pull/124646) | New section in the ignore-properties article, including precedence and invalid configuration behavior. |
| Open generic polymorphism | [dotnet/runtime#127318](https://github.com/dotnet/runtime/pull/127318) | New C# and Visual Basic examples and supported/unsupported resolution guidance adapted from runtime tests. |
| New numeric converters | [dotnet/runtime#131523](https://github.com/dotnet/runtime/pull/131523) | New supported-type and JSON Schema guidance for `BFloat16`, `Decimal32`, `Decimal64`, and `Decimal128`. |
| Open generic converters | [dotnet/runtime#123209](https://github.com/dotnet/runtime/pull/123209) | Existing converter guidance checked and refined; the .NET 11 highlights now link to it. |
| By-reference constructors | [dotnet/runtime#122950](https://github.com/dotnet/runtime/pull/122950) | New constructor-binding table and C#/Visual Basic examples adapted from reflection and source-generator tests. |
| Extension data | [dotnet/runtime#120636](https://github.com/dotnet/runtime/pull/120636) and [#122838](https://github.com/dotnet/runtime/pull/122838) | Existing overflow guidance updated for `IReadOnlyDictionary` materialization and `JsonObject` flattening. |
| `IReadOnlySet<T>` | [dotnet/runtime#120306](https://github.com/dotnet/runtime/pull/120306) | Added to the supported collection table and corrected in What's New. |
| Generic type metadata lookup | [dotnet/runtime#123940](https://github.com/dotnet/runtime/pull/123940) | New strongly typed contract-metadata guidance and updated What's New sample. |
| `Utf8JsonWriter.Reset` options | [dotnet/runtime#126578](https://github.com/dotnet/runtime/pull/126578) | New writer-reuse guidance and updated executable sample. |

## Expert review notes

All modified Markdown identifies the work as `ai-assisted`.

The new union article, structural-classifier behavior, closed-hierarchy RC1 APIs, and new numeric converters warrant focused API-owner review. The locally available .NET 11 Preview 7 SDK predates some of those merged/backported APIs, so their descriptions and examples were checked against the corresponding runtime tests and API proposals rather than executed against that SDK. The union, polymorphism, naming, ignore, extension-data, collection, metadata, writer, JSONL, C#, Visual Basic, and F# examples that Preview 7 contains were compiled or executed locally.

## Validation

- Markdownlint: 15 changed Markdown files, 0 issues.
- Local relative links and snippet paths: 15 files validated.
- `docs/core/whats-new/dotnet-11/snippets/csharp/snippets.csproj`: build succeeded with .NET SDK `11.0.100-preview.7` and 0 warnings.
- Standalone C# verification covered transparent union JSON, closed and open-generic polymorphism, naming and ignore precedence, extension data, `IReadOnlySet<T>`, generic metadata lookup, writer reset, by-reference constructors, and JSON Lines output.
- Standalone Visual Basic verification covered naming and ignore attributes, writer reset, and open-generic polymorphism.
- Standalone F# verification produced `"Point"` and `{"$type":"Circle","radius":3.14}` for the documented discriminated union.
- `git diff --check` completed without errors.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| File | Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-11/libraries.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/core/whats-new/dotnet-11/libraries.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-11/libraries?branch=pr-en-us-55467) |
| [docs/core/whats-new/dotnet-11/overview.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/core/whats-new/dotnet-11/overview.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-11/overview?branch=pr-en-us-55467) |
| [docs/core/whats-new/dotnet-11/snippets/csharp/Libraries.cs](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/core/whats-new/dotnet-11/snippets/csharp/Libraries.cs) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-11/libraries?branch=pr-en-us-55467) |
| [docs/fundamentals/toc.yml](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/fundamentals/toc.yml) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-11/libraries?branch=pr-en-us-55467) |
| [docs/standard/serialization/system-text-json/converters-how-to.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/standard/serialization/system-text-json/converters-how-to.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/converters-how-to?branch=pr-en-us-55467) |
| [docs/standard/serialization/system-text-json/custom-contracts.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/standard/serialization/system-text-json/custom-contracts.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/custom-contracts?branch=pr-en-us-55467) |
| [docs/standard/serialization/system-text-json/customize-properties.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/standard/serialization/system-text-json/customize-properties.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/customize-properties?branch=pr-en-us-55467) |
| [docs/standard/serialization/system-text-json/extract-schema.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/standard/serialization/system-text-json/extract-schema.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/extract-schema?branch=pr-en-us-55467) |
| [docs/standard/serialization/system-text-json/handle-overflow.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/standard/serialization/system-text-json/handle-overflow.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/handle-overflow?branch=pr-en-us-55467) |
| [docs/standard/serialization/system-text-json/ignore-properties.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/standard/serialization/system-text-json/ignore-properties.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/ignore-properties?branch=pr-en-us-55467) |
| [docs/standard/serialization/system-text-json/immutability.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/standard/serialization/system-text-json/immutability.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/immutability?branch=pr-en-us-55467) |
| [docs/standard/serialization/system-text-json/polymorphism.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/standard/serialization/system-text-json/polymorphism.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/polymorphism?branch=pr-en-us-55467) |
| [docs/standard/serialization/system-text-json/reflection-vs-source-generation.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/standard/serialization/system-text-json/reflection-vs-source-generation.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/reflection-vs-source-generation?branch=pr-en-us-55467) |
| [docs/standard/serialization/system-text-json/source-generation-modes.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/standard/serialization/system-text-json/source-generation-modes.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation-modes?branch=pr-en-us-55467) |
| [docs/standard/serialization/system-text-json/supported-types.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/standard/serialization/system-text-json/supported-types.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/supported-types?branch=pr-en-us-55467) |
| [docs/standard/serialization/system-text-json/union-types.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/standard/serialization/system-text-json/union-types.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/union-types?branch=pr-en-us-55467) |
| [docs/standard/serialization/system-text-json/use-utf8jsonwriter.md](https://github.com/dotnet/docs/blob/7caa9d11df9463fd24c2ed453cbc0804691282ed/docs/standard/serialization/system-text-json/use-utf8jsonwriter.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/use-utf8jsonwriter?branch=pr-en-us-55467) |

</details>

<!-- PREVIEW-TABLE-END -->