### PR TITLE
Document recent MSTest and MTP features

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-cli-options.md
+++ b/docs/core/testing/microsoft-testing-platform-cli-options.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform (MTP) CLI options reference
 description: Find platform and extension command-line options for MTP in one place.
 author: Evangelink
 ms.author: amauryleve
-ms.date: 08/31/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 
@@ -65,7 +65,7 @@ This article gives a central entry point for MTP command-line options.
 
 - **`--diagnostic`**
 
-  Enables the diagnostic logging. The default log level is `Trace`. The file is written in the output directory with the following name format, `log_[MMddHHssfff].diag`.
+  Enables diagnostic logging. The default log level is `Trace`. For each test source, MTP writes `<asm>_<tfm>_<arch>_<timestamp>.diag`. If a timestamp collides, MTP adds a process and counter suffix instead of overwriting the existing file.
 
 - **`--diagnostic-synchronous-write`**
 
@@ -80,7 +80,7 @@ This article gives a central entry point for MTP command-line options.
 
 - **`--diagnostic-file-prefix`**
 
-  The prefix for the log file name. Defaults to `"log"`.
+  The prefix for the log file name. The default is `<asm>_<tfm>_<arch>`.
 
   > [!NOTE]
   > Available in MTP starting with version 2.0.0. It replaces the previous `--diagnostic-output-fileprefix` option, which was removed in MTP 2.0.0.
@@ -142,7 +142,7 @@ This article gives a central entry point for MTP command-line options.
 
 - **`--minimum-expected-tests`**
 
-  Specifies the minimum number of tests that are expected to run. By default, at least one test is expected to run.
+  Specifies the minimum number of tests that must run. When the run executes fewer tests, including zero, it exits with code `9`. An explicit minimum supersedes `--zero-tests-policy`.
 
 - **`--no-banner`**
 
@@ -179,7 +179,7 @@ This article gives a central entry point for MTP command-line options.
 
 - **`--zero-tests-policy`**
 
-  Controls whether a run that executes no tests because every test was skipped is treated as a failure. Valid values are `allow-skipped` (default) and `strict`. With `allow-skipped`, an all-skipped run succeeds; with `strict`, it fails with exit code 8 (the behavior before 2.3.0).
+  Controls whether a run that executes no tests because every test was skipped is treated as a failure. Valid values are `allow-skipped` (default) and `strict`. With `allow-skipped`, an all-skipped run succeeds. With `strict`, it fails with exit code `8`. An explicit `--minimum-expected-tests` value supersedes this policy and uses exit code `9` when the minimum isn't met.
 
   > [!NOTE]
   > This option is available in MTP starting with version 2.3.0.

--- a/docs/core/testing/microsoft-testing-platform-code-coverage.md
+++ b/docs/core/testing/microsoft-testing-platform-code-coverage.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform (MTP) code coverage
 description: Learn about collecting code coverage data with MTP.
 author: evangelink
 ms.author: amauryleve
