### PR TITLE
Add common patterns for field keyword in C# 14

### DIFF
--- a/docs/csharp/whats-new/csharp-14.md
+++ b/docs/csharp/whats-new/csharp-14.md
@@ -36,7 +36,6 @@ You can find any breaking changes introduced in C# 14 in our article on [breakin
 C# 14 adds new syntax to define *extension members*. The new syntax enables you to declare *extension properties* in addition to extension methods. You can also declare extension members that extend the type, rather than an instance of the type. In other words, these new extension members can appear as static members of the type you extend. These extensions can include user defined operators implemented as static extension methods. The following code example shows an example of the different kinds of extension members you can declare:
 
 ```csharp
-
 public static class Enumerable
 {
     // Extension block
@@ -62,7 +61,6 @@ public static class Enumerable
         public static IEnumerable<TSource> operator + (IEnumerable<TSource> left, IEnumerable<TSource> right) => left.Concat(right);
     }
 }
-
 ```
 
 The members in the first extension block are called as though they're instance members of `IEnumerable<TSource>`, for example `sequence.IsEmpty`. The members in the second extension block are called as though they're static members of `IEnumerable<TSource>`, for example `IEnumerable<int>.Identity`.
@@ -76,26 +74,22 @@ The token `field` enables you to write a property accessor body without declarin
 For example, previously, if you wanted to ensure that a `string` property couldn't be set to `null`, you had to declare a backing field and implement both accessors:
 
 ```csharp
-
 private string _msg;
 public string Message
 {
     get => _msg;
     set => _msg = value ?? throw new ArgumentNullException(nameof(value));
 }
-
 ```
 
 You can now simplify your code to:
 
 ```csharp
-
 public string Message
 {
     get;
     set => field = value ?? throw new ArgumentNullException(nameof(value));
 }
-
 ```
 
  You can also simplify common patterns like lazy initialization, property change notifications, and structured string fields. The following code shows examples of each:
@@ -103,7 +97,6 @@ public string Message
 **Lazy Initialization:**
 
 ```csharp
-
 public SqlConnection Connection
 {
     get => field ??= new SqlConnection("connection-string");
@@ -123,8 +116,6 @@ public string Email
     get;
     set => field = value?.Trim()?.ToLowerInvariant() ?? string.Empty;
 }
-
-
 ```
 
 You can declare a body for one or both accessors for a field backed property.
@@ -148,19 +139,15 @@ Beginning with C# 14, the argument to `nameof` can be an unbound generic type. F
 You can add parameter modifiers, such as `scoped`, `ref`, `in`, `out`, or `ref readonly` to lambda expression parameters without specifying the parameter type:
 
 ```csharp
-
 delegate bool TryParse<T>(string text, out T result);
 // ...
 TryParse<int> parse1 = (text, out result) => Int32.TryParse(text, out result);
-
 ```
 
 Previously, adding any modifiers was allowed only when the parameter declarations included the types for the parameters. The preceding declaration would require types on all parameters:
 
 ```csharp
-
 TryParse<int> parse2 = (string text, out int result) => Int32.TryParse(text, out result);
-
 ```
 
 The `params` modifier still requires an explicitly typed parameter list.
@@ -188,20 +175,16 @@ The null-conditional member access operators, `?.` and `?[]`, can now be used on
 Before C# 14, you needed to null-check a variable before assigning to a property:
 
 ```csharp
-
 if (customer is not null)
 {
     customer.Order = GetCurrentOrder();
 }
-
 ```
 
 You can simplify the preceding code using the `?.` operator:
 
 ```csharp
-
 customer?.Order = GetCurrentOrder();
-
 ```
 
 The right side of the `=` operator is evaluated only when the left side isn't null. If `customer` is null, the code doesn't call `GetCurrentOrder`.

--- a/docs/csharp/whats-new/csharp-14.md
+++ b/docs/csharp/whats-new/csharp-14.md
@@ -92,7 +92,7 @@ public string Message
 }
 ```
 
- You can also simplify common patterns like lazy initialization, property change notifications, and structured string fields. The following code shows examples of each:
+You can also simplify common patterns like lazy initialization, property change notifications, and structured string fields. The following code shows examples of each:
 
 **Lazy Initialization:**
 

--- a/docs/csharp/whats-new/csharp-14.md
+++ b/docs/csharp/whats-new/csharp-14.md
@@ -35,7 +35,9 @@ You can find any breaking changes introduced in C# 14 in our article on [breakin
 
 C# 14 adds new syntax to define *extension members*. The new syntax enables you to declare *extension properties* in addition to extension methods. You can also declare extension members that extend the type, rather than an instance of the type. In other words, these new extension members can appear as static members of the type you extend. These extensions can include user defined operators implemented as static extension methods. The following code example shows an example of the different kinds of extension members you can declare:
 
+
 ```csharp
