### PR TITLE
add environment variable config for thread pool min/max threads

### DIFF
--- a/docs/core/runtime-config/threading.md
+++ b/docs/core/runtime-config/threading.md
@@ -1,7 +1,7 @@
 ---
 title: Threading config settings
 description: Learn about the settings that configure threading for .NET apps.
-ms.date: 11/04/2021
+ms.date: 08/28/2026
 ---
 # Runtime configuration options for threading
 
@@ -45,11 +45,11 @@ This article details the settings you can use to configure threading in .NET.
 - Specifies the minimum number of threads for the worker thread pool.
 - Corresponds to the <xref:System.Threading.ThreadPool.SetMinThreads*?displayProperty=nameWithType> method.
 
-| | Setting name | Values |
-| - | - | - |
-| **runtimeconfig.json** | `System.Threading.ThreadPool.MinThreads` | An integer that represents the minimum number of threads |
-| **MSBuild property** | `ThreadPoolMinThreads` | An integer that represents the minimum number of threads |
-| **Environment variable** | N/A | N/A |
+| | Setting name | Values | Version introduced |
+| - | - | - | - |
+| **runtimeconfig.json** | `System.Threading.ThreadPool.MinThreads` | An integer that represents the minimum number of threads | |
+| **MSBuild property** | `ThreadPoolMinThreads` | An integer that represents the minimum number of threads | |
+| **Environment variable** | `DOTNET_ThreadPool_ForceMinWorkerThreads` | A hexadecimal integer that represents the minimum number of threads | .NET 10 |
 
 ### Examples
 
@@ -92,11 +92,11 @@ Project file:
 - Specifies the maximum number of threads for the worker thread pool.
 - Corresponds to the <xref:System.Threading.ThreadPool.SetMaxThreads*?displayProperty=nameWithType> method.
 
-| | Setting name | Values |
-| - | - | - |
-| **runtimeconfig.json** | `System.Threading.ThreadPool.MaxThreads` | An integer that represents the maximum number of threads |
-| **MSBuild property** | `ThreadPoolMaxThreads` | An integer that represents the maximum number of threads |
-| **Environment variable** | N/A | N/A |
+| | Setting name | Values | Version introduced |
+| - | - | - | - |
+| **runtimeconfig.json** | `System.Threading.ThreadPool.MaxThreads` | An integer that represents the maximum number of threads | |
+| **MSBuild property** | `ThreadPoolMaxThreads` | An integer that represents the maximum number of threads | |
+| **Environment variable** | `DOTNET_ThreadPool_ForceMaxWorkerThreads` | A hexadecimal integer that represents the maximum number of threads | .NET 10 |
 
 ### Examples
 

--- a/docs/core/runtime-config/threading.md
+++ b/docs/core/runtime-config/threading.md
@@ -49,7 +49,7 @@ This article details the settings you can use to configure threading in .NET.
 | - | - | - | - |
 | **runtimeconfig.json** | `System.Threading.ThreadPool.MinThreads` | An integer that represents the minimum number of threads | |
 | **MSBuild property** | `ThreadPoolMinThreads` | An integer that represents the minimum number of threads | |
-| **Environment variable** | `DOTNET_ThreadPool_ForceMinWorkerThreads` | A hexadecimal integer that represents the minimum number of threads | .NET 10 |
+| **Environment variable** | `DOTNET_ThreadPool_ForceMinWorkerThreads` | A hexadecimal integer that represents the minimum number of worker threads (for example, `0x20` or `20` for 32 threads) | .NET 10 |
 
 ### Examples
 
@@ -96,7 +96,7 @@ Project file:
 | - | - | - | - |
 | **runtimeconfig.json** | `System.Threading.ThreadPool.MaxThreads` | An integer that represents the maximum number of threads | |
 | **MSBuild property** | `ThreadPoolMaxThreads` | An integer that represents the maximum number of threads | |
-| **Environment variable** | `DOTNET_ThreadPool_ForceMaxWorkerThreads` | A hexadecimal integer that represents the maximum number of threads | .NET 10 |
+| **Environment variable** | `DOTNET_ThreadPool_ForceMaxWorkerThreads` | A hexadecimal integer that represents the minimum number of worker threads (for example, `0x14` for 20 threads) | .NET 10 |
 
 ### Examples
 


### PR DESCRIPTION
## Summary

Mention the environment variable config for thread pool min/max threads

contributes to https://github.com/dotnet/runtime/issues/132828

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/runtime-config/threading.md](https://github.com/dotnet/docs/blob/52c995a1306e3a1713652b6af05f3da87ce033f0/docs/core/runtime-config/threading.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/runtime-config/threading?branch=pr-en-us-55772) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202608281227101798-55772/BuildReport?accessString=a0586944e65069d290e19c6c1baed7b955e7364232284f649b99b09b5dafe951)