### PR TITLE
Fix langversion typo in union types tutorial

### DIFF
--- a/docs/csharp/whats-new/tutorials/unions.md
+++ b/docs/csharp/whats-new/tutorials/unions.md
@@ -42,13 +42,13 @@ You build a class library, `SmartHome.Core`, that holds the union types, and a c
 
    ```dotnetcli
    dotnet new sln -n TelemetryMonitor
-   dotnet new classlib --langversion preview -n SmartHome.Core
-   dotnet new console --langversion preview -n SmartHome.App
+   dotnet new classlib --langVersion preview -n SmartHome.Core
+   dotnet new console --langVersion preview -n SmartHome.App
    dotnet sln add SmartHome.Core SmartHome.App
    dotnet add SmartHome.App reference SmartHome.Core
    ```
 
-1. The previous commands included the `--langversion preview` to enable C# 15 preview features. In each project file, verify that the language version is set to `preview`:
+1. The previous commands included the `--langVersion preview` to enable C# 15 preview features. In each project file, verify that the language version is set to `preview`:
 
    ```xml
    <PropertyGroup>


### PR DESCRIPTION
## Summary
Per the man page for dotnet new classlib and dotnet new console, the --langversion arg should be --langVersion.

Confirmed in local CLI on:
  Version:      11.0.0-preview.7.26381.103
  Architecture: arm64
  Commit:       e2c1e00b3d

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/csharp/whats-new/tutorials/unions.md](https://github.com/dotnet/docs/blob/327874829d4d10cec8b3f1e5b59881ef732766bb/docs/csharp/whats-new/tutorials/unions.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/tutorials/unions?branch=pr-en-us-55774) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202608281455064790-55774/BuildReport?accessString=623d1e562f7ab7164e1cf4c211d2abfce4cdde55b38b62b4ace2e74a244be9ac)