-ms.date: 02/25/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 
@@ -40,6 +40,17 @@ For more information about the available options, see [settings](../additional-t
 
 > [!NOTE]
 > The default value of `IncludeTestAssembly` in Microsoft.Testing.Extensions.CodeCoverage is `false`, while it used to be `true` in VSTest. This means that test projects are excluded by default. For more information, see [Code Coverage configuration](https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md).
+
+## Coverage summaries and thresholds
+
+> [!IMPORTANT]
+> The first-class coverage result model is available in MTP 2.4 preview.
+
+Compatible collectors can publish covered and coverable measurements, threshold evaluations, and coverage report references as one correlated test coverage result. The terminal reporter and compatible report consumers render the measurements and derive percentages without parsing collector-specific files.
+
+Collectors choose whether to publish this model. Use the collector's documented options to configure collection and thresholds.
+
+When a published threshold evaluation fails, an otherwise successful run exits with code `14`. Use `--ignore-exit-code 14` when a threshold failure shouldn't fail the process.
 
 ## Version compatibility
 

--- a/docs/core/testing/microsoft-testing-platform-config.md
+++ b/docs/core/testing/microsoft-testing-platform-config.md
@@ -132,12 +132,12 @@ Use `commandLineOptionDefaults` to supply an argument only when an enabled featu
 } }
 ```
 
-MTP resolves an option value in this order:
+MTP resolves an option value by using the first match in this priority order:
 
-1. An explicit command-line value.
-1. An active `commandLineOptions` entry.
-1. A `commandLineOptionDefaults` entry in *testconfig.json*.
-1. An MSBuild-provided default.
+- An explicit command-line value.
+- An active `commandLineOptions` entry.
+- A `commandLineOptionDefaults` entry in *testconfig.json*.
+- An MSBuild-provided default.
 
 For an MSBuild-provided default, add a `TestingPlatformCommandLineOptionDefault` item. The `Include` value must omit leading hyphens:
 

--- a/docs/core/testing/microsoft-testing-platform-config.md
+++ b/docs/core/testing/microsoft-testing-platform-config.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform (MTP) config options
 description: Learn how to configure MTP using testconfig.json configuration settings and environment variables.
 author: Evangelink
 ms.author: amauryleve
-ms.date: 08/31/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 
@@ -102,6 +102,50 @@ Starting with MTP 2.3.0, MTP can read CLI options from *testconfig.json* through
 
 Configuration doesn't install or register an extension. Each test application must reference the package that provides an extension option, either directly or through a test SDK configuration or profile. Otherwise, the option remains unrecognized whether you put it in *testconfig.json* or on the command line.
 
+Use the `commandLineOptions` object for active options. Omit the leading `--` from each key. Use `true` for a zero-argument option, and use `false` to disable an option. For one argument, use a string or number. For repeated or multiple arguments, use an array:
+
+```json
+{ "commandLineOptions": {
+  "report-trx": true,
+  "report-trx-filename": "results.trx",
+  "filter-uid": ["test-1", "test-2"]
+} }
+```
+
+MTP treats a string or number scalar as the first argument of an argument-bearing option. To pass a Boolean argument, use an array such as `[true]` or `[false]`. The array distinguishes the argument from a Boolean presence value.
+
+MTP validates configured entries like command-line entries. Unknown options, invalid values, and values with the wrong arity fail validation. An explicit command-line option overrides the corresponding `commandLineOptions` entry.
+
+Bootstrap-only options run before MTP loads configuration. Don't put `config-file`, `diagnostic`, `diagnostic-output-directory`, `diagnostic-file-prefix`, `diagnostic-verbosity`, `diagnostic-synchronous-write`, or `enable-dynamic-extensions` in `commandLineOptions`.
+
+### Passive command-line option defaults
+
+> [!IMPORTANT]
+> `commandLineOptionDefaults` is available in MTP 2.4 preview.
+
+Use `commandLineOptionDefaults` to supply an argument only when an enabled feature requests that option and no higher-priority value exists. A passive default doesn't enable an option, register an extension, or activate a feature. Omit the leading `--` from each key.
+
+```json
+{ "commandLineOptionDefaults": {
+  "report-trx-filename": "{asm}.trx",
+  "show-test-results": ["failed", "skipped"]
+} }
+```
+
+MTP resolves an option value in this order:
+
+1. An explicit command-line value.
+1. An active `commandLineOptions` entry.
+1. A `commandLineOptionDefaults` entry in *testconfig.json*.
+1. An MSBuild-provided default.
+
+For an MSBuild-provided default, add a `TestingPlatformCommandLineOptionDefault` item. The `Include` value must omit leading hyphens:
+
+```xml
+<TestingPlatformCommandLineOptionDefault Include="report-trx-filename"
+                                         Value="{asm}.trx" />
+```
+
 For a complete reference of command-line options, see [MTP CLI options reference](microsoft-testing-platform-cli-options.md).
 
 ### Test framework-specific settings
@@ -153,6 +197,20 @@ If you're migrating from a *.runsettings* file, the following table maps common 
 | `DataCollectionRunSettings` (coverage) | CLI options | Use `--coverage` from `Microsoft.Testing.Extensions.CodeCoverage`. Starting with MTP 2.3.0, MTP can read CLI options from *testconfig.json*. See [Code coverage](microsoft-testing-platform-code-coverage.md). |
 | `TestRunParameters` | `--test-parameter` CLI | Use `--test-parameter key=value` on the command line. |
 
+## MSBuild configuration
+
+> [!IMPORTANT]
+> `TestingPlatformEnvironmentVariable` is available in MTP 2.4 preview.
+
+To set an environment variable on the test process that `InvokeTestingPlatform` launches, add a `TestingPlatformEnvironmentVariable` item:
+
+```xml
+<TestingPlatformEnvironmentVariable Include="MY_OPTIONS"
+                                    Value="first;second" />
+```
+
+The `Value` metadata preserves semicolons instead of splitting them into MSBuild items. Declared values overlay the environment that the MSBuild process inherits. Without these items, the launched process inherits the environment unchanged.
+
 ## Environment variables
 
 Environment variables can be used to supply some runtime configuration information.
@@ -186,7 +244,7 @@ The output directory of the diagnostic logging. If not specified, the file is ge
 
 ### `TESTINGPLATFORM_DIAGNOSTIC_FILE_PREFIX` environment variable
 
-The prefix for the log file name. Defaults to `"log_"`. Matches the `--diagnostic-file-prefix` command-line option.
+The prefix for the log file name. By default, MTP uses `<asm>_<tfm>_<arch>` and appends a timestamp. The resulting file name is `<asm>_<tfm>_<arch>_<timestamp>.diag`. The variable matches the `--diagnostic-file-prefix` command-line option.
 
 > [!NOTE]
 > This environment variable name is available in MTP starting with version 2.3.0. The legacy `TESTINGPLATFORM_DIAGNOSTIC_OUTPUT_FILEPREFIX` environment variable is still honored for backward compatibility but is deprecated and might be removed in a future major version. When both variables are set, `TESTINGPLATFORM_DIAGNOSTIC_FILE_PREFIX` takes precedence.
@@ -222,6 +280,19 @@ When set to `1` or `true`, suppresses the startup banner, the copyright message,
 Starting with MTP 2.4.0, this variable overrides the directory where MTP creates Unix domain-socket files for named-pipe communication. Use it when a sandbox or container doesn't allow socket creation in the default temporary directory. MTP creates and checks the directory, and fails with an error when the directory isn't writable or the resulting socket path is too long.
 
 The variable has no effect on Windows, where named pipes don't use file-system paths. It also doesn't relocate a pipe that another process, such as the .NET SDK, creates.
+
+### Deadline cancellation prototype
+
+> [!WARNING]
+> **EXPERIMENTAL/PROTOTYPE:** Deadline cancellation is a prototype in MTP 2.4 preview. Its variables and behavior can change or be removed.
+
+Set `TESTINGPLATFORM_DEADLINE` to the complete hard-cancel instant supplied by the deadline producer. Use an ISO 8601 UTC value. Don't subtract MTP's margins from the value.
+
+MTP requests a graceful stop before the deadline. `TESTINGPLATFORM_DEADLINE_STOP_MARGIN` controls how early and defaults to 60 seconds. A test framework that doesn't support graceful stop ignores this request.
+
+As a fallback, `TESTINGPLATFORM_DEADLINE_DUMP_MARGIN` starts an active HangDump extension before the deadline. The margin defaults to 30 seconds. HangDump captures the process tree and then kills the test host. Without a deadline, MTP doesn't start a deadline timer.
+
+The deadline producer remains responsible for hard cancellation at the supplied instant.
 
 ### `TESTINGPLATFORM_WAIT_ATTACH_DEBUGGER` environment variable
 

--- a/docs/core/testing/microsoft-testing-platform-server-mode.md
+++ b/docs/core/testing/microsoft-testing-platform-server-mode.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform (MTP) server mode
 description: Learn how tools and IDEs drive MTP test applications through JSON-RPC server mode.
 author: Evangelink
 ms.author: amauryleve
-ms.date: 08/26/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 
@@ -18,7 +18,7 @@ Start the public JSON-RPC server with `--server` or `--server jsonrpc`.
 
 ## Use the source-only client
 
-Starting with MTP 2.4.0, the [Microsoft.Testing.Platform.ServerMode.Client.Sources](https://www.nuget.org/packages/Microsoft.Testing.Platform.ServerMode.Client.Sources) package supplies a canonical client for the JSON-RPC protocol. The package injects C# source into your project instead of adding a runtime assembly.
+The MTP 2.4 preview provides a canonical JSON-RPC client. Add the [Microsoft.Testing.Platform.ServerMode.Client.Sources](https://www.nuget.org/packages/Microsoft.Testing.Platform.ServerMode.Client.Sources) package. The package injects C# source into your project instead of adding a runtime assembly.
 
 The source-only design provides:
 
@@ -26,13 +26,27 @@ The source-only design provides:
 - Native AOT-compatible, reflection-free serialization.
 - Protocol types and serialization code from the same repository as the MTP server.
 
-The injected `MtpServerClient` and `IMtpServerClient` types can initialize a connection, discover tests, run tests, request server exit, and report test-node updates. The types remain `internal` to your assembly.
+The injected `MtpServerClient`, `IMtpServerClient`, and protocol types can initialize a connection, discover tests, run tests, request server exit, and report test-node updates. All injected types remain `internal` to the consuming assembly.
 
 ## Meet client requirements
 
 Use C# 12 or later. The package sets `LangVersion` to `12.0` when your project doesn't specify a language version. It also supplies internal compatibility types for .NET Framework 4.6.2 and `netstandard2.0`.
 
 Remove any hand-written copy of the MTP client before you add the package to avoid duplicate internal types.
+
+## Choose a launch model
+
+To start the test application as an external process, use `MtpServerClient.LaunchAsync`. The client owns that child process and terminates it during teardown when needed.
+
+For an embedded host or UI-thread environment that can't use `Process.Start`, use `MtpServerClient.LaunchInProcessAsync`. The method runs the test application through an asynchronous callback in the current process. Don't block the launching thread because the callback and client share the process.
+
+Both launch models use a loopback TCP transport. Browser WebAssembly can't create the required listener, so in-process launch throws <xref:System.PlatformNotSupportedException>. In-process launch doesn't provide an alternative WebAssembly transport.
+
+## Shut down the client
+
+To tear down the client and launched application without blocking the calling thread, call `IMtpServerClient.ShutdownAsync()`. The asynchronous method avoids UI-thread responsiveness and deadlock problems in embedded hosts.
+
+For an in-process host, `MtpServerClientOptions.ServerShutdownTimeout` controls how long teardown waits after the client closes the transport. The default is 30 seconds. Read `ServerExitCode` after shutdown to get the callback's exit code. The value remains `null` while the application runs or when the application fails instead of returning an exit code.
 
 ## Choose connection behavior
 

--- a/docs/core/testing/microsoft-testing-platform-terminal-output.md
+++ b/docs/core/testing/microsoft-testing-platform-terminal-output.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform (MTP) terminal output
 description: Learn about the built-in terminal test reporter in MTP, including output modes, ANSI support, and progress indicators.
 author: evangelink
 ms.author: amauryleve
-ms.date: 08/26/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 
@@ -13,13 +13,16 @@ The terminal test reporter is the built-in implementation of status and progress
 
 ## Output modes
 
-There are two output modes available:
+MTP supports these output modes:
 
-- `Normal`, the output contains the banner, reports full failures of tests, warning messages, and writes summary of the run.
+- `Minimal` reports failed result blocks.
+- `Normal` reports failed and skipped result blocks. It also contains the banner, warning messages, and run summary.
   ![Output with 1 failed test and a summary](./media/test-output-and-summary.png)
 
-- `Detailed`, the same as `Normal` but it also reports `Passed` tests.
+- `Detailed` reports all result blocks.
   ![Output with 1 failed, and 1 passed test and a summary](./media/test-output-and-summary-with-passed.png)
+
+`Minimal` is available in MTP 2.4 preview.
 
 ## ANSI
 
@@ -57,11 +60,14 @@ If your code must write directly to the console and you need that output to rema
 | `--progress` | 2.3.0 | Controls whether progress is shown. Valid values are `auto` (default), `on` (also accepts `true`, `enable`, `1`), and `off` (also accepts `false`, `disable`, `0`). |
 | `--no-ansi` | — | Disables outputting ANSI escape characters to screen. |
 | `--ansi` | 2.3.0 | Controls whether ANSI escape characters are emitted. Valid values are `auto` (default), `on` (also accepts `true`, `enable`, `1`), and `off` (also accepts `false`, `disable`, `0`). |
-| `--output` | — | Specifies the output verbosity when reporting tests. Valid values are `Normal` and `Detailed`. Default is `Normal`. |
+| `--output` | — | Specifies the output verbosity for test results. Valid values are `Minimal`, `Normal`, and `Detailed`. The default is `Normal`. `Minimal` requires MTP 2.4 preview. |
+| `--show-test-results` | 2.4.0 | Selects result blocks by outcome. Use `passed`, `failed`, `skipped`, `all`, or `none`. `failed` also includes errors, timeouts, and cancellations. |
 | `--show-stdout` | 2.2.1 | Determines when to show captured standard output of a test. Valid values are `All`, `Failed`, and `None`. Default is `All`. |
 | `--show-stderr` | 2.2.1 | Determines when to show captured error output of a test. Valid values are `All`, `Failed`, and `None`. Default is `All`. |
 | `--show-flaky-tests` | 2.4.0 | Controls the `flaky:` summary and the **Flaky tests** list for tests that pass after a retry. Use `on` or `off`; the default is `on`. Applies to MSTest `[Retry]` and the [retry extension](microsoft-testing-platform-retry.md). |
 | `--show-slowest-tests` | 2.4.0 | Shows the requested number of slowest tests in the summary. For a multi-module run, MTP reports the slowest tests for each module. |
+
+Combine `passed`, `failed`, and `skipped` with commas, spaces, or repeated `--show-test-results` options. Don't combine `all` or `none` with another value. An explicit `--show-test-results` value overrides the `--output` preset regardless of option order. The filter changes result blocks only; progress and summary counts remain unchanged.
 
 > [!NOTE]
 > A dash (—) in the **MTP version** column marks core options that aren't tied to a specific version because they've been available since the platform's initial releases.

--- a/docs/core/testing/microsoft-testing-platform-terminal-output.md
+++ b/docs/core/testing/microsoft-testing-platform-terminal-output.md
@@ -61,7 +61,7 @@ If your code must write directly to the console and you need that output to rema
 | `--no-ansi` | — | Disables outputting ANSI escape characters to screen. |
 | `--ansi` | 2.3.0 | Controls whether ANSI escape characters are emitted. Valid values are `auto` (default), `on` (also accepts `true`, `enable`, `1`), and `off` (also accepts `false`, `disable`, `0`). |
 | `--output` | — | Specifies the output verbosity for test results. Valid values are `Minimal`, `Normal`, and `Detailed`. The default is `Normal`. `Minimal` requires MTP 2.4 preview. |
-| `--show-test-results` | 2.4.0 | Selects result blocks by outcome. Use `passed`, `failed`, `skipped`, `all`, or `none`. `failed` also includes errors, timeouts, and cancellations. |
+| `--show-test-results <OUTCOME>` | 2.4.0 | Selects result blocks by outcome. Use `passed`, `failed`, `skipped`, `all`, or `none`. `failed` also includes errors, timeouts, and cancellations. |
 | `--show-stdout` | 2.2.1 | Determines when to show captured standard output of a test. Valid values are `All`, `Failed`, and `None`. Default is `All`. |
 | `--show-stderr` | 2.2.1 | Determines when to show captured error output of a test. Valid values are `All`, `Failed`, and `None`. Default is `All`. |
 | `--show-flaky-tests` | 2.4.0 | Controls the `flaky:` summary and the **Flaky tests** list for tests that pass after a retry. Use `on` or `off`; the default is `on`. Applies to MSTest `[Retry]` and the [retry extension](microsoft-testing-platform-retry.md). |

--- a/docs/core/testing/microsoft-testing-platform-test-reports.md
+++ b/docs/core/testing/microsoft-testing-platform-test-reports.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform (MTP) test reports
 description: Learn about the MTP extensions that create test report files (TRX, HTML, JUnit, CTRF, Azure DevOps, GitHub Actions).
 author: evangelink
 ms.author: amauryleve
-ms.date: 08/31/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 
@@ -30,6 +30,8 @@ A file name can include a relative path that stays within the test results direc
 | `{time}` | High-precision timestamp. |
 
 For example, `--report-trx-filename "{asm}_{tfm}_{arch}.trx"` reproduces the default TRX name.
+
+If a default or explicit TRX, HTML, or JUnit file name already exists for a test source, the extension warns and overwrites the file. Starting with the MTP 2.4 preview, CTRF uses the same behavior. To retain report history, include `{time}`.
 
 > [!NOTE]
 > Placeholder names are case-sensitive and use lowercase. Placeholder support for report file names is available in MTP starting with version 2.3.0.
@@ -61,6 +63,8 @@ builder.AddTrxReportProvider();
 
 > [!NOTE]
 > Available in MTP starting with version 2.3.0, TRX results stream to disk as the run progresses. If the test host crashes, the TRX file keeps the results collected before the crash.
+>
+> Starting with the MTP 2.4 preview, an MTP-generated TRX preserves MSTest `[WorkItem]` and `[GitHubWorkItem]` metadata.
 
 ### Options
 
@@ -136,7 +140,11 @@ builder.AddCtrfReportProvider();
 | `--report-ctrf` | Generates the CTRF JSON report. |
 | `--report-ctrf-filename` | The name of the generated CTRF JSON report. The value must end with `.json`. The default is `<UserName>_<MachineName>_<assembly>_<tfm>_<timestamp>.ctrf.json`. To customize the name, see [Report file names](#report-file-names). Requires `--report-ctrf`. |
 
-Starting with MSTest 4.4, CTRF results for retried tests include the `retries` and `retryAttempts` fields. When a test passes after an earlier failed attempt, its result also includes `flaky: true`. The terminal summary identifies flaky and retried tests. TRX and JUnit reports keep one final result per test instead of recording every attempt.
+Starting with the MTP 2.4 preview, CTRF preserves every result when multiple tests use the same UID. It also includes per-test and prior-attempt attachments and infers their MIME types from file names.
+
+For retried tests, CTRF correlates attempts only when the relationship is unambiguous. It then records earlier attempts in `retryAttempts`, sets `retries`, and marks a later successful result as `flaky: true`. Ambiguous same-UID results remain separate so the report doesn't associate diagnostics with the wrong test.
+
+The terminal summary identifies flaky and retried tests. TRX and JUnit reports keep one final result per test instead of recording every attempt.
 
 ## Azure DevOps reports
 
@@ -170,7 +178,7 @@ builder.TestHost.AddAzureDevOpsProvider();
 | `--report-azdo-upload-artifact-include` | 2.3.0 | Includes files in the Azure DevOps artifact upload using glob patterns relative to the test results directory. Defaults to `**/*`. Requires `--report-azdo-upload-artifacts` to be a value other than `off`. |
 | `--report-azdo-upload-artifact-exclude` | 2.3.0 | Excludes files from the Azure DevOps artifact upload using glob patterns relative to the test results directory. Requires `--report-azdo-upload-artifacts` to be a value other than `off`. |
 | `--report-azdo-upload-artifact-name` | 2.3.0 | Overrides the Azure DevOps artifact container name. Defaults to `TestResults_{assemblyName}_{tfm}`. Requires `--report-azdo-upload-artifacts` to be a value other than `off`. |
-| `--publish-azdo-test-results` | 2.3.0 | Publishes test results live to the Azure DevOps **Tests** tab. |
+| `--publish-azdo-test-results` | 2.3.0 | Streams results to an Azure DevOps test run as tests complete. The build's **Tests** tab lists the completed run. |
 | `--publish-azdo-run-name` | 2.3.0 | Sets a custom Azure DevOps test run name for live test-result publishing. Requires `--publish-azdo-test-results`. |
 
 > [!WARNING]
@@ -182,6 +190,16 @@ builder.TestHost.AddAzureDevOpsProvider();
 The extension automatically detects that it is running in continuous integration (CI) environment by checking the `TF_BUILD` environment variable.
 
 Starting with MTP 2.4.0, Azure DevOps Markdown summaries aggregate results across every test module in a `dotnet test` invocation. When you also enable code coverage, the summary includes covered and total counts, percentages, threshold results, and an indicator when coverage data is partial.
+
+In the MTP 2.4 preview, live publishing automatically uploads file attachments for unsuccessful results to Azure DevOps test results. Unsuccessful outcomes include failed, errored, timed-out, and canceled results.
+
+When a result supplies standard output or standard error, the extension can attach up to 256 KiB of each inline stream. Each file-backed attachment has a 16-MiB limit.
+
+The extension also uploads run-level `.coverage`, `.cobertura.xml`, and `.opencover.xml` files as code coverage attachments. These test-run and result attachments are separate from `--report-azdo-upload-artifacts`, which uploads selected files as Azure Pipelines build artifacts.
+
+For retried tests, Azure DevOps publishes prior attempts as subresults and attaches each attempt's artifacts to the subresult that produced them. If safe retry correlation isn't available, the extension publishes a separate result instead of dropping it.
+
+When live publishing creates the run, it prints the run URL so you can follow results before completion. It also sends `pipelineReference` and the start date when the pipeline environment provides them. The build's **Tests** tab doesn't list an in-progress run; it lists the run after completion.
 
 ## GitHub Actions reports
 
@@ -213,7 +231,12 @@ builder.AddGitHubActionsProvider();
 | `--report-gh-annotations` | 2.3.0 | Enables or disables annotations for failed and skipped tests. Valid values are `on` (default) and `off`. Requires `--report-gh`. |
 | `--report-gh-step-summary` | 2.3.0 | Controls whether the extension writes a Markdown job summary to the file referenced by `GITHUB_STEP_SUMMARY`. Valid values are `on` (default), `off`, and, starting with MTP 2.4.0, `on-failure`. Requires `--report-gh`. |
 | `--report-gh-step-summary-sections` | 2.4.0 | Selects summary content. Valid values are `test-results`, `slow-tests`, `coverage`, and `all` (default). Requires `--report-gh` and a summary mode other than `off`. |
+| `--report-gh-failure-details` | 2.4.0 | Enables or disables bounded failure details in the job summary. Use `on` (default) or `off`. Details include the message, exception type, source location, and stack trace when available. Requires `--report-gh`. |
+| `--report-gh-history` | 2.4.0 | Reads and updates a bounded local test-history snapshot at the specified file path. The workflow must download the previous snapshot before the run and upload the updated file afterward. Requires `--report-gh`. |
+| `--report-gh-history-window` | 2.4.0 | Sets the retained history window from 1 through 90 days. The default is 30 days. Requires `--report-gh-history`. |
 | `--report-gh-slow-test-notices` | 2.3.0 | Enables or disables slow-test notices. Valid values are `on` (default) and `off`. Requires `--report-gh`. |
 | `--report-gh-slow-test-threshold` | 2.3.0 | The duration a test can run before a slow-test notice is emitted. Accepts a bare number of seconds or a value with a unit suffix such as `90s`, `2m`, or `1.5h`. The default is `60s`. Requires `--report-gh`. |
 
 Starting with MTP 2.4.0, GitHub Actions Markdown summaries aggregate results across every test module in a `dotnet test` invocation. When you also enable code coverage, select `coverage` or `all` to include covered and total counts, percentages, threshold results, and an indicator when coverage data is partial.
+
+Failure details stay within bounded message, stack, failure-count, and whole-summary budgets. When content exceeds a limit, the report truncates or condenses it and states that reduction in the summary.

--- a/docs/core/testing/microsoft-testing-platform-troubleshooting.md
+++ b/docs/core/testing/microsoft-testing-platform-troubleshooting.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform (MTP) troubleshooting
 description: Troubleshoot MTP issues, exit codes, and known problems.
 author: Evangelink
 ms.author: amauryleve
-ms.date: 08/31/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 
@@ -25,12 +25,15 @@ MTP uses known exit codes to communicate test failure or app errors. Exit codes 
 | `5` | The exit code `5` indicates that the command-line arguments passed to the test app were invalid. |
 | `6` (no longer used) | Exit code `6` is no longer produced by the platform; it previously indicated that the test session was using a non-implemented feature. |
 | `7` | The exit code `7` indicates that a test session was unable to complete successfully, and likely crashed. It's possible that this was caused by a test session that was run via a test controller's extension point. |
-| `8` | The exit code `8` indicates that the test session ran zero tests. |
-| `9` | The exit code `9` indicates that the minimum execution policy for the executed tests was violated. |
+| `8` | The exit code `8` indicates that the test session ran zero tests under the strict `--zero-tests-policy`. |
+| `9` | The exit code `9` indicates that the run executed fewer tests than `--minimum-expected-tests` requires, including zero tests. |
 | `10` | The exit code `10` indicates that the test adapter, Testing.Platform Test Framework, MSTest, NUnit, or xUnit, failed to run tests for an infrastructure reason unrelated to the test's self. An example is failing to create a fixture needed by tests. |
 | `11` | The exit code `11` indicates that the test process will exit if dependent process exits. |
 | `12` | The exit code `12` indicates that the test session was unable to run because the client does not support any of the supported protocol versions. |
 | `13` | The exit code `13` indicates that the test session was stopped due to reaching the specified number of maximum failed tests using `--maximum-failed-tests` command-line option. For more information, see [the Options section in MTP CLI options reference](microsoft-testing-platform-cli-options.md) |
+| `14` | The exit code `14` indicates that a compatible coverage collector published a failed coverage threshold evaluation. |
+
+An explicit `--minimum-expected-tests` value supersedes `--zero-tests-policy`. Without the minimum option, strict zero-test handling continues to use exit code `8`.
 
 To enable verbose logging and troubleshoot issues, see [Diagnostic logging](#diagnostic-logging).
 
@@ -64,11 +67,13 @@ You can also enable the diagnostic logs using the environment variables:
 | `TESTINGPLATFORM_DIAGNOSTIC` | If set to `1`, enables the diagnostic logging. |
 | `TESTINGPLATFORM_DIAGNOSTIC_VERBOSITY` | Defines the verbosity level. The available values are `Trace`, `Debug`, `Information`, `Warning`, `Error`, or `Critical`. |
 | `TESTINGPLATFORM_DIAGNOSTIC_OUTPUT_DIRECTORY` | The output directory of the diagnostic logging, if not specified the file is generated in the default _TestResults_ directory. |
-| `TESTINGPLATFORM_DIAGNOSTIC_FILE_PREFIX` | The prefix for the log file name. Defaults to `"log_"`. Available in MTP starting with version 2.3.0; the legacy name `TESTINGPLATFORM_DIAGNOSTIC_OUTPUT_FILEPREFIX` is still honored for backward compatibility. |
+| `TESTINGPLATFORM_DIAGNOSTIC_FILE_PREFIX` | The prefix for the log file name. The default produces `<asm>_<tfm>_<arch>_<timestamp>.diag`. Available in MTP starting with version 2.3.0; the legacy name `TESTINGPLATFORM_DIAGNOSTIC_OUTPUT_FILEPREFIX` is still honored for backward compatibility. |
 | `TESTINGPLATFORM_DIAGNOSTIC_SYNCHRONOUS_WRITE` | Forces the built-in file logger to synchronously write logs. Useful for scenarios where you don't want to lose any log entries (if the process crashes). This does slow down the test execution. Available in MTP starting with version 2.3.0; the legacy name `TESTINGPLATFORM_DIAGNOSTIC_FILELOGGER_SYNCHRONOUSWRITE` is still honored for backward compatibility. |
 
 > [!NOTE]
 > Environment variables take precedence over the command line arguments.
+
+MTP writes a diagnostic file for each test source. If two files receive the same timestamp, MTP adds a process and counter suffix instead of overwriting an existing file.
 
 ## Resolve configuration errors
 

--- a/docs/core/testing/mstest-analyzers/mstest0048.md
+++ b/docs/core/testing/mstest-analyzers/mstest0048.md
@@ -1,7 +1,8 @@
 ---
 title: "MSTEST0048: Avoid TestContext properties in fixture methods"
 description: "Learn about code analysis rule MSTEST0048: Avoid TestContext properties in fixture methods"
-ms.date: 07/24/2025
+ms.date: 09/02/2026
+ai-usage: ai-assisted
 f1_keywords:
 - MSTEST0048
 - TestContextPropertyUsageAnalyzer
@@ -28,6 +29,8 @@ ms.author: amauryleve
 
 A fixture method (methods with <xref:Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyInitializeAttribute>, <xref:Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyCleanupAttribute>, <xref:Microsoft.VisualStudio.TestTools.UnitTesting.ClassInitializeAttribute>, or <xref:Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupAttribute>) accesses restricted <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext> properties.
 
+Starting with MSTest.Analyzers 4.4 preview, the rule also reports constant indexer access to a restricted key, such as `testContext.Properties["TestName"]`. It doesn't report indexer access when the key isn't a constant string.
+
 ## Rule description
 
 Certain <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext> properties aren't available in fixture methods because they're specific to individual test execution:
@@ -39,12 +42,10 @@ Properties unavailable in class and assembly fixture methods:
 - `DataRow`
 - `DataConnection`
 - `TestName`
-- `ManagedMethod`
 
 Properties unavailable in assembly-level fixture methods:
 
 - `FullyQualifiedTestClassName`
-- `ManagedType`
 
 ## How to fix violations
 

--- a/docs/core/testing/unit-testing-mstest-configure.md
+++ b/docs/core/testing/unit-testing-mstest-configure.md
@@ -3,7 +3,7 @@ title: Configure MSTest
 description: Learn how to configure MSTest.
 author: Evangelink
 ms.author: amauryleve
-ms.date: 08/06/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 
@@ -26,7 +26,7 @@ The following runsettings entries let you configure how MSTest behaves.
 |`AssemblyCleanupTimeout`|None|Specify globally the timeout to apply on each instance of assembly cleanup method. `[Timeout]` attribute specified on the assembly cleanup method overrides the global timeout.|
 |`AssemblyInitializeTimeout`|None|Specify globally the timeout to apply on each instance of assembly initialize method. `[Timeout]` attribute specified on the assembly initialize method overrides the global timeout.|
 |`AssemblyResolution`|false|You can specify paths to extra assemblies when finding and running unit tests. For example, use these paths for dependency assemblies that aren't in the same directory as the test assembly. To specify a path, use a **Directory Path** element. Paths can include environment variables.<br /><br />`<AssemblyResolution>  <Directory path="D:\myfolder\bin\" includeSubDirectories="false"/> </AssemblyResolution>`<br /><br />This feature is only applied when using a .NET Framework target.|
-|`CaptureTraceOutput`|`Result`|Capture text from the `Console.Write*`, `Trace.Write*`, and `Debug.Write*` APIs and associate it with the current test. Starting with MSTest 4.4, use `None`, `Result`, or `Live`. `Live` also echoes `Console`, `Trace`, and `TestContext.Write*` output to the console while the test runs. The earlier Boolean values remain supported: `true` maps to `Result`, and `false` maps to `None`.|
+|`CaptureTraceOutput`|`Result`|Capture text from the `Console.Write*` and `Trace.Write*` APIs and associate it with the current test. On .NET Framework, capture also includes `Debug.Write*` through shared trace listeners. Modern .NET doesn't route `Debug.Write*` through those listeners, so MSTest doesn't capture it. Starting with the MSTest 4.4 preview, use `None`, `Result`, or `Live`. `Live` also echoes `Console`, `Trace`, and `TestContext.Write*` output while the test runs. The earlier Boolean values remain supported: `true` maps to `Result`, and `false` maps to `None`.|
 |`ClassCleanupLifecycle`|EndOfClass|If you want the class cleanup to occur at the end of assembly, set it to `EndOfAssembly`. (No longer supported starting from MSTest v4 as `EndOfClass` is the default and only [ClassCleanup](<xref:Microsoft.VisualStudio.TestTools.UnitTesting.ClassCleanupAttribute>) behavior)|
 |`ClassCleanupTimeout`|None|Specify globally the timeout to apply on each instance of class cleanup method. `[Timeout]` attribute specified on the class cleanup method overrides the global timeout.|
 |`ClassInitializeTimeout`|None|Specify globally the timeout to apply on each instance of class initialize method. `[Timeout]` attribute specified on the class initialize method overrides the global timeout.|
@@ -176,7 +176,7 @@ All the settings in this section belong to the `output` element.
 
 | Entry | Default | Description |
 |-------|---------|-------------|
-| captureTrace | `Result` | Capture `Console`, `Trace`, and `Debug` output and associate it with the current test. Starting with MSTest 4.4, use `None`, `Result`, or `Live`. `Live` also echoes output, including `TestContext.Write*` messages, while the test runs. The Boolean values remain supported: `true` maps to `Result`, and `false` maps to `None`. |
+| captureTrace | `Result` | Capture `Console` and `Trace` output and associate it with the current test. On .NET Framework, capture also includes `Debug` output through shared trace listeners. Modern .NET `Debug.Write*` output isn't captured. Starting with the MSTest 4.4 preview, use `None`, `Result`, or `Live`. `Live` also echoes output, including `TestContext.Write*` messages, while the test runs. The Boolean values remain supported: `true` maps to `Result`, and `false` maps to `None`. |
 
 Example:
 

--- a/docs/core/testing/unit-testing-mstest-intro.md
+++ b/docs/core/testing/unit-testing-mstest-intro.md
@@ -3,7 +3,7 @@ title: MSTest overview
 description: Learn about MSTest, Microsoft's testing framework for .NET, including supported platforms, key features, and getting started.
 author: Evangelink
 ms.author: amauryleve
-ms.date: 08/06/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 
@@ -35,7 +35,8 @@ MSTest supports a wide range of .NET platforms and target frameworks. The follow
 | **UWP** | UAP 10, .NET 9+ with UAP | UI thread | `UITestMethod` | Use VSTest. Modern .NET UWP requires `<UseUwp>true</UseUwp>`; see [UWP sample](https://github.com/microsoft/testfx/tree/main/samples/public/BlankUwpNet9App) |
 | **WinUI 3** | .NET 8+ | UI thread | `UITestMethod` | Requires Windows App SDK; see [Test WinUI 3 apps with MSTest and MTP](unit-testing-mstest-winui.md) |
 | **Native AOT** | .NET 8+ | Full parallelization | Most attributes | Limited feature set; see [Native AOT sample](https://github.com/microsoft/testfx/tree/main/samples/public/mstest-runner/NativeAotRunner) |
-| **Browser WebAssembly** | .NET 10+ custom host | Single-threaded | Limited | Custom Microsoft.Testing.Platform host support starts with MSTest 4.4 |
+| **Browser WebAssembly** | .NET 10+ custom host | Single-threaded | Limited | MTP execution support starts with the MSTest 4.4 preview |
+| **WASI WebAssembly** | .NET 10+ custom host | Single-threaded | Limited | MTP execution support starts with the MSTest 4.4 preview |
 
 ### Platform-specific considerations
 
@@ -85,11 +86,15 @@ Starting with MSTest 4.4, Microsoft.Testing.Platform also supports unpackaged Wi
 
 Native AOT compilation is supported with some limitations due to reduced reflection capabilities. Use source generators where possible and test your AOT scenarios with the [NativeAotRunner sample](https://github.com/microsoft/testfx/tree/main/samples/public/mstest-runner/NativeAotRunner).
 
-#### Browser WebAssembly
+#### Browser and WASI WebAssembly
 
-Starting with MSTest 4.4, a custom .NET 10 browser WebAssembly host can call `AddMSTest` to run tests from a referenced MSTest assembly. In the host project, set `EnableMSTestRunner` to `true` and `GenerateTestingPlatformEntryPoint` to `false` so the custom host owns the application entry point. Keep the MSTest and Microsoft.Testing.Platform package versions aligned.
+The MSTest 4.4 preview supports custom .NET 10 browser or WASI WebAssembly hosts. To run tests from a referenced MSTest assembly, call `AddMSTest`. In the host project, set `EnableMSTestRunner` to `true` and `GenerateTestingPlatformEntryPoint` to `false`. Keep the MSTest and MTP package versions aligned.
 
-On a single-threaded WebAssembly runtime, MSTest can't interrupt timed-out tests, and debugger launch options aren't supported. For a complete host, see the [BrowserPlayground sample](https://github.com/microsoft/testfx/tree/main/samples/BrowserPlayground).
+On a single-threaded WebAssembly runtime, MSTest can't forcibly interrupt a timed-out test. Debugger wait isn't supported on browser or WASI, and browser doesn't support debugger launch options.
+
+MTP can stream TRX data and report test and session file artifacts through the host's WebAssembly virtual file system and artifact channel. Azure DevOps publishing works only when the host provides supported HTTP access and the required pipeline authentication. These features don't grant unrestricted host file-system or network access.
+
+For a complete browser host, see the [BrowserPlayground sample](https://github.com/microsoft/testfx/tree/main/samples/BrowserPlayground).
 
 ### STA threading support
 

--- a/docs/core/testing/unit-testing-mstest-sdk.md
+++ b/docs/core/testing/unit-testing-mstest-sdk.md
@@ -3,7 +3,7 @@ title: MSTest SDK configuration
 author: MarcoRossignoli
 description: Learn how to configure MSTest.Sdk profiles, extensions, and advanced features.
 ms.author: mrossignoli
-ms.date: 08/31/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 
@@ -250,20 +250,40 @@ The default MSTest.Sdk extension profile supplies the `Microsoft.Testing.Extensi
 +    arguments: '--configuration Release -- --report-trx --results-directory $(Agent.TempDirectory) --coverage'
 ```
 
+## Reflection source generator
+
+> [!IMPORTANT]
+> The following MSTest 4.4 behavior is available only in preview builds until MSTest 4.4.0 is released.
+
+MSTest 4.3 introduced the reflection source generator in the independently versioned, experimental `MSTest.SourceGeneration` package. Starting with MSTest 4.4, the package graduates from experimental status and uses the MSTest version.
+
+Native AOT projects include the source generator automatically. For a non-NativeAOT project that uses MSTest.Sdk, opt in with `<EnableMSTestSourceGeneration>true</EnableMSTestSourceGeneration>`. MSTest.Sdk aligns the `MSTest.SourceGeneration`, `MSTest.TestFramework`, and `MSTest.TestAdapter` versions through `MSTestVersion`.
+
+The SDK also supports source generation in reusable test libraries and projects that use Central Package Management. It supplies matching `MSTest.TestAdapter` runtime hooks and generates the required `PackageVersion` items.
+
+.NET Standard doesn't support these runtime hooks. When you enable source generation for a .NET Standard target, the SDK reports this error:
+
+> MSTest source generation is not supported for .NET Standard target frameworks because the required MSTest.TestAdapter runtime hooks are unavailable.
+
+The source generator discovers tests at compile time. When the generator is active, test classes must declare `[TestClass]` directly instead of inheriting it. The [MSTEST0069](mstest-analyzers/mstest0069.md) analyzer flags classes that rely on an inherited `[TestClass]`.
+
+Starting with MSTest 4.3.2, `MSTestSourceGenMode` defaults to `ReflectionFree` for trimmed and Native AOT projects. This mode uses generated metadata and invokers where it supports the test shape. On runtimes that support reflection, MSTest falls back to reflection for unsupported or missing generated entries.
+
+Starting with MSTest 4.4, reflection-free generation materializes complete inherited attribute metadata, including `AttributeUsage` and `AllowMultiple`. On MTP, it can bypass runtime discovery and validation for plain synchronous `[TestMethod]` and `[DataRow]` methods. Async tests, custom test method attributes, `DynamicData`, custom `ITestDataSource` implementations, and ambiguous test shapes use the fallback path. VSTest also retains its existing path.
+
+Reflection-free mode reports these diagnostics:
+
+| ID | Unsupported test shape |
+| --- | --- |
+| `AOTSG0001` | Static test class |
+| `AOTSG0002` | Open generic test class, including a class nested in a generic type |
+| `AOTSG0003` | Class that generated code can't access, including a file-local class or private or private-protected nesting |
+| `AOTSG0004` | Generic test method |
+| `AOTSG0005` | Test method with a `ref`, `in`, or `out` parameter |
+
 ## Experimental features
 
-The following MSTest 4.3 features are **experimental**. Their public APIs are subject to change, and they're surfaced behind experimental diagnostics, so opting in requires acknowledging the corresponding diagnostic ID. Use them with that caveat in mind.
-
-### Reflection source generator
-
-> [!NOTE]
-> Introduced in MSTest 4.3.0 (experimental).
-
-The MSTest reflection source generator discovers tests at compile time instead of relying on runtime reflection, which makes test projects compatible with trimming and Native AOT. Enable it by adding the [MSTest.SourceGeneration](https://www.nuget.org/packages/MSTest.SourceGeneration) package. When the source generator is active, test classes must declare `[TestClass]` directly rather than inherit it; the [MSTEST0069](mstest-analyzers/mstest0069.md) analyzer flags classes that rely on an inherited `[TestClass]`.
-
-Starting with MSTest 4.3.2, `MSTestSourceGenMode` defaults to `ReflectionFree` for trimmed and Native AOT projects.
-
-Starting with MSTest 4.4, reflection-free generation materializes complete inherited attribute metadata, including `AttributeUsage` and `AllowMultiple`. When the generator can't materialize metadata statically, MSTest falls back to reflection where the runtime supports it.
+The following MSTest 4.3 features are **experimental**. Their public APIs are subject to change, and they're surfaced behind experimental diagnostics. To opt in, acknowledge the corresponding diagnostic ID.
 
 ### Programmatic test filtering with `ITestFilter`
 

--- a/docs/core/testing/unit-testing-mstest-writing-tests-assertions.md
+++ b/docs/core/testing/unit-testing-mstest-writing-tests-assertions.md
@@ -3,7 +3,7 @@ title: MSTest assertions
 description: Learn about MSTest assertions including Assert, StringAssert, and CollectionAssert classes for validating test results.
 author: Evangelink
 ms.author: amauryleve
-ms.date: 08/06/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 
@@ -150,6 +150,17 @@ MSTest 4.3 also adds:
 - Interpolated-string message overloads for the async `Assert.ThrowsAsync`/`Assert.ThrowsExactlyAsync` methods, and rejection of `ValueTask<TResult>`-returning delegates that would otherwise not be awaited.
 - Complete exception details, including stack traces and inner exceptions, in `Assert.Throws*` failure messages.
 - Assertion failure stacks that hide MSTest implementation frames and render built-in numeric values at full precision.
+
+> [!IMPORTANT]
+> The following assertion overloads are planned for MSTest 4.4 and are available only in preview builds until MSTest 4.4.0 is released.
+
+MSTest 4.4 adds span and memory overloads to `Assert.IsEmpty`, `Assert.IsNotEmpty`, and the remaining collection APIs. The overloads accept <xref:System.Span`1>, <xref:System.ReadOnlySpan`1>, <xref:System.Memory`1>, and <xref:System.ReadOnlyMemory`1>:
+
+- All-item checks: `AreAllDistinct`, `AreAllNotNull`, and `AreAllOfType`.
+- Comparisons: `AreEquivalent`, `AreNotEquivalent`, `AreSequenceEqual`, and `AreNotSequenceEqual`.
+- Containment: `Contains`, `ContainsAll`, `ContainsSingle`, `DoesNotContain`, and `DoesNotContainAll`.
+
+With the MSTest 4.4 and MTP 2.4 previews, capable IDEs and reporters receive assertion expected and actual values as separate structured properties. Consumers don't need to parse these values from the failure message.
 
 `Assert.AddValueFormatter` returns an <xref:System.IDisposable> registration. Dispose the registration to remove the formatter. The formatter applies only to the current asynchronous context, so parallel tests can use different formatters without changing each other's output. Because the API is experimental in MSTest 4.3, acknowledge or suppress the `MSTESTEXP` diagnostic before you use it.
 

--- a/docs/core/testing/unit-testing-mstest-writing-tests-controlling-execution.md
+++ b/docs/core/testing/unit-testing-mstest-writing-tests-controlling-execution.md
@@ -3,7 +3,7 @@ title: Test execution and control in MSTest
 description: Learn how to control test execution in MSTest with parallelization, threading, timeouts, retries, and conditional execution.
 author: Evangelink
 ms.author: amauryleve
-ms.date: 08/06/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 
@@ -439,6 +439,10 @@ Starting with MSTest 3.8, create custom retry logic by inheriting from <xref:Mic
 
 > [!IMPORTANT]
 > The `RetryBaseAttribute.ExecuteAsync` API, and its `RetryContext` and `RetryResult` types, are experimental. Using them produces the `MSTESTEXP` diagnostic, which you must acknowledge before you use the API.
+
+Starting with the MSTest 4.4 preview, `RetryResult.AllResults` exposes the result arrays from every attempt in the order they were added. MTP reports earlier attempts as superseded, while VSTest receives only the final result. MSTest retries only when an attempt contains a failed or timed-out result. An inconclusive result by itself stops the retry sequence.
+
+Process-level `--retry-failed-tests` and an MSTest retry attribute apply at different levels. Their effects are multiplicative because each process-level attempt can run the attribute's complete retry sequence.
 
 ```csharp
 public class CustomRetryAttribute : RetryBaseAttribute

--- a/docs/core/testing/unit-testing-mstest-writing-tests-data-driven.md
+++ b/docs/core/testing/unit-testing-mstest-writing-tests-data-driven.md
@@ -4,7 +4,7 @@ description: Learn how to use data-driven testing in MSTest with DataRow, Dynami
 author: Evangelink
 ms.author: amauryleve
 ai-usage: ai-assisted
-ms.date: 06/16/2026
+ms.date: 09/02/2026
 ---
 
 # Data-driven testing in MSTest
@@ -20,14 +20,29 @@ MSTest provides several attributes for data-driven testing:
 | [`DataRow`](#datarowattribute) | Inline test data | Simple, static test cases |
 | [`DynamicData`](#dynamicdataattribute) | Data from methods, properties, or fields | Complex or computed test data |
 | [`DataSource`](#datasourceattribute) | External data files or databases | Legacy scenarios with external data sources |
+| `CombinatorialData` | Cartesian product of parameter values | Combinations of independent inputs |
 
 MSTest also provides the following types to extend data-driven scenarios:
 
 - [`TestDataRow<T>`](#testdatarow): A return type for `ITestDataSource` implementations (including `DynamicData`) that adds metadata support such as display names, categories, and ignore messages to individual test cases.
 - [`ITestDataSource`](#itestdatasource): An interface you can implement on a custom attribute to create fully custom data source attributes.
 
-> [!TIP]
-> For combinatorial testing (testing all combinations of multiple parameter sets), use the open-source [Combinatorial.MSTest](https://www.nuget.org/packages/Combinatorial.MSTest) NuGet package. This community-maintained package is [available on GitHub](https://github.com/Youssef1313/Combinatorial.MSTest) but isn't maintained by Microsoft.
+> [!IMPORTANT]
+> Built-in combinatorial testing is planned for MSTest 4.4 and is available only in preview builds until MSTest 4.4.0 is released.
+
+## Combinatorial test data
+
+To generate the Cartesian product of values for a test method's parameters, use the types in the `Microsoft.VisualStudio.TestTools.UnitTesting.Combinatorial` namespace. Apply `CombinatorialDataAttribute` to the method, and use these parameter attributes when you need to control the values:
+
+- `CombinatorialValuesAttribute` supplies an explicit set of values.
+- `CombinatorialRangeAttribute` supplies an integer range.
+- `CombinatorialRandomDataAttribute` supplies unique random integers. Configure the count, minimum, maximum, and seed.
+
+When you omit a parameter attribute, MSTest infers values for supported types. It uses `true` and `false` for `bool`, `0` and `1` for `int`, and every named value for an enum. For a nullable supported type, MSTest also includes `null`.
+
+Built-in combinatorial data supports Native AOT. It doesn't support pairwise generation, permutations, exclusions, member-backed dynamic values, class-data activation, or a fluent builder.
+
+For advanced scenarios that require these unsupported features, consider the open-source [Combinatorial.MSTest](https://www.nuget.org/packages/Combinatorial.MSTest) package. The community maintains this package independently of Microsoft.
 
 ## `DataRowAttribute`
 
@@ -604,7 +619,7 @@ public class UnfoldingExample
 - **Name your test cases**: Use `DisplayName` to make test failures easier to identify.
 - **Keep data sources close**: Define data sources in the same class when possible for better maintainability.
 - **Use meaningful data**: Choose test data that exercises edge cases and boundary conditions.
-- **Consider combinatorial testing**: For testing parameter combinations, use the [Combinatorial.MSTest](https://www.nuget.org/packages/Combinatorial.MSTest) package.
+- **Use combinatorial testing for independent inputs**: In MSTest 4.4 preview, use built-in combinatorial data for a full Cartesian product. For unsupported advanced generation strategies, consider the community [Combinatorial.MSTest](https://www.nuget.org/packages/Combinatorial.MSTest) package.
 
 ## See also
 

--- a/docs/core/testing/unit-testing-mstest-writing-tests-testcontext.md
+++ b/docs/core/testing/unit-testing-mstest-writing-tests-testcontext.md
@@ -3,7 +3,7 @@ title: MSTest TestContext
 description: Learn about the TestContext class of MSTest.
 author: Evangelink
 ms.author: amauryleve
-ms.date: 08/06/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 
@@ -90,6 +90,8 @@ You can use the `DataSource` attribute to read the data from the CSV file:
 ### Store and retrieve runtime data
 
 You can use <xref:Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.Properties?displayProperty=nameWithType> to store custom key-value pairs that can be accessed across different methods in the same test session.
+
+Starting with the MSTest 4.4 preview, the indexer consistently returns `null` when a custom key doesn't exist.
 
 ```csharp
 TestContext.Properties["MyKey"] = "MyValue";

--- a/docs/core/tools/dotnet-test-mtp.md
+++ b/docs/core/tools/dotnet-test-mtp.md
@@ -145,7 +145,7 @@ With MTP, `dotnet test` operates faster than with VSTest. The test-related argum
 
   Selects result blocks by outcome. In MTP 2.4 preview, use `passed`, `failed`, `skipped`, `all`, or `none`. The `failed` value also includes errors, timeouts, and cancellations.
 
-  Combine `passed`, `failed`, and `skipped` with commas, spaces, or repeated options. Don't combine `all` or `none` with another value. This explicit option overrides the `--output` preset regardless of option order.
+  Combine `passed`, `failed`, and `skipped` with commas, spaces, or repeated `--show-test-results` options. Don't combine `all` or `none` with another value. This explicit option overrides the `--output` preset regardless of option order.
 
 - **`--no-launch-profile`**
 

--- a/docs/core/tools/dotnet-test-mtp.md
+++ b/docs/core/tools/dotnet-test-mtp.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet test command with Microsoft.Testing.Platform (MTP)
 description: The dotnet test command is used to execute unit tests in a given project using MTP.
-ms.date: 08/31/2026
+ms.date: 09/02/2026
 ai-usage: ai-assisted
 ---
 # dotnet test with Microsoft.Testing.Platform (MTP)
@@ -36,6 +36,7 @@ dotnet test
     [--no-ansi]
     [--no-progress]
     [--output <VERBOSITY_LEVEL>]
+    [--show-test-results <OUTCOME>]
     [--no-launch-profile]
     [--no-launch-profile-arguments]
     [<args>...]
@@ -138,7 +139,13 @@ With MTP, `dotnet test` operates faster than with VSTest. The test-related argum
 
 - **`--output <VERBOSITY_LEVEL>`**
 
-  Specifies the output verbosity when reporting tests. Valid values are `Normal` and `Detailed`. The default is `Normal`.
+  Specifies the output verbosity for test results. Valid values are `Minimal`, `Normal`, and `Detailed`. The default is `Normal`. `Minimal` requires MTP 2.4 preview.
+
+- **`--show-test-results <OUTCOME>`**
+
+  Selects result blocks by outcome. In MTP 2.4 preview, use `passed`, `failed`, `skipped`, `all`, or `none`. The `failed` value also includes errors, timeouts, and cancellations.
+
+  Combine `passed`, `failed`, and `skipped` with commas, spaces, or repeated options. Don't combine `all` or `none` with another value. This explicit option overrides the `--output` preset regardless of option order.
 
 - **`--no-launch-profile`**
 


### PR DESCRIPTION
## Why

Recent TestFX releases added and refined user-facing MSTest and Microsoft.Testing.Platform behavior that was missing, incomplete, or stale in the .NET documentation. This update follows an audit of all 1,397 TestFX pull requests merged from June 2 through September 2, 2026.

## What changed

- Documents MSTest 4.4 preview features, including built-in combinatorial data, graduated source generation, reflection-free diagnostics, retry behavior, assertion overloads, and TestContext updates.
- Documents MTP 2.4 preview features across configuration, terminal output, coverage thresholds, reports, server mode, WebAssembly support, and exit-code behavior.
- Corrects stale guidance for combinatorial testing, diagnostic file names, Azure DevOps live publishing, output capture, and zero-test policies.
- Preserves preview and prototype notices and intentionally excludes MSTest v5 work merged only to the `dev/v5` branch.

## Source breakdown

The updated sections were adapted from merged `microsoft/testfx` implementation pull requests, package documentation, changelogs, schemas, RFCs, and public API definitions. Existing .NET documentation text was retained where it remained accurate. New explanatory text and organization were generated with AI assistance and require subject-matter expert review, especially for preview availability, configuration precedence, reporter behavior, and source-generation fallback semantics.

## Validation

- Markdownlint passes across all affected documentation areas.
- The final diff passes Git whitespace checks.
- A correctness review compared API names, option names, defaults, and version gates against the upstream TestFX implementation.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

<details><summary><strong>Toggle expand/collapse</strong></summary><br/>

| File | Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-cli-options.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/microsoft-testing-platform-cli-options.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-cli-options?branch=pr-en-us-55800) |
| [docs/core/testing/microsoft-testing-platform-code-coverage.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/microsoft-testing-platform-code-coverage.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-code-coverage?branch=pr-en-us-55800) |
| [docs/core/testing/microsoft-testing-platform-config.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/microsoft-testing-platform-config.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-config?branch=pr-en-us-55800) |
| [docs/core/testing/microsoft-testing-platform-server-mode.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/microsoft-testing-platform-server-mode.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-server-mode?branch=pr-en-us-55800) |
| [docs/core/testing/microsoft-testing-platform-terminal-output.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/microsoft-testing-platform-terminal-output.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-terminal-output?branch=pr-en-us-55800) |
| [docs/core/testing/microsoft-testing-platform-test-reports.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/microsoft-testing-platform-test-reports.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-test-reports?branch=pr-en-us-55800) |
| [docs/core/testing/microsoft-testing-platform-troubleshooting.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/microsoft-testing-platform-troubleshooting.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-troubleshooting?branch=pr-en-us-55800) |
| [docs/core/testing/mstest-analyzers/mstest0048.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/mstest-analyzers/mstest0048.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0048?branch=pr-en-us-55800) |
| [docs/core/testing/unit-testing-mstest-configure.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/unit-testing-mstest-configure.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-configure?branch=pr-en-us-55800) |
| [docs/core/testing/unit-testing-mstest-intro.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/unit-testing-mstest-intro.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-intro?branch=pr-en-us-55800) |
| [docs/core/testing/unit-testing-mstest-sdk.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/unit-testing-mstest-sdk.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-sdk?branch=pr-en-us-55800) |
| [docs/core/testing/unit-testing-mstest-writing-tests-assertions.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/unit-testing-mstest-writing-tests-assertions.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-writing-tests-assertions?branch=pr-en-us-55800) |
| [docs/core/testing/unit-testing-mstest-writing-tests-controlling-execution.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/unit-testing-mstest-writing-tests-controlling-execution.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-writing-tests-controlling-execution?branch=pr-en-us-55800) |
| [docs/core/testing/unit-testing-mstest-writing-tests-data-driven.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/unit-testing-mstest-writing-tests-data-driven.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-writing-tests-data-driven?branch=pr-en-us-55800) |
| [docs/core/testing/unit-testing-mstest-writing-tests-testcontext.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/testing/unit-testing-mstest-writing-tests-testcontext.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-mstest-writing-tests-testcontext?branch=pr-en-us-55800) |
| [docs/core/tools/dotnet-test-mtp.md](https://github.com/dotnet/docs/blob/a62ddfe92250a6a3323820d935040e84dfcac81e/docs/core/tools/dotnet-test-mtp.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test-mtp?branch=pr-en-us-55800) |

</details>


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202609021158354491-55800/BuildReport?accessString=c78a1e0db0712f69db0a54800d86fa2f7aac1a0479c3c27eb234d7a5811174ba)