### PR TITLE
Clarify Azure DevOps group defaults by MTP release

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-test-reports.md
+++ b/docs/core/testing/microsoft-testing-platform-test-reports.md
@@ -174,10 +174,10 @@ builder.TestHost.AddAzureDevOpsProvider();
 | `--publish-azdo-run-name` | 2.3.0 | Sets a custom Azure DevOps test run name for live test-result publishing. Requires `--publish-azdo-test-results`. |
 
 > [!WARNING]
-> Groups aren't recommended when multiple test assemblies run in parallel. Azure DevOps `##[group]` and `##[endgroup]` formatting commands are sequential and anonymous. Concurrent assembly output can interleave, cause incorrect group nesting, and put lines under the wrong assembly. For MTP 2.4.0 preview builds, pass `--report-azdo-groups off` to disable groups. Starting with the stable MTP 2.4.0 release, groups are disabled by default. Pass `--report-azdo-groups on` only for a single assembly or serialized assembly execution.
+> Don't enable groups when multiple test assemblies run in parallel. Azure DevOps `##[group]` and `##[endgroup]` formatting commands are sequential and anonymous. Concurrent assembly output can interleave, cause incorrect group nesting, and put lines under the wrong assembly. If you use an MTP 2.4.0 preview build, pass `--report-azdo-groups off` to disable groups. The stable MTP 2.4.0 release disables groups by default. Pass `--report-azdo-groups on` only for a single assembly or serialized assembly execution.
 
 > [!NOTE]
-> The **MTP version** column lists the first MTP version that contains each option. The Azure DevOps extension itself became stable in MTP 1.9.0 with `--report-azdo` and `--report-azdo-severity`; the remaining options were added in MTP 2.3.0 or the unreleased MTP 2.4.0.
+> The **MTP version** column lists the first MTP version that contains each option. The Azure DevOps extension itself became stable in MTP 1.9.0 with `--report-azdo` and `--report-azdo-severity`; the remaining options were added in MTP 2.3.0 or 2.4.0.
 
 The extension automatically detects that it is running in continuous integration (CI) environment by checking the `TF_BUILD` environment variable.
 

--- a/docs/core/testing/microsoft-testing-platform-test-reports.md
+++ b/docs/core/testing/microsoft-testing-platform-test-reports.md
@@ -159,7 +159,7 @@ builder.TestHost.AddAzureDevOpsProvider();
 |---|---|---|
 | `--report-azdo` | 1.9.0 | Enables the Azure DevOps report generator. Errors and warnings are written to the output in a format that Azure DevOps understands. |
 | `--report-azdo-severity` | 1.9.0 | Severity to use for reported events. Valid values are `error` (default) and `warning`. |
-| `--report-azdo-groups` | 2.4.0 | Enables or disables per-assembly log groups. When enabled, each test assembly's output appears in a collapsible section of the Azure Pipelines log. Valid values are `on` and `off` (default). Requires `--report-azdo`. |
+| `--report-azdo-groups` | 2.4.0 | Enables or disables per-assembly log groups. When enabled, each test assembly's output appears in a collapsible section of the Azure Pipelines log. Valid values are `on` and `off`. MTP 2.4.0 preview builds default to `on`; the stable MTP 2.4.0 release defaults to `off`. Requires `--report-azdo`. |
 | `--report-azdo-annotations` | 2.4.0 | Enables or disables annotations for failed and skipped tests. Valid values are `on` (default) and `off`. Requires `--report-azdo`. |
 | `--report-azdo-flaky-history` | 2.3.0 | Queries Azure DevOps test result history for the past N days (1-90) and annotates reported failures with flakiness context. Requires `--report-azdo`. |
 | `--report-azdo-demote-known-flaky` | 2.3.0 | Demotes failures that are flaky enough in the Azure DevOps history window (default threshold is 25%) from errors to warnings. Requires `--report-azdo` and `--report-azdo-flaky-history`. |
@@ -174,7 +174,7 @@ builder.TestHost.AddAzureDevOpsProvider();
 | `--publish-azdo-run-name` | 2.3.0 | Sets a custom Azure DevOps test run name for live test-result publishing. Requires `--publish-azdo-test-results`. |
 
 > [!WARNING]
-> Groups are disabled by default and aren't recommended when multiple test assemblies run in parallel. Azure DevOps `##[group]` and `##[endgroup]` formatting commands are sequential and anonymous. Concurrent assembly output can interleave, cause incorrect group nesting, and put lines under the wrong assembly. Set `--report-azdo-groups on` only for a single assembly or serialized assembly execution.
+> Groups aren't recommended when multiple test assemblies run in parallel. Azure DevOps `##[group]` and `##[endgroup]` formatting commands are sequential and anonymous. Concurrent assembly output can interleave, cause incorrect group nesting, and put lines under the wrong assembly. For MTP 2.4.0 preview builds, pass `--report-azdo-groups off` to disable groups. Starting with the stable MTP 2.4.0 release, groups are disabled by default. Pass `--report-azdo-groups on` only for a single assembly or serialized assembly execution.
 
 > [!NOTE]
 > The **MTP version** column lists the first MTP version that contains each option. The Azure DevOps extension itself became stable in MTP 1.9.0 with `--report-azdo` and `--report-azdo-severity`; the remaining options were added in MTP 2.3.0 or the unreleased MTP 2.4.0.


### PR DESCRIPTION
## Summary

- clarify that MTP 2.4.0 preview builds default Azure DevOps log groups to `on`
- document that the stable MTP 2.4.0 release defaults groups to `off`
- tell preview users to pass `--report-azdo-groups off` for parallel multi-assembly runs

Follow-up to #55325.

## Validation

- `markdownlint-cli2 docs/core/testing/microsoft-testing-platform-test-reports.md`
- `git diff --check`

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-test-reports.md](https://github.com/dotnet/docs/blob/970e175d8ec7e6caa33ff809cb8b6bf7fcdc7c3f/docs/core/testing/microsoft-testing-platform-test-reports.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-test-reports?branch=pr-en-us-55746) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202608261415528378-55746/BuildReport?accessString=2dd8596529b33d304106a520f09303215639ea29e8f2777ccc634728a1026954)