+
 public static class Enumerable
 {
     // Extension block
@@ -61,7 +63,9 @@ public static class Enumerable
         public static IEnumerable<TSource> operator + (IEnumerable<TSource> left, IEnumerable<TSource> right) => left.Concat(right);
     }
 }
+
 ```
+
 
 The members in the first extension block are called as though they're instance members of `IEnumerable<TSource>`, for example `sequence.IsEmpty`. The members in the second extension block are called as though they're static members of `IEnumerable<TSource>`, for example `IEnumerable<int>.Identity`.
 
@@ -73,29 +77,38 @@ The token `field` enables you to write a property accessor body without declarin
 
 For example, previously, if you wanted to ensure that a `string` property couldn't be set to `null`, you had to declare a backing field and implement both accessors:
 
+
 ```csharp
+
 private string _msg;
 public string Message
 {
     get => _msg;
     set => _msg = value ?? throw new ArgumentNullException(nameof(value));
 }
+
 ```
 
 You can now simplify your code to:
 
+
 ```csharp
+
 public string Message
 {
     get;
     set => field = value ?? throw new ArgumentNullException(nameof(value));
 }
+
 ```
+
 
  You can also simplify common patterns like lazy initialization, property change notifications, and structured string fields. The following code shows examples of each:
 
 **Lazy Initialization:**
+
 ```csharp
+
 public SqlConnection Connection
 {
     get => field ??= new SqlConnection("connection-string");
@@ -116,7 +129,9 @@ public string Email
     set => field = value?.Trim()?.ToLowerInvariant() ?? string.Empty;
 }
 
+
 ```
+
 
 You can declare a body for one or both accessors for a field backed property.
 
@@ -138,17 +153,24 @@ Beginning with C# 14, the argument to `nameof` can be an unbound generic type. F
 
 You can add parameter modifiers, such as `scoped`, `ref`, `in`, `out`, or `ref readonly` to lambda expression parameters without specifying the parameter type:
 
+
 ```csharp
+
 delegate bool TryParse<T>(string text, out T result);
 // ...
 TryParse<int> parse1 = (text, out result) => Int32.TryParse(text, out result);
+
 ```
 
 Previously, adding any modifiers was allowed only when the parameter declarations included the types for the parameters. The preceding declaration would require types on all parameters:
 
+
 ```csharp
+
 TryParse<int> parse2 = (string text, out int result) => Int32.TryParse(text, out result);
+
 ```
+
 
 The `params` modifier still requires an explicitly typed parameter list.
 
@@ -174,18 +196,26 @@ The null-conditional member access operators, `?.` and `?[]`, can now be used on
 
 Before C# 14, you needed to null-check a variable before assigning to a property:
 
+
 ```csharp
+
 if (customer is not null)
 {
     customer.Order = GetCurrentOrder();
 }
+
 ```
+
 
 You can simplify the preceding code using the `?.` operator:
 
+
 ```csharp
+
 customer?.Order = GetCurrentOrder();
+
 ```
+
 
 The right side of the `=` operator is evaluated only when the left side isn't null. If `customer` is null, the code doesn't call `GetCurrentOrder`.
 

--- a/docs/csharp/whats-new/csharp-14.md
+++ b/docs/csharp/whats-new/csharp-14.md
@@ -91,7 +91,8 @@ public string Message
     set => field = value ?? throw new ArgumentNullException(nameof(value));
 }
 ```
-### Common patterns with `field`
+
+ You can also simplify common patterns like lazy initialization, property change notifications, and structured string fields. The following code shows examples of each:
 
 **Lazy Initialization:**
 ```csharp

--- a/docs/csharp/whats-new/csharp-14.md
+++ b/docs/csharp/whats-new/csharp-14.md
@@ -90,7 +90,8 @@ public string Message
     get;
     set => field = value ?? throw new ArgumentNullException(nameof(value));
 }
-### Common Patterns with `field`
+```
+### Common patterns with `field`
 
 **Lazy Initialization:**
 ```csharp

--- a/docs/csharp/whats-new/csharp-14.md
+++ b/docs/csharp/whats-new/csharp-14.md
@@ -196,16 +196,13 @@ if (customer is not null)
 
 ```
 
-
 You can simplify the preceding code using the `?.` operator:
-
 
 ```csharp
 
 customer?.Order = GetCurrentOrder();
 
 ```
-
 
 The right side of the `=` operator is evaluated only when the left side isn't null. If `customer` is null, the code doesn't call `GetCurrentOrder`.
 

--- a/docs/csharp/whats-new/csharp-14.md
+++ b/docs/csharp/whats-new/csharp-14.md
@@ -35,7 +35,6 @@ You can find any breaking changes introduced in C# 14 in our article on [breakin
 
 C# 14 adds new syntax to define *extension members*. The new syntax enables you to declare *extension properties* in addition to extension methods. You can also declare extension members that extend the type, rather than an instance of the type. In other words, these new extension members can appear as static members of the type you extend. These extensions can include user defined operators implemented as static extension methods. The following code example shows an example of the different kinds of extension members you can declare:
 
