### PR TITLE
Add testing agent skills guidance

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-ai.md
+++ b/docs/core/testing/microsoft-testing-platform-ai.md
@@ -16,14 +16,15 @@ The experimental [Microsoft.Testing.Platform.AI](https://www.nuget.org/packages/
 
 ## Use AI coding tools for test workflows
 
-The packages in this article let MTP extensions call AI models at test run time. To use an AI coding assistant to create, analyze, or migrate tests in your repository, use the curated [.NET Agent Skills](https://github.com/dotnet/skills) instead.
+The packages in this article let MTP extensions call AI models during a test run. To use an AI coding assistant to create, analyze, or migrate tests in your repository, use the curated [.NET Agent Skills](https://github.com/dotnet/skills) instead.
 
 Choose a workflow based on your goal:
 
 | Goal | Skill or agent |
 |---|---|
 | Create or extend tests | Use the [`code-testing-agent` skill](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test/skills/code-testing-agent) from the [`dotnet-test` plugin](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test). The skill researches the codebase, plans the work, implements tests, and verifies the changes. |
-| Audit test quality | Use the [`test-quality-auditor` agent](https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/agents/test-quality-auditor.agent.md) for a broad assessment, or invoke a focused `dotnet-test` skill for assertions, coverage, test gaps, or test smells. |
+| Run or troubleshoot tests | Use the [`run-tests` skill](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test/skills/run-tests) to execute tests or diagnose test execution without changing test code. |
+| Audit test quality | Use the [`test-quality-auditor` agent](https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/agents/test-quality-auditor.agent.md) for a broad assessment, or invoke a focused skill from the [`dotnet-test` skills directory](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test/skills) for assertions, coverage, test gaps, or test smells. |
 | Improve testability | Use the [`testability-migration` agent](https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/agents/testability-migration.agent.md) to find static dependencies and introduce testable abstractions. |
 | Migrate a test framework or platform | Use the [`test-migration` agent](https://github.com/dotnet/skills/blob/main/plugins/dotnet-test-migration/agents/test-migration.agent.md) from the [`dotnet-test-migration` plugin](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test-migration). The agent detects the current setup and selects the appropriate migration skill. |
 

--- a/docs/core/testing/microsoft-testing-platform-ai.md
+++ b/docs/core/testing/microsoft-testing-platform-ai.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform (MTP) AI integrations
 description: Learn how MTP extensions access AI chat clients and configure the Azure AI Foundry provider.
 author: Evangelink
 ms.author: amauryleve
-ms.date: 08/26/2026
+ms.date: 08/28/2026
 ai-usage: ai-assisted
 ---
 
@@ -13,6 +13,21 @@ The experimental [Microsoft.Testing.Platform.AI](https://www.nuget.org/packages/
 
 > [!IMPORTANT]
 > The AI APIs use the `TPEXP` diagnostic ID and can change in a future release. The packages supply infrastructure to extensions; they don't add AI behavior to a test suite by themselves.
+
+## Use AI coding tools for test workflows
+
+The packages in this article let MTP extensions call AI models at test run time. To use an AI coding assistant to create, analyze, or migrate tests in your repository, use the curated [.NET Agent Skills](https://github.com/dotnet/skills) instead.
+
+Choose a workflow based on your goal:
+
+| Goal | Skill or agent |
+|---|---|
+| Create or extend tests | Use the [`code-testing-agent` skill](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test/skills/code-testing-agent) from the [`dotnet-test` plugin](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test). The skill researches the codebase, plans the work, implements tests, and verifies the changes. |
+| Audit test quality | Use the [`test-quality-auditor` agent](https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/agents/test-quality-auditor.agent.md) for a broad assessment, or invoke a focused `dotnet-test` skill for assertions, coverage, test gaps, or test smells. |
+| Improve testability | Use the [`testability-migration` agent](https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/agents/testability-migration.agent.md) to find static dependencies and introduce testable abstractions. |
+| Migrate a test framework or platform | Use the [`test-migration` agent](https://github.com/dotnet/skills/blob/main/plugins/dotnet-test-migration/agents/test-migration.agent.md) from the [`dotnet-test-migration` plugin](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test-migration). The agent detects the current setup and selects the appropriate migration skill. |
+
+For installation steps and supported coding agents, see the [.NET Agent Skills repository](https://github.com/dotnet/skills#installation). Install `dotnet-test` alongside `dotnet-test-migration` because migration workflows reuse its platform detection and test verification skills.
 
 ## Choose the packages
 

--- a/docs/core/testing/microsoft-testing-platform-hot-reload.md
+++ b/docs/core/testing/microsoft-testing-platform-hot-reload.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform (MTP) Hot Reload
 description: Learn about the MTP Hot Reload extension for running tests with hot reload.
 author: evangelink
 ms.author: amauryleve
-ms.date: 02/25/2026
+ms.date: 08/28/2026
 ai-usage: ai-assisted
 ---
 
@@ -24,6 +24,8 @@ builder.TestHost.AddHotReloadProvider();
 ## Hot reload
 
 Hot reload lets you modify your app's managed source code while the application is running, without the need to manually pause or hit a breakpoint. Simply make a supported change while the app is running and select the **Apply code changes** button in Visual Studio to apply your edits.
+
+If you use an AI coding assistant, the [`mtp-hot-reload` .NET Agent Skill](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test/skills/mtp-hot-reload) guides the assistant through setup and recovery from unsupported edits. This skill isn't an MTP extension or CLI plugin.
 
 > [!NOTE]
 > The current version is limited to supporting hot reload in "console mode" only. There is currently no support for hot reload in Test Explorer for Visual Studio or Visual Studio Code.

--- a/docs/core/testing/migrating-vstest-microsoft-testing-platform.md
+++ b/docs/core/testing/migrating-vstest-microsoft-testing-platform.md
@@ -3,7 +3,7 @@ title: Migration guide from VSTest to Microsoft.Testing.Platform (MTP)
 description: Step-by-step guide to migrate from VSTest to Microsoft.Testing.Platform (MTP), including argument mapping, project configuration, and CI pipeline updates.
 author: Youssef1313
 ms.author: ygerges
-ms.date: 08/26/2026
+ms.date: 08/28/2026
 ai-usage: ai-assisted
 ---
 
@@ -18,6 +18,9 @@ If you still need to choose a platform, start with [Test platforms overview](./t
 If you need detailed behavior of `dotnet test` modes, see [Testing with `dotnet test`](./unit-testing-with-dotnet-test.md).
 
 If you need a single list of platform and extension command-line options, see [MTP CLI options reference](./microsoft-testing-platform-cli-options.md).
+
+> [!TIP]
+> To automate a repository-wide migration, install the [`dotnet-test`](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test) and [`dotnet-test-migration`](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test-migration) plugins. Ask the [`test-migration` agent](https://github.com/dotnet/skills/blob/main/plugins/dotnet-test-migration/agents/test-migration.agent.md) to detect and migrate your test setup, or invoke the [`migrate-vstest-to-mtp` skill](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test-migration/skills/migrate-vstest-to-mtp) for this specific migration. Review the generated changes before you merge them.
 
 ## Opt-in to use MTP
 

--- a/docs/core/testing/migrating-vstest-microsoft-testing-platform.md
+++ b/docs/core/testing/migrating-vstest-microsoft-testing-platform.md
@@ -20,7 +20,7 @@ If you need detailed behavior of `dotnet test` modes, see [Testing with `dotnet 
 If you need a single list of platform and extension command-line options, see [MTP CLI options reference](./microsoft-testing-platform-cli-options.md).
 
 > [!TIP]
-> To automate a repository-wide migration, install the [`dotnet-test`](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test) and [`dotnet-test-migration`](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test-migration) plugins. Ask the [`test-migration` agent](https://github.com/dotnet/skills/blob/main/plugins/dotnet-test-migration/agents/test-migration.agent.md) to detect and migrate your test setup, or invoke the [`migrate-vstest-to-mtp` skill](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test-migration/skills/migrate-vstest-to-mtp) for this specific migration. Review the generated changes before you merge them.
+> To automate a repository-wide migration with an AI coding assistant, install the [`dotnet-test`](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test) and [`dotnet-test-migration`](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test-migration) plugins from [.NET Agent Skills](https://github.com/dotnet/skills). Ask the [`test-migration` agent](https://github.com/dotnet/skills/blob/main/plugins/dotnet-test-migration/agents/test-migration.agent.md) to detect and migrate your test setup, or invoke the [`migrate-vstest-to-mtp` skill](https://github.com/dotnet/skills/tree/main/plugins/dotnet-test-migration/skills/migrate-vstest-to-mtp) for this specific migration. Review the generated changes before you merge them.
 
 ## Opt-in to use MTP
 


### PR DESCRIPTION
## Summary

Adds focused guidance for readers who want an AI coding assistant to create, assess, improve, or migrate tests. The MTP AI article now distinguishes runtime AI integrations from coding-agent workflows and points to a small set of relevant skills and agents. The VSTest-to-MTP guide adds one targeted migration callout instead of repeating the full plugin catalog.

The guidance is adapted from the `dotnet-test` and `dotnet-test-migration` plugin documentation in `dotnet/skills`. The documentation changes were created with AI assistance.

Fixes: N/A

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-ai.md](https://github.com/dotnet/docs/blob/a22229be8bd934bfafa688233f3acb489d271950/docs/core/testing/microsoft-testing-platform-ai.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-ai?branch=pr-en-us-55775) |
| [docs/core/testing/microsoft-testing-platform-hot-reload.md](https://github.com/dotnet/docs/blob/a22229be8bd934bfafa688233f3acb489d271950/docs/core/testing/microsoft-testing-platform-hot-reload.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-hot-reload?branch=pr-en-us-55775) |
| [docs/core/testing/migrating-vstest-microsoft-testing-platform.md](https://github.com/dotnet/docs/blob/a22229be8bd934bfafa688233f3acb489d271950/docs/core/testing/migrating-vstest-microsoft-testing-platform.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/migrating-vstest-microsoft-testing-platform?branch=pr-en-us-55775) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202608281655143721-55775/BuildReport?accessString=2e06d6ab8f1e33fb12fd5a643fbc5617bde3a3a7aef05562d60eb04d91e16821)