### PR TITLE
Clarify how configuration binder binds types

### DIFF
--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -73,11 +73,13 @@ One of the key advantages of using the .NET configuration abstractions is the ab
 
 These abstractions are agnostic to their underlying configuration provider (<xref:Microsoft.Extensions.Configuration.IConfigurationProvider>). In other words, you can use an `IConfiguration` instance to access any configuration value from multiple providers.
 
-The binder can use different approaches to process configuration values:​
+The binder can process configuration values in several ways:
 
-- Direct deserialization (using built-in converters) for primitive types​.
-- The <xref:System.ComponentModel.TypeConverter> for a complex type when the type has one​.
-- Reflection for a complex type that has properties.
+- Use a single configuration value directly for a `string` or `object` target, or convert it to a common .NET type, such as a numeric type, an enumeration, or a nullable type. The binder converts a Base64-encoded string to a byte array.
+- Bind hierarchical configuration to an object's properties or constructor parameters.
+- Bind child configuration sections to arrays, collections, sets, and dictionaries.
+- Use the matching configuration section directly when the target type is <xref:Microsoft.Extensions.Configuration.IConfigurationSection>.
+- Convert a single configuration value to a custom type. The default binder uses a <xref:System.ComponentModel.TypeConverter> when the custom type defines one. The source generator binder doesn't support this.
 
 > [!NOTE]
 > The binder has a few limitations:

--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -75,11 +75,11 @@ These abstractions are agnostic to their underlying configuration provider (<xre
 
 The binder can process configuration values in several ways:
 
-- Use a single configuration value directly for a `string` or `object` target, or convert it to a common .NET type, such as a numeric type, an enumeration, or a nullable type. The binder converts a Base64-encoded string to a byte array.
-- Bind hierarchical configuration to an object's properties or constructor parameters.
-- Bind child configuration sections to arrays, collections, sets, and dictionaries.
-- Use the matching configuration section directly when the target type is <xref:Microsoft.Extensions.Configuration.IConfigurationSection>.
-- Convert a single configuration value to a custom type. The default binder uses a <xref:System.ComponentModel.TypeConverter> when the custom type defines one. The source generator binder doesn't support this.
+- Uses a single configuration value directly for a `string` or `object` target, or converts it to a common .NET type, such as a numeric type, an enumeration, or a nullable type. The binder converts a Base64-encoded string to a byte array.
+- Binds hierarchical configuration to an object's properties or constructor parameters.
+- Binds child configuration sections to arrays, collections, sets, and dictionaries.
+- Uses the matching configuration section directly when the target type is <xref:Microsoft.Extensions.Configuration.IConfigurationSection>.
+- Converts a single configuration value to a custom type. The default binder uses a <xref:System.ComponentModel.TypeConverter> when the custom type defines one. The source generator binder doesn't support this.
 
 > [!NOTE]
 > The binder has a few limitations:

--- a/docs/core/extensions/configuration.md
+++ b/docs/core/extensions/configuration.md
@@ -73,13 +73,13 @@ One of the key advantages of using the .NET configuration abstractions is the ab
 
 These abstractions are agnostic to their underlying configuration provider (<xref:Microsoft.Extensions.Configuration.IConfigurationProvider>). In other words, you can use an `IConfiguration` instance to access any configuration value from multiple providers.
 
-The binder can process configuration values in several ways:
+The binder processes configuration values in several ways:
 
-- Uses a single configuration value directly for a `string` or `object` target, or converts it to a common .NET type, such as a numeric type, an enumeration, or a nullable type. The binder converts a Base64-encoded string to a byte array.
-- Binds hierarchical configuration to an object's properties or constructor parameters.
-- Binds child configuration sections to arrays, collections, sets, and dictionaries.
-- Uses the matching configuration section directly when the target type is <xref:Microsoft.Extensions.Configuration.IConfigurationSection>.
-- Converts a single configuration value to a custom type. The default binder uses a <xref:System.ComponentModel.TypeConverter> when the custom type defines one. The source generator binder doesn't support this.
+- It uses a single configuration value directly for a `string` or `object` target, or converts it to a common .NET type, such as a numeric type, an enumeration, or a nullable type. The binder converts a Base64-encoded string to a byte array.
+- It binds hierarchical configuration to an object's properties or constructor parameters.
+- It binds child configuration sections to arrays, collections, sets, and dictionaries.
+- It uses the matching configuration section directly when the target type is <xref:Microsoft.Extensions.Configuration.IConfigurationSection>.
+- It converts a single configuration value to a custom type. The default binder uses a <xref:System.ComponentModel.TypeConverter> when the custom type defines one. The source-generated binder doesn't support this conversion.
 
 > [!NOTE]
 > The binder has a few limitations:


### PR DESCRIPTION
The old list was incomplete and inaccurate (especially for the source generator binder).

The new list should be accurate and complete, without going into too much detail (it's probably not useful to explicitly list the types supported by the source generator binder here).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/extensions/configuration.md](https://github.com/dotnet/docs/blob/e10de7765183895943743acf59dd3c23c4d89ca0/docs/core/extensions/configuration.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/extensions/configuration?branch=pr-en-us-55762) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202608281220084303-55762/BuildReport?accessString=e475dff95fa1105d49df1877c5d55340215733680ab7b9fd1af97e90d9351d66)