### PR TITLE
Document Schannel handshake message limits for SslStream

### DIFF
--- a/docs/core/extensions/sslstream-troubleshooting.md
+++ b/docs/core/extensions/sslstream-troubleshooting.md
@@ -31,11 +31,11 @@ On Windows, you may encounter the `(0x8009030E): No credentials are available in
 
 ## Handshake message exceeds the Schannel limit
 
-On Windows, Schannel rejects fragmented TLS handshake messages that exceed its configured size limit. `SslStream` might report this failure as an <xref:System.Security.Authentication.AuthenticationException> with an inner <xref:System.ComponentModel.Win32Exception> that contains error `0x80090326` (`SEC_E_ILLEGAL_MESSAGE`) and the message `The message received was unexpected or badly formatted`. Large certificate chains or a long list of acceptable certificate issuers during mutual TLS authentication can produce large handshake messages.
+On Windows, you might hit a handshake failure when a fragmented TLS handshake message exceeds the size limit that Schannel enforces. In this case, `SslStream` surfaces an <xref:System.Security.Authentication.AuthenticationException> whose inner <xref:System.ComponentModel.Win32Exception> reports error `0x80090326` (`SEC_E_ILLEGAL_MESSAGE`) and the message `The message received was unexpected or badly formatted`. You're most likely to produce large handshake messages when you use large certificate chains or when a peer sends a long list of acceptable certificate issuers during mutual TLS authentication.
 
-The error isn't specific to message size. To confirm the cause, use a packet-capture tool to inspect the handshake messages and their sizes before you change the Schannel configuration.
+Because this error isn't specific to message size, confirm the cause before you change any Schannel configuration. Use a packet-capture tool to inspect the handshake messages and their sizes.
 
-If the capture confirms that a handshake message exceeds the limit, an administrator can create one of the following `DWORD` values under `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Messaging`:
+If the capture confirms that a handshake message exceeds the limit, ask an administrator to create one of the following `DWORD` values under `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Messaging`:
 
 | Value | Applies to | Default |
 | --- | --- | --- |
@@ -43,7 +43,7 @@ If the capture confirms that a handshake message exceeds the limit, an administr
 | `MessageLimitServer` | Messages that a TLS server accepts when it doesn't use client authentication. | `0x4000` bytes |
 | `MessageLimitServerClientAuth` | Messages that a TLS server accepts when it uses client authentication. | `0x8000` bytes |
 
-Set the smallest value that accepts the expected handshake message. Schannel supports values up to `0x10000` bytes. Because these settings affect the entire machine and larger limits increase memory use for each security context, don't change them unless you've confirmed the cause. For more information and registry-editing precautions, see [Messaging - fragment parsing](/windows-server/security/tls/tls-registry-settings#messaging--fragment-parsing).
+Set the smallest value that accepts the expected handshake message. Schannel supports values up to `0x10000` bytes. Don't change these settings unless you've confirmed the cause, because they affect the entire machine and larger limits increase memory use for each security context. For more information and registry-editing precautions, see [Messaging - fragment parsing](/windows-server/security/tls/tls-registry-settings#messaging--fragment-parsing).
 
 ## Client and server do not possess a common algorithm
 

--- a/docs/core/extensions/sslstream-troubleshooting.md
+++ b/docs/core/extensions/sslstream-troubleshooting.md
@@ -3,7 +3,8 @@ title: Troubleshoot SslStream authentication issues
 description: Learn how to troubleshoot and investigate issues when performing authentication with SslStream in .NET.
 author: rzikm
 ms.author: radekzikmund
-ms.date: 03/13/2023
+ms.date: 08/24/2026
+ai-usage: ai-assisted
 ---
 
 # Troubleshoot `SslStream` authentication issues
@@ -27,6 +28,22 @@ Unfortunately, for client application the only solution is to add the certificat
 ## Handshake failed with ephemeral keys
 
 On Windows, you may encounter the `(0x8009030E): No credentials are available in the security package` error message when attempting to use certificates with ephemeral keys. This behavior is due to a bug in the underlying OS API (Schannel). More relevant info and workarounds can be found on the associated [GitHub issue](https://github.com/dotnet/runtime/issues/23749).
+
+## Handshake message exceeds the Schannel limit
+
+On Windows, Schannel rejects fragmented TLS handshake messages that exceed its configured size limit. `SslStream` might report this failure as an <xref:System.Security.Authentication.AuthenticationException> with an inner <xref:System.ComponentModel.Win32Exception> that contains error `0x80090326` (`SEC_E_ILLEGAL_MESSAGE`) and the message `The message received was unexpected or badly formatted`. Large certificate chains or a long list of acceptable certificate issuers during mutual TLS authentication can produce large handshake messages.
+
+The error isn't specific to message size. To confirm the cause, use a packet-capture tool to inspect the handshake messages and their sizes before you change the Schannel configuration.
+
+If the capture confirms that a handshake message exceeds the limit, an administrator can create one of the following `DWORD` values under `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Messaging`:
+
+| Value | Applies to | Default |
+| --- | --- | --- |
+| `MessageLimitClient` | Messages that a TLS client accepts. | `0x8000` bytes |
+| `MessageLimitServer` | Messages that a TLS server accepts when it doesn't use client authentication. | `0x4000` bytes |
+| `MessageLimitServerClientAuth` | Messages that a TLS server accepts when it uses client authentication. | `0x8000` bytes |
+
+Set the smallest value that accepts the expected handshake message. Schannel supports values up to `0x10000` bytes. Because these settings affect the entire machine and larger limits increase memory use for each security context, don't change them unless you've confirmed the cause. For more information and registry-editing precautions, see [Messaging - fragment parsing](/windows-server/security/tls/tls-registry-settings#messaging--fragment-parsing).
 
 ## Client and server do not possess a common algorithm
 


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/77989

## Summary

Adds a new troubleshooting section to the `SslStream` authentication troubleshooting article that documents the Windows Schannel handshake message size limit.

`SslStream` can surface this as an `AuthenticationException` wrapping a `Win32Exception` with error `0x80090326` (`SEC_E_ILLEGAL_MESSAGE`). This happens when large certificate chains or long lists of acceptable certificate issuers during mutual TLS produce handshake messages that exceed Schannel''s configured limit.

The new section covers:

- How the failure manifests and its likely causes.
- Guidance to confirm the cause with a packet capture before changing configuration.
- The relevant `SCHANNEL\Messaging` registry values (`MessageLimitClient`, `MessageLimitServer`, `MessageLimitServerClientAuth`), their scope, and defaults.
- Cautions about machine-wide impact and increased memory use, with a link to the official Windows Server TLS registry settings reference.

Also updates `ms.date` and adds the `ai-usage: ai-assisted` frontmatter.

## AI usage

This content was created with the assistance of AI (`ai-usage: ai-assisted`).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/extensions/sslstream-troubleshooting.md](https://github.com/dotnet/docs/blob/d32dd975653fe07097aca877a6045df85f295cba/docs/core/extensions/sslstream-troubleshooting.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/sslstream-troubleshooting?branch=pr-en-us-55739) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202608261246213638-55739/BuildReport?accessString=33df262191cefdb9eb548eeb502c4db10705f48a4829be07d1fa211919357394)