### PR TITLE
Add metrics configuration docs

### DIFF
--- a/docs/core/diagnostics/metrics-collection.md
+++ b/docs/core/diagnostics/metrics-collection.md
@@ -2,7 +2,7 @@
 title: Collect metrics - .NET
 description: Tutorial to collect metrics in .NET applications
 ms.topic: tutorial
-ms.date: 10/27/2021
+ms.date: 08/27/2026
 ---
 
 # Collect metrics
@@ -20,6 +20,38 @@ For more information on custom metric instrumentation and options, see [Compare 
 ## Prerequisites
 
 - [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet) or a later
+
+## Configure metrics with IConfiguration
+
+Starting with .NET 8, Generic Host applications that use the default builder settings automatically call <xref:Microsoft.Extensions.DependencyInjection.MetricsServiceExtensions.AddMetrics*> and load the `Metrics` section from <xref:Microsoft.Extensions.Configuration.IConfiguration>. In a non-hosted dependency injection application, call `AddMetrics` and <xref:Microsoft.Extensions.Diagnostics.Metrics.MetricsBuilderConfigurationExtensions.AddConfiguration(Microsoft.Extensions.Diagnostics.Metrics.IMetricsBuilder,Microsoft.Extensions.Configuration.IConfiguration)> explicitly to bind the same section:
+
+```csharp
+services.AddMetrics(metrics =>
+    metrics.AddConfiguration(configuration.GetSection("Metrics")));
+```
+
+Import the `Microsoft.Extensions.DependencyInjection` and `Microsoft.Extensions.Diagnostics.Metrics` namespaces to use these extension methods.
+
+> [!IMPORTANT]
+> The `Metrics` configuration only selects which instruments registered <xref:Microsoft.Extensions.Diagnostics.Metrics.IMetricsListener> implementations receive. It doesn't register listeners or activate their subscriptions, create metrics, aggregate measurements, export data, or automatically configure OpenTelemetry, Prometheus, `dotnet-counters`, or any other collector.
+
+Use the following sections to choose which meters the rules apply to:
+
+| Section | Applies to |
+| --- | --- |
+| `EnabledMetrics` | Both global and local meters. |
+| `EnabledGlobalMetrics` | Meters created directly with <xref:System.Diagnostics.Metrics.Meter>. |
+| `EnabledLocalMetrics` | Meters created by the service container's <xref:System.Diagnostics.Metrics.IMeterFactory>. |
+
+An `EnabledMetrics`, `EnabledGlobalMetrics`, or `EnabledLocalMetrics` section directly under `Metrics` applies to every registered listener. To target one listener, nest the section under the listener's <xref:Microsoft.Extensions.Diagnostics.Metrics.IMetricsListener.Name> value, such as `Metrics:MyListener:EnabledMetrics`. Listener and instrument names require exact matches without regard to case.
+
+Within any of these sections, a Boolean meter entry enables or disables every instrument whose meter name matches. To set instrument-level rules, use an object with instrument names as keys. The special `Default` entry supplies a fallback. A Boolean `Default` entry at the meter level applies to otherwise unmatched meters. Within a meter object, `Default` applies to otherwise unmatched instruments. A listener doesn't receive an instrument if no rule matches it.
+
+The following `appsettings.json` example enables the `Contoso.Web` meter by default but disables its noisy `request-duration` instrument:
+
+:::code language="json" source="snippets/Metrics/appsettings.json":::
+
+Meter names use case-insensitive prefix matching. A meter name can contain at most one `*` wildcard to match a prefix and suffix. More-specific rules take precedence in this order: listener-specific rules, longer meter-name patterns, instrument-specific rules, and scope-specific rules. If equally specific rules conflict, the last configured rule wins.
 
 ## Create an example app
 

--- a/docs/core/diagnostics/snippets/Metrics/appsettings.json
+++ b/docs/core/diagnostics/snippets/Metrics/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Metrics": {
+    "EnabledMetrics": {
+      "Contoso.Web": {
+        "Default": true,
+        "request-duration": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a concise **Configure metrics with IConfiguration** section to the metrics collection tutorial.

- Documents Generic Host configuration and explicit non-hosted DI registration.
- Covers metric scopes, listener-specific rules, `Default`, matching, and precedence.
- Adds a valid `appsettings.json` example.
- Clarifies that configuration filters instruments for `IMetricsListener`; it doesn't configure collection or export.
- Uses the merged implementation and `MetricsConfigureOptionsTests` from [dotnet/runtime#90201](https://github.com/dotnet/runtime/pull/90201) as the source of truth. No proposal APIs were copied from [dotnet/runtime#85684](https://github.com/dotnet/runtime/issues/85684).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/diagnostics/metrics-collection.md](https://github.com/dotnet/docs/blob/bbc6f6cdb9c9154cc4e90cfda94f30ebe25985dd/docs/core/diagnostics/metrics-collection.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-collection?branch=pr-en-us-55759) |
| [docs/core/diagnostics/snippets/Metrics/appsettings.json](https://github.com/dotnet/docs/blob/bbc6f6cdb9c9154cc4e90cfda94f30ebe25985dd/docs/core/diagnostics/snippets/Metrics/appsettings.json) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-collection?branch=pr-en-us-55759) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202608271336287714-55759/BuildReport?accessString=3188e4feac9653f2bf64441e9d540194780df8dffb1d8e842d7744b9165af385)