### PR TITLE
Update documentation for constant interpolated strings

### DIFF
--- a/docs/csharp/fundamentals/strings/interpolation.md
+++ b/docs/csharp/fundamentals/strings/interpolation.md
@@ -77,7 +77,7 @@ For better readability, break long interpolation expressions across multiple lin
 
 ## Build constant strings
 
-You can build constant interpolated strings when every interpolated expression is a constant value.That makes it usable for attribute arguments, `switch` patterns, and other contexts that require compile-time constants:
+You can build constant interpolated strings when every interpolated expression is a constant `string` value. That makes it usable for attribute arguments, `switch` patterns, and other contexts that require compile-time constants:
 
 :::code language="csharp" source="snippets/interpolation/Program.cs" id="ConstantInterpolated":::
 


### PR DESCRIPTION
# Overview
Clarify that interpolated expressions must be constant strings for building constant interpolated strings, fix spacing between sentences.

# Details
Reading the old version, you might get confused as to why you cannot interpolate `const` integral values into strings, like this:
<img width="317" height="152" alt="image" src="https://github.com/user-attachments/assets/71516428-c24e-45de-ba7a-3468fc6f93e1" />

Also the sentence was missing a space after the `.`:
<img width="558" height="159" alt="image" src="https://github.com/user-attachments/assets/1d260bc9-6c50-41c6-96ad-ed4c042c6f63" />


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/csharp/fundamentals/strings/interpolation.md](https://github.com/dotnet/docs/blob/c4fc11b092e81a9722d3920fb052e048b8620ca3/docs/csharp/fundamentals/strings/interpolation.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/csharp/fundamentals/strings/interpolation?branch=pr-en-us-55888) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202609041737330235-55888/BuildReport?accessString=5be69b605da1deab5632b3e9953258b5078a722ed7958898b1383fe58181d40d)