### PR TITLE
Fix missing output in enumeration extension methods example

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md
@@ -18,6 +18,16 @@ You can call the extension method as though it was declared on the `enum` type:
 
 :::code language="csharp" source="./snippets/ExtensionMembers/CustomExtensionMethods.cs" id="ExampleExtendEnum":::
 
+:::output
+First is a passing grade.
+Second is not a passing grade.
+
+Raising the bar. Passing grade is now C!
+
+First is not a passing grade.
+Second is not a passing grade.
+:::
+
 Beginning with C# 14, you can declare *extension members* in an extension block. The new syntax enables you to add *extension properties*. You can also add extension members that appear to be new static methods or properties. You're no longer limited to extensions that appear to be instance methods. The following example shows an extension block that adds an instance extension property for `Passing`, and a static extension property for `MinimumPassingGrade`:
 
 :::code language="csharp" source="./snippets/ExtensionMembers/CustomExtensionMembers.cs" id="EnumExtensionMembers":::


### PR DESCRIPTION
Added the missing output line "Raising the bar. Passing grade is now C!"  to the final example in the article. This resolves issue #55626.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md](https://github.com/dotnet/docs/blob/ec0937265e4935b9ff3c48ae9c32f9877819c8c3/docs/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/how-to-create-a-new-method-for-an-enumeration?branch=pr-en-us-55632) |

<!-- PREVIEW-TABLE-END -->