-
 ```csharp
 
 public static class Enumerable
@@ -66,7 +65,6 @@ public static class Enumerable
 
 ```
 
-
 The members in the first extension block are called as though they're instance members of `IEnumerable<TSource>`, for example `sequence.IsEmpty`. The members in the second extension block are called as though they're static members of `IEnumerable<TSource>`, for example `IEnumerable<int>.Identity`.
 
 You can learn more details by reading the article on [extension members](../programming-guide/classes-and-structs/extension-methods.md) in the programming guide, the language reference article on the [`extension` keyword](../language-reference/keywords/extension.md), and the [feature specification](~/_csharplang/proposals/csharp-14.0/extensions.md) for the new extension members feature.
@@ -76,7 +74,6 @@ You can learn more details by reading the article on [extension members](../prog
 The token `field` enables you to write a property accessor body without declaring an explicit backing field. The token `field` is replaced with a compiler synthesized backing field.
 
 For example, previously, if you wanted to ensure that a `string` property couldn't be set to `null`, you had to declare a backing field and implement both accessors:
-
 
 ```csharp
 
@@ -91,7 +88,6 @@ public string Message
 
 You can now simplify your code to:
 
-
 ```csharp
 
 public string Message
@@ -101,7 +97,6 @@ public string Message
 }
 
 ```
-
 
  You can also simplify common patterns like lazy initialization, property change notifications, and structured string fields. The following code shows examples of each:
 
@@ -132,7 +127,6 @@ public string Email
 
 ```
 
-
 You can declare a body for one or both accessors for a field backed property.
 
 There's a potential breaking change or confusion reading code in types that also include a symbol named `field`. You can use `@field` or `this.field` to disambiguate between the `field` keyword and the identifier, or you can rename the current `field` symbol to provide better distinction.
@@ -153,7 +147,6 @@ Beginning with C# 14, the argument to `nameof` can be an unbound generic type. F
 
 You can add parameter modifiers, such as `scoped`, `ref`, `in`, `out`, or `ref readonly` to lambda expression parameters without specifying the parameter type:
 
-
 ```csharp
 
 delegate bool TryParse<T>(string text, out T result);
@@ -164,13 +157,11 @@ TryParse<int> parse1 = (text, out result) => Int32.TryParse(text, out result);
 
 Previously, adding any modifiers was allowed only when the parameter declarations included the types for the parameters. The preceding declaration would require types on all parameters:
 
-
 ```csharp
 
 TryParse<int> parse2 = (string text, out int result) => Int32.TryParse(text, out result);
 
 ```
-
 
 The `params` modifier still requires an explicitly typed parameter list.
 
@@ -195,7 +186,6 @@ You can learn more in the feature specification for [user-defined compound assig
 The null-conditional member access operators, `?.` and `?[]`, can now be used on the left hand side of an assignment or compound assignment.
 
 Before C# 14, you needed to null-check a variable before assigning to a property:
-
 
 ```csharp
 

--- a/docs/csharp/whats-new/csharp-14.md
+++ b/docs/csharp/whats-new/csharp-14.md
@@ -90,6 +90,30 @@ public string Message
     get;
     set => field = value ?? throw new ArgumentNullException(nameof(value));
 }
+### Common Patterns with `field`
+
+**Lazy Initialization:**
+```csharp
+public SqlConnection Connection
+{
+    get => field ??= new SqlConnection("connection-string");
+}
+public string DisplayName
+{
+    get;
+    set
+    {
+        if (field == value) return;
+        field = value;
+        OnPropertyChanged();
+    }
+}
+public string Email
+{
+    get;
+    set => field = value?.Trim().ToLower() ?? "";
+}
+
 ```
 
 You can declare a body for one or both accessors for a field backed property.

--- a/docs/csharp/whats-new/csharp-14.md
+++ b/docs/csharp/whats-new/csharp-14.md
@@ -112,7 +112,7 @@ public string DisplayName
 public string Email
 {
     get;
-    set => field = value?.Trim().ToLower() ?? "";
+    set => field = value?.Trim()?.ToLowerInvariant() ?? string.Empty;
 }
 
 ```


### PR DESCRIPTION
Added practical examples showing three common patterns when using field-backed properties: Lazy initialization
MVVM property notifications
Data normalization
These patterns help developers understand real-world usage beyond the null-checking example.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/csharp/whats-new/csharp-14.md](https://github.com/dotnet/docs/blob/0d55052cdc2121fb0a777d5f11b205a067e25665/docs/csharp/whats-new/csharp-14.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14?branch=pr-en-us-55777) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202609022119519813-55777/BuildReport?accessString=594fb424d1617383a2568befb191390e8476592d7114386307ed1d134411df9c)