### PR TITLE
Clarify architecture migration from VSTest to MTP

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-test-reports.md
+++ b/docs/core/testing/microsoft-testing-platform-test-reports.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform (MTP) test reports
 description: Learn about the MTP extensions that create test report files (TRX, HTML, JUnit, CTRF, Azure DevOps, GitHub Actions).
 author: evangelink
 ms.author: amauryleve
-ms.date: 08/06/2026
+ms.date: 08/26/2026
 ai-usage: ai-assisted
 ---
 
@@ -172,7 +172,12 @@ The extension automatically detects that it is running in continuous integration
 
 The GitHub Actions report emits GitHub Actions-native workflow commands so test runs produce a first-class experience on the runner: per-assembly log groups, failed and skipped test annotations (surfaced in the workflow **Annotations** tab and, when the source location resolves, on the pull request's **Files changed** diff), a Markdown job summary appended to the file referenced by `GITHUB_STEP_SUMMARY`, and slow-test notices.
 
+This extension requires the [Microsoft.Testing.Extensions.GitHubActionsReport](https://www.nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport) NuGet package.
+
 The extension activates only when the run is on GitHub Actions (the `GITHUB_ACTIONS` environment variable is `true`) and the `--report-gh` switch is set; otherwise it does nothing. When active, each feature is enabled by default and can be turned off individually with its `--report-gh-*` option.
+
+> [!IMPORTANT]
+> The `--report-gh` option belongs to `Microsoft.Testing.Extensions.GitHubActionsReport`. The [GitHubActionsTestLogger](https://www.nuget.org/packages/GitHubActionsTestLogger) package provides a different option, `--report-github`. The options aren't aliases and work only when the test project registers the package that owns the option.
 
 > [!NOTE]
 > Available in MTP starting with version 2.3.0. This extension is experimental, and its options and output format might change in a future version.

--- a/docs/core/testing/migrating-vstest-microsoft-testing-platform.md
+++ b/docs/core/testing/migrating-vstest-microsoft-testing-platform.md
@@ -122,10 +122,19 @@ For .NET 10 SDK and later versions, use a project-level matrix:
 
 ```powershell
 $testProjects = @("tests/A.Tests/A.Tests.csproj", "tests/B.Tests/B.Tests.csproj")
+$testRunFailed = $false
 foreach ($configuration in "Debug", "Release") {
     foreach ($architecture in "x86", "x64") {
-        $testProjects | ForEach-Object { dotnet test --project $_ -c $configuration --arch $architecture }
+        foreach ($testProject in $testProjects) {
+            dotnet test --project $testProject -c $configuration --arch $architecture
+            if ($LASTEXITCODE -ne 0) {
+                $testRunFailed = $true
+            }
+        }
     }
+}
+if ($testRunFailed) {
+    throw "One or more test runs failed."
 }
 ```
 

--- a/docs/core/testing/migrating-vstest-microsoft-testing-platform.md
+++ b/docs/core/testing/migrating-vstest-microsoft-testing-platform.md
@@ -3,7 +3,8 @@ title: Migration guide from VSTest to Microsoft.Testing.Platform (MTP)
 description: Step-by-step guide to migrate from VSTest to Microsoft.Testing.Platform (MTP), including argument mapping, project configuration, and CI pipeline updates.
 author: Youssef1313
 ms.author: ygerges
-ms.date: 09/15/2025
+ms.date: 08/26/2026
+ai-usage: ai-assisted
 ---
 
 # Migrate from VSTest to Microsoft.Testing.Platform (MTP)
@@ -89,6 +90,45 @@ The build-related arguments are irrelevant to the test platform and as such don'
 - `-r|--runtime <RUNTIME_IDENTIFIER>`
 - `-v|--verbosity <LEVEL>`
 
+Although `--arch` remains a build-related option, it replaces the architecture that VSTest selects through `RunConfiguration.TargetPlatform`. Pass `--arch` to `dotnet test` itself, before any `--` separator.
+
+For example, migrate this VSTest project command:
+
+```dotnetcli
+dotnet test MyTests.csproj -c Debug -- RunConfiguration.TargetPlatform=x86 /Parallel
+```
+
+For .NET 10 SDK and later versions, use this MTP command:
+
+```dotnetcli
+dotnet test --project MyTests.csproj -c Debug --arch x86
+```
+
+Replace `x86` with `x64` to target x64. MTP runs test modules in parallel by default, so `/Parallel` doesn't need a replacement. To limit module-level parallelism, use `--max-parallel-test-modules <NUMBER>`.
+
+> [!IMPORTANT]
+> You can't combine `--solution` with `--arch`, `--os`, or `--runtime`. These options set `RuntimeIdentifier` as a global MSBuild property, and solution builds don't support a global `RuntimeIdentifier`. To test a solution across architectures, invoke each test project separately or set `RuntimeIdentifier` in the individual test projects.
+
+For example, replace these four solution-level VSTest commands:
+
+```dotnetcli
+dotnet test MySolution.sln -c Debug -- RunConfiguration.TargetPlatform=x86 /Parallel
+dotnet test MySolution.sln -c Release -- RunConfiguration.TargetPlatform=x86 /Parallel
+dotnet test MySolution.sln -c Debug -- RunConfiguration.TargetPlatform=x64 /Parallel
+dotnet test MySolution.sln -c Release -- RunConfiguration.TargetPlatform=x64 /Parallel
+```
+
+For .NET 10 SDK and later versions, use a project-level matrix:
+
+```powershell
+$testProjects = @("tests/A.Tests/A.Tests.csproj", "tests/B.Tests/B.Tests.csproj")
+foreach ($configuration in "Debug", "Release") {
+    foreach ($architecture in "x86", "x64") {
+        $testProjects | ForEach-Object { dotnet test --project $_ -c $configuration --arch $architecture }
+    }
+}
+```
+
 The test-related arguments are VSTest specific and so need to be transformed to match the new platform. The following table shows the mapping between the VSTest arguments and the new platform:
 
 | VSTest argument | New platform argument |
@@ -108,6 +148,8 @@ The test-related arguments are VSTest specific and so need to be transformed to 
 | `--results-directory <RESULTS_DIR>` | `--results-directory <RESULTS_DIR>` |
 | `-s\|--settings <SETTINGS_FILE>` | Depends upon the selected test framework |
 | `-t\|--list-tests` | `--list-tests` |
+| `-- RunConfiguration.TargetPlatform=<ARCHITECTURE>` | `--arch <ARCHITECTURE>` for a project invocation |
+| `/Parallel` | No option required. MTP runs test modules in parallel by default. |
 | `-- <RunSettings arguments>` | `--test-parameter` (provided by [VSTestBridge](microsoft-testing-platform-extensions-vstest-bridge.md)) |
 
 #### `--collect`
@@ -177,6 +219,27 @@ dotnet test --report-trx
 > [!IMPORTANT]
 > As explained earlier, when using MTP with the VSTest-based `dotnet test`, extra `--` is needed before the arguments intended to be passed to the platform.
 > So, this becomes `dotnet test -- --report-trx`.
+
+GitHub Actions reporter options are package-specific and aren't interchangeable:
+
+| Reporter package | MTP option |
+|---|---|
+| [Microsoft.Testing.Extensions.GitHubActionsReport](microsoft-testing-platform-test-reports.md#github-actions-reports) | `--report-gh` |
+| [GitHubActionsTestLogger](https://www.nuget.org/packages/GitHubActionsTestLogger) | `--report-github` |
+
+The test application recognizes an option only when the package that owns it is installed and registered. For example, if you migrate `--logger GitHubActions` and keep the `GitHubActionsTestLogger` package, replace the VSTest command:
+
+```dotnetcli
+dotnet test --logger GitHubActions
+```
+
+With .NET 10 SDK and later versions, use:
+
+```dotnetcli
+dotnet test --report-github
+```
+
+For .NET 9 SDK and earlier versions, use `dotnet test -- --report-github` instead.
 
 #### `--settings`
 


### PR DESCRIPTION
## Summary

Clarify the VSTest-to-Microsoft.Testing.Platform migration path after a real-world migration treated x86/x64 coverage as too complex. The guide now maps `RunConfiguration.TargetPlatform` to project-scoped `--arch`, explains why solution-wide `--arch` isn't supported, and provides before-and-after commands plus a project/configuration/architecture matrix.

Also distinguish the extension-owned GitHub reporting options: `Microsoft.Testing.Extensions.GitHubActionsReport` provides `--report-gh`, while `GitHubActionsTestLogger` provides `--report-github`. Each option requires its owning package to be installed and registered.

Validation:

- Markdownlint passes with zero errors for both changed pages.
- The PowerShell matrix dry run produces all eight project, configuration, and architecture combinations.
- Both linked NuGet package pages return HTTP 200.

Source context: The architecture example adapts the migration confusion demonstrated in nietras/Sep#582. The explanatory guidance and examples are newly generated and require product review.

Fixes: N/A

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-test-reports.md](https://github.com/dotnet/docs/blob/b8b77341a2f9774c647c4050e83fd729c4f609c2/docs/core/testing/microsoft-testing-platform-test-reports.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-test-reports?branch=pr-en-us-55748) |
| [docs/core/testing/migrating-vstest-microsoft-testing-platform.md](https://github.com/dotnet/docs/blob/b8b77341a2f9774c647c4050e83fd729c4f609c2/docs/core/testing/migrating-vstest-microsoft-testing-platform.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/migrating-vstest-microsoft-testing-platform?branch=pr-en-us-55748) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202608261450460887-55748/BuildReport?accessString=09a29eae22838793a0401614b626ef57ea71c34a9c29df5c299e91aa0a6b1135)