### PR TITLE
Adjust description of cs0465 with the correct restriction

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0465.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0465.md
@@ -1,7 +1,8 @@
 ---
 description: "Compiler Warning (level 1) CS0465"
 title: "Compiler Warning (level 1) CS0465"
-ms.date: 07/20/2015
+ms.date: 08/24/2026
+ai-usage: ai-assisted
 f1_keywords:
   - "CS0465"
 helpviewer_keywords:
@@ -12,13 +13,13 @@ ms.assetid: 3d36faae-147f-4173-b164-af953fd86eea
 
 Introducing a 'Finalize' method can interfere with destructor invocation. Did you intend to declare a destructor?
 
- This warning occurs when you create a class with a method whose signature is `public virtual void Finalize`.
+The compiler issues this warning when you declare a method with the signature `void Finalize()`.
 
- If such a class is used as a base class and if the deriving class defines a finalizer, the finalizer will override the base class `Finalize` method, not <xref:System.Object.Finalize*>.
+A method named `Finalize` can interfere with finalizer invocation. To define a finalizer, declare `~TypeName()` instead of a `Finalize` method. For more information, see [Finalizers](../../programming-guide/classes-and-structs/finalizers.md).
 
 ## Example
 
- The following sample generates CS0465.
+The following sample generates CS0465.
 
 ```csharp
 // CS0465.cs


### PR DESCRIPTION
## Summary

- Fixed the signature
- Simplified description of the problem
- Linked to the finalizer docs

Fixes #55617 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/csharp/language-reference/compiler-messages/cs0465.md](https://github.com/dotnet/docs/blob/9c9a3cec1c2dcc3888990336837bd22e55b5deab/docs/csharp/language-reference/compiler-messages/cs0465.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0465?branch=pr-en-us-55640) |

<!-- PREVIEW-TABLE-END -->