### PR TITLE
Clarify F# spacing before invocation parentheses

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -1,7 +1,7 @@
 ---
 title: F# code formatting guidelines
 description: Learn guidelines for formatting F# code.
-ms.date: 10/02/2025
+ms.date: 08/26/2026
 ---
 # F# code formatting guidelines
 
@@ -243,6 +243,48 @@ SomeClass.Invoke ()
 
 // ❌ Not OK, formatting tools will remove the extra space by default
 String.Format (x.IngredientName, x.Quantity)
+```
+
+Which of the two conventions applies is decided by the last part of the name. Nothing earlier in the name has a say:
+
+```fsharp
+// ✔️ OK - `convertTo` is lower-case, so the space is added
+Volume.Conversion.convertTo (x.Quantity, Liter)
+
+// ✔️ OK - `Contains` is capitalized, so no space is added
+recipe.Ingredients.Contains(x.IngredientName)
+```
+
+Both conventions apply only when the whole thing being applied is a plain dotted name, that is, identifiers separated by dots and nothing else. As soon as a call, an index, a receiver that isn't a name, or a type application comes before the parentheses, no space is added. This keeps a fluent chain from ending in a single spaced call:
+
+```fsharp
+// ✔️ OK - a plain dotted name, however many dots it has
+recipe.Ingredients.convertTo (Liter)
+
+// ✔️ OK - a call comes before the parentheses, so no space is added
+getRecipe().convertTo(Liter)
+
+// ✔️ OK - an index comes before the parentheses
+recipe.Ingredients[0].convertTo(Liter)
+
+// ✔️ OK - a receiver that isn't a name, such as an expression or a literal
+(getRecipe x.IngredientName).convertTo(Liter)
+
+// ✔️ OK - a type application, on the call itself or with no dots at all
+recipe.convertTo<Liter>(x.Quantity)
+unbox<Volume>(x.Quantity)
+
+// ❌ Not OK, formatting tools will remove the extra space by default
+getRecipe().convertTo (Liter)
+recipe.Ingredients[0].convertTo (Liter)
+unbox<Volume> (x.Quantity)
+```
+
+The type application case only comes up where the parentheses are already written. Formatting tools don't add parentheses, so a generic application written without them is left as it is:
+
+```fsharp
+// ✔️ OK
+unbox<Volume> x.Quantity
 ```
 
 These same formatting conventions apply to pattern matching. F# style values consistent formatting:

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -245,7 +245,7 @@ SomeClass.Invoke ()
 String.Format (x.IngredientName, x.Quantity)
 ```
 
-Which of the two conventions applies is decided by the last part of the name. Nothing earlier in the name has a say:
+The last part of the name decides which convention applies. Nothing earlier in the name has a say:
 
 ```fsharp
 // ✔️ OK - `convertTo` is lower-case, so the space is added


### PR DESCRIPTION
## Summary

The F# style guide stated that lower-case functions take a space before a parenthesized argument and capitalized methods do not, but it never said which part of a dotted name makes that choice, nor that the choice is only available in the first place when the whole callee is a plain dotted name.

Record both. The last part of the name selects the convention, and a call, an index, a receiver that is not a name, or a type application in front of the parentheses keeps them tight regardless. This is the rule agreed at fsharp/fslang-design#648, which stops a fluent chain from ending in a single spaced call.

Fixes https://github.com/fsharp/fslang-design/issues/648

//cc @dsyme 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/fsharp/style-guide/formatting.md](https://github.com/dotnet/docs/blob/ab4942078200412f623f5851f161dd77309d018e/docs/fsharp/style-guide/formatting.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/fsharp/style-guide/formatting?branch=pr-en-us-55750) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202608261950094886-55750/BuildReport?accessString=1a3220aac402f35207180d7265f4b3c799460c5f5bc862e020ca5ed540576061)