### PR TITLE
Document MSTest CI report extensions in the Default profile

### DIFF
--- a/docs/core/testing/unit-testing-mstest-sdk.md
+++ b/docs/core/testing/unit-testing-mstest-sdk.md
@@ -59,10 +59,10 @@ You can set the profile using the property `TestingExtensionsProfile` with one o
   * [HTML Report](./microsoft-testing-platform-test-reports.md#html-reports)
   * [Retry](./microsoft-testing-platform-retry.md#retry)
 
-  The Azure DevOps Report extension is also included in `AllMicrosoft` in MSTest.Sdk versions 3.11.0 through 4.2.x.
+  In MSTest.Sdk versions 3.11.0 through 4.2.x, the Azure DevOps Report extension is included only in `AllMicrosoft`.
 
 > [!NOTE]
-> The profiles reference the Azure DevOps Report and GitHub Actions Report packages, but reporting remains disabled at runtime. Pass `--report-azdo` or `--report-gh` to enable the corresponding report for a test run.
+> The profiles reference the Azure DevOps Report and GitHub Actions Report packages, but reporting remains disabled at runtime. Pass `--report-azdo` to enable Azure DevOps reporting. To enable GitHub Actions reporting, run the tests on GitHub Actions and pass `--report-gh`.
 
 Here's a full example, using the `None` profile:
 
@@ -141,7 +141,7 @@ You can also disable an extension that's coming from the selected profile. For e
 </Project>
 ```
 
-Starting with MSTest.Sdk 4.3.0, the `Default` profile references the Azure DevOps Report and GitHub Actions Report packages. To remove either package reference, set `<EnableMicrosoftTestingExtensionsAzureDevOpsReport>false</EnableMicrosoftTestingExtensionsAzureDevOpsReport>` or `<EnableMicrosoftTestingExtensionsGitHubActionsReport>false</EnableMicrosoftTestingExtensionsGitHubActionsReport>`. If you keep the package references, reporting still starts only when you pass `--report-azdo` or `--report-gh` for the test run.
+In MSTest.Sdk 4.3.0 and later, the `Default` profile references the Azure DevOps Report and GitHub Actions Report packages. To remove either package reference, set `<EnableMicrosoftTestingExtensionsAzureDevOpsReport>false</EnableMicrosoftTestingExtensionsAzureDevOpsReport>` or `<EnableMicrosoftTestingExtensionsGitHubActionsReport>false</EnableMicrosoftTestingExtensionsGitHubActionsReport>`. If you keep the package references, Azure DevOps reporting starts only when you pass `--report-azdo`. GitHub Actions reporting starts only when you run the tests on GitHub Actions and pass `--report-gh`.
 
 ## Features
 

--- a/docs/core/testing/unit-testing-mstest-sdk.md
+++ b/docs/core/testing/unit-testing-mstest-sdk.md
@@ -3,7 +3,7 @@ title: MSTest SDK configuration
 author: MarcoRossignoli
 description: Learn how to configure MSTest.Sdk profiles, extensions, and advanced features.
 ms.author: mrossignoli
-ms.date: 08/26/2026
+ms.date: 08/27/2026
 ai-usage: ai-assisted
 ---
 
@@ -45,21 +45,24 @@ You can set the profile using the property `TestingExtensionsProfile` with one o
 
   * [Code Coverage](./microsoft-testing-platform-code-coverage.md#microsoft-code-coverage)
   * [Trx Report](./microsoft-testing-platform-test-reports.md#visual-studio-test-reports-trx)
+  * [Azure DevOps Report](./microsoft-testing-platform-test-reports.md#azure-devops-reports) (MSTest.Sdk 4.3.0+)
+  * [GitHub Actions Report](./microsoft-testing-platform-test-reports.md#github-actions-reports) (experimental and prerelease, MSTest.Sdk 4.3.0+)
 
 * `AllMicrosoft` - Enables the Microsoft extensions selected for broad out-of-the-box use, including extensions with a restrictive license. Experimental and API-only extensions can still require explicit opt-in.
 
-  Enables the following extensions:
+  Enables all extensions from the `Default` profile, plus the following extensions:
 
-  * [Code Coverage](./microsoft-testing-platform-code-coverage.md#microsoft-code-coverage)
   * [Crash Dump](./microsoft-testing-platform-crash-hang-dumps.md#crash-dump)
   * [Fakes](./microsoft-testing-platform-fakes.md) (MSTest.Sdk 3.7.0+)
   * [Hang Dump](./microsoft-testing-platform-crash-hang-dumps.md#hang-dump)
   * [Hot Reload](./microsoft-testing-platform-hot-reload.md#hot-reload)
   * [HTML Report](./microsoft-testing-platform-test-reports.md#html-reports)
-  * [GitHub Actions Report](./microsoft-testing-platform-test-reports.md#github-actions-reports) (MSTest.Sdk 4.3.0+)
   * [Retry](./microsoft-testing-platform-retry.md#retry)
-  * [Trx Report](./microsoft-testing-platform-test-reports.md#visual-studio-test-reports-trx)
-  * [AzureDevOpsReport](./microsoft-testing-platform-test-reports.md#azure-devops-reports)
+
+  The Azure DevOps Report extension is also included in `AllMicrosoft` in MSTest.Sdk versions 3.11.0 through 4.2.x.
+
+> [!NOTE]
+> The profiles reference the Azure DevOps Report and GitHub Actions Report packages, but reporting remains disabled at runtime. Pass `--report-azdo` or `--report-gh` to enable the corresponding report for a test run.
 
 Here's a full example, using the `None` profile:
 
@@ -82,10 +85,10 @@ Here's a full example, using the `None` profile:
 | [Hang Dump](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HangDump)                 |       |                    | :heavy_check_mark:  |
 | [Hot Reload](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HotReload)               |       |                    | :heavy_check_mark:  |
 | [HTML Report](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HtmlReport)             |       |                    | :heavy_check_mark:  |
-| [GitHub Actions Report](https://www.nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport) |       |              | :heavy_check_mark:³ |
+| [GitHub Actions Report](https://www.nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport) |       | :heavy_check_mark:³ | :heavy_check_mark:³ |
 | [Retry](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Retry)                        |       |                    | :heavy_check_mark:  |
 | [Trx](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport)                      |       | :heavy_check_mark: | :heavy_check_mark:  |
-| [AzureDevOpsReport](./microsoft-testing-platform-test-reports.md#azure-devops-reports) |       |                    | :heavy_check_mark:²  |
+| [Azure DevOps Report](https://www.nuget.org/packages/Microsoft.Testing.Extensions.AzureDevOpsReport) |       | :heavy_check_mark:³ | :heavy_check_mark:² |
 
 ¹ MSTest.Sdk 3.7.0+
 ² MSTest.Sdk 3.11.0+
@@ -137,6 +140,8 @@ You can also disable an extension that's coming from the selected profile. For e
 
 </Project>
 ```
+
+Starting with MSTest.Sdk 4.3.0, the `Default` profile references the Azure DevOps Report and GitHub Actions Report packages. To remove either package reference, set `<EnableMicrosoftTestingExtensionsAzureDevOpsReport>false</EnableMicrosoftTestingExtensionsAzureDevOpsReport>` or `<EnableMicrosoftTestingExtensionsGitHubActionsReport>false</EnableMicrosoftTestingExtensionsGitHubActionsReport>`. If you keep the package references, reporting still starts only when you pass `--report-azdo` or `--report-gh` for the test run.
 
 ## Features
 


### PR DESCRIPTION
Starting with MSTest.Sdk 4.3.0, the `Default` profile references the Azure DevOps and GitHub Actions report extensions. The profile documentation needs to reflect those package references without implying that CI reporting starts automatically.

- Add both reporters to the `Default` profile and profile matrix.
- Consolidate shared `AllMicrosoft` entries and preserve earlier Azure DevOps availability.
- Keep runtime activation explicit through `--report-azdo` and `--report-gh`.
- Document package opt-out properties and note that GitHub Actions Report remains experimental and prerelease.

Validation: `git diff --check`

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/testing/unit-testing-mstest-sdk.md](https://github.com/dotnet/docs/blob/8de98bccb6bf7476d63b1290d5ba72b9ed74b21d/docs/core/testing/unit-testing-mstest-sdk.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-sdk?branch=pr-en-us-55760) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202608271443167717-55760/BuildReport?accessString=217d632c77286f87be426d3d141842356535da93bb4d949409b944fe5ce5bed5)