### PR TITLE
Add PhysicalFilesWatcher reliability improvements to What's new

### DIFF
--- a/docs/core/whats-new/dotnet-11/libraries.md
+++ b/docs/core/whats-new/dotnet-11/libraries.md
@@ -641,6 +641,12 @@ builder.Services.AddTracing(tracing =>
 
 The same release adds `ActivitySourceFactory` and unseals `ActivitySource`, which together support factory-driven creation and refreshable listeners.
 
+### Improved reliability of watching for configuration file changes
+
+<xref:Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher>, which is mainly used for watching changes in configuration files, received several improvements to make it more reliable.
+
+In particular, it now better handles relative paths, directories that don't exist, and filesystems that can't be watched. It now also avoids watching subdirectories when it's not necessary.
+
 ## Cryptography
 
 - [X25519 Diffie-Hellman key exchange](#x25519-diffie-hellman-key-exchange)

--- a/docs/core/whats-new/dotnet-11/libraries.md
+++ b/docs/core/whats-new/dotnet-11/libraries.md
@@ -641,11 +641,11 @@ builder.Services.AddTracing(tracing =>
 
 The same release adds `ActivitySourceFactory` and unseals `ActivitySource`, which together support factory-driven creation and refreshable listeners.
 
-### Improved reliability of watching for configuration file changes
+### Improved reliability for configuration file change detection
 
-<xref:Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher>, which is mainly used for watching changes in configuration files, received several improvements to make it more reliable.
+The <xref:Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher> type, which configuration providers use to detect configuration file changes, includes several reliability improvements.
 
-In particular, it now better handles relative paths, directories that don't exist, and filesystems that can't be watched. It now also avoids watching subdirectories when it's not necessary.
+It now handles relative paths, missing directories, and file systems that don't support file watching more reliably. It also avoids watching subdirectories when it doesn't need to.
 
 ## Cryptography
 


### PR DESCRIPTION
`PhysicalFilesWatcher` received several reliability bug fixes in .Net 11 (see [this list](https://github.com/dotnet/runtime/commits/main/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs?since=2025-09-01&until=2026-08-26)).

I think it raises to the level where it becomes worth mentioning in What's new.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/whats-new/dotnet-11/libraries.md](https://github.com/dotnet/docs/blob/e7a83e40feee6e1429f8155fbf350ada207a8a9a/docs/core/whats-new/dotnet-11/libraries.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-11/libraries?branch=pr-en-us-55747) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202608261419029573-55747/BuildReport?accessString=5a8cc3a28dfbf524e82c817cd56502ea42723bb5e45b1a405aa039965d5c168f)