### PR TITLE
Clarify daily build source in installation script

### DIFF
--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -159,7 +159,7 @@ The install scripts do not update the registry on Windows. They just download th
 
   The different quality values signal different stages of the release process of the SDK or Runtime installed.
 
-  * `daily`: The latest builds of the SDK or Runtime. They're built every day and aren't tested. They aren't recommended for production use but can often be used to test specific features or fixes immediately after they are merged into the product. These builds are from the `dotnet/installer` repo, and so if you're looking for fixes from `dotnet/sdk` you must wait for code to flow and be merged from SDK to Installer before it appears in a daily build.
+  * `daily`: The latest builds of the SDK or Runtime. They're built every day and aren't tested. They aren't recommended for production use but can often be used to test specific features or fixes immediately after they are merged into the product. These builds are from the [dotnet/dotnet](https://github.com/dotnet/dotnet) VMR (Virtual Monolithic Repository), and so if you're looking for fixes from a repository like `dotnet/sdk` or `dotnet/runtime` you must wait for code to flow and be merged into `dotnet/dotnet` before it appears in a daily build.
   * `preview`: The monthly public releases of the next version of .NET, intended for public use. Not recommended for production use. Intended to allow users to experiment and test the new major version before release.
   * `GA`: The final stable releases of the .NET SDK and Runtime. Intended for public use as well as production support.
 

--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -159,7 +159,7 @@ The install scripts do not update the registry on Windows. They just download th
 
   The different quality values signal different stages of the release process of the SDK or Runtime installed.
 
-  * `daily`: The latest builds of the SDK or Runtime. They're built every day and aren't tested. They aren't recommended for production use but can often be used to test specific features or fixes immediately after they are merged into the product. These builds are from the [dotnet/dotnet](https://github.com/dotnet/dotnet) VMR (Virtual Monolithic Repository), and so if you're looking for fixes from a repository like `dotnet/sdk` or `dotnet/runtime` you must wait for code to flow and be merged into `dotnet/dotnet` before it appears in a daily build.
+  * `daily`: The latest builds of the SDK or Runtime. They're built every day and aren't tested. Don't use them in production. These builds come from the [dotnet/dotnet](https://github.com/dotnet/dotnet) VMR (Virtual Monolithic Repository), so you might need to wait for changes from repositories like `dotnet/sdk` or `dotnet/runtime` to flow into `dotnet/dotnet` before they appear in a daily build.
   * `preview`: The monthly public releases of the next version of .NET, intended for public use. Not recommended for production use. Intended to allow users to experiment and test the new major version before release.
   * `GA`: The final stable releases of the .NET SDK and Runtime. Intended for public use as well as production support.
 


### PR DESCRIPTION
The daily builds happen from the .NET VMR repo nowadays.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/tools/dotnet-install-script.md](https://github.com/dotnet/docs/blob/5baa1bfa4b7058a5bab56f56810a66dbc0dc23f2/docs/core/tools/dotnet-install-script.md) | [Preview published page](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script?branch=pr-en-us-55644) |

<!-- PREVIEW-TABLE-END -->