### PR TITLE
add ConfigurationIgnoreAttribute to docs

### DIFF
--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -155,17 +155,9 @@ This approach allows the binder to populate the mutable `List<string>` while pre
 
 #### Exclude properties from binding
 
-Starting in .NET 11, apply <xref:Microsoft.Extensions.Configuration.ConfigurationIgnoreAttribute> to a property when you don't want the configuration binder to populate it. The reflection-based binder and the [configuration source generator](configuration-generator.md) both honour the attribute.
+If you don't want the configuration binder to populate a property, apply <xref:Microsoft.Extensions.Configuration.ConfigurationIgnoreAttribute> to it (available starting in .NET 11). Both the reflection-based binder and the [configuration source generator](configuration-generator.md) honor this attribute.
 
-```csharp
-public sealed class AppOptions
-{
-    public string Endpoint { get; set; } = "";
-
-    [ConfigurationIgnore]
-    public string RuntimeValue { get; set; } = "calculated";
-}
-```
+:::code language="csharp" source="snippets/configuration/binding-scenarios/ConfigurationIgnore/Program.cs" id="AppOptions":::
 
 If configuration contains values for both `Endpoint` and `RuntimeValue`, the binder updates `Endpoint` and leaves `RuntimeValue` at its existing value.
 

--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -155,7 +155,7 @@ This approach allows the binder to populate the mutable `List<string>` while pre
 
 #### Exclude properties from binding
 
-If you don't want the configuration binder to populate a property, apply <xref:Microsoft.Extensions.Configuration.ConfigurationIgnoreAttribute> to it (available starting in .NET 11). Both the reflection-based binder and the [configuration source generator](configuration-generator.md) honor this attribute.
+If you don't want the configuration binder to populate a property, apply <xref:Microsoft.Extensions.Configuration.ConfigurationIgnoreAttribute> to it (available starting in .NET 11).
 
 :::code language="csharp" source="snippets/configuration/binding-scenarios/ConfigurationIgnore/Program.cs" id="AppOptions":::
 

--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 description: Learn how to use the Configuration API to configure .NET applications. Explore various inbuilt configuration providers.
-ms.date: 10/09/2024
+ms.date: 08/27/2026
 ms.topic: overview
 ai-usage: ai-assisted
 ---
@@ -118,6 +118,7 @@ The configuration binder has specific behaviors and limitations when working wit
 - [Bind to dictionaries](#bind-to-dictionaries)
 - [Dictionary keys with colons](#dictionary-keys-with-colons)
 - [Bind to IReadOnly* types](#bind-to-ireadonly-types)
+- [Exclude properties from binding](#exclude-properties-from-binding)
 - [Bind with parameterized constructors](#bind-with-parameterized-constructors)
 
 #### Bind to dictionaries
@@ -151,6 +152,22 @@ The configuration class implementation:
 :::code language="csharp" source="snippets/configuration/binding-scenarios/DictionaryBinding/Program.cs" id="SettingsWithReadOnly":::
 
 This approach allows the binder to populate the mutable `List<string>` while presenting an immutable interface to consumers through `IReadOnlyList<string>`.
+
+#### Exclude properties from binding
+
+Starting in .NET 11, apply <xref:Microsoft.Extensions.Configuration.ConfigurationIgnoreAttribute> to a property when you don't want the configuration binder to populate it. The reflection-based binder and the [configuration source generator](configuration-generator.md) both honour the attribute.
+
+```csharp
+public sealed class AppOptions
+{
+    public string Endpoint { get; set; } = "";
+
+    [ConfigurationIgnore]
+    public string RuntimeValue { get; set; } = "calculated";
+}
+```
+
+If configuration contains values for both `Endpoint` and `RuntimeValue`, the binder updates `Endpoint` and leaves `RuntimeValue` at its existing value.
 
 #### Bind with parameterized constructors
 

--- a/docs/core/extensions/snippets/configuration/binding-scenarios/ConfigurationIgnore/ConfigurationIgnore.csproj
+++ b/docs/core/extensions/snippets/configuration/binding-scenarios/ConfigurationIgnore/ConfigurationIgnore.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net11.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/docs/core/extensions/snippets/configuration/binding-scenarios/ConfigurationIgnore/Program.cs
+++ b/docs/core/extensions/snippets/configuration/binding-scenarios/ConfigurationIgnore/Program.cs
@@ -1,0 +1,29 @@
+// <AppOptions>
+using Microsoft.Extensions.Configuration;
+
+public sealed class AppOptions
+{
+    public string Endpoint { get; set; } = "";
+
+    [ConfigurationIgnore]
+    public string RuntimeValue { get; set; } = "calculated";
+}
+// </AppOptions>
+
+public static class Program
+{
+    public static void Main()
+    {
+        var configuration = new ConfigurationManager
+        {
+            [nameof(AppOptions.Endpoint)] = "https://localhost",
+            [nameof(AppOptions.RuntimeValue)] = "configured",
+        };
+
+        var options = new AppOptions();
+        configuration.Bind(options);
+
+        Console.WriteLine($"Endpoint: {options.Endpoint}");
+        Console.WriteLine($"RuntimeValue: {options.RuntimeValue}");
+    }
+}


### PR DESCRIPTION
## Summary

Document `ConfigurationIgnoreAttribute` in the main .NET configuration guidance. Explain that reflection-based and source-generated binding skip attributed properties, and add an example.

Related to dotnet/runtime#126396 and dotnet/runtime#125111.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/extensions/configuration.md](https://github.com/dotnet/docs/blob/8ce494ded20c6980e7e15629a8dcc36ab85bea5c/docs/core/extensions/configuration.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/configuration?branch=pr-en-us-55757) |
| [docs/core/extensions/snippets/configuration/binding-scenarios/ConfigurationIgnore/Program.cs](https://github.com/dotnet/docs/blob/8ce494ded20c6980e7e15629a8dcc36ab85bea5c/docs/core/extensions/snippets/configuration/binding-scenarios/ConfigurationIgnore/Program.cs) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/configuration?branch=pr-en-us-55757) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202608281309054130-55757/BuildReport?accessString=3ec9714a159c5543cf353b647b844971b4096a77262111b160cf515e4383792a)