### PR TITLE
Composite ReadyToRun - clarify enabling conditions

### DIFF
--- a/docs/core/deploying/ready-to-run.md
+++ b/docs/core/deploying/ready-to-run.md
@@ -83,7 +83,18 @@ These symbols will be placed in the publish directory and for Windows will have 
 
 ## Composite ReadyToRun
 
-Normal ReadyToRun compilation produces binaries that can be serviced and manipulated individually. Starting in .NET 6, support for Composite ReadyToRun compilation has been added. Composite ReadyToRun compiles a set of assemblies that must be distributed together. This has the advantage that the compiler is able to perform better optimizations and reduces the set of methods that cannot be compiled via the ReadyToRun process. However, as a tradeoff, compilation speed is significantly decreased, and the overall file size of the application is significantly increased. Due to these tradeoffs, use of Composite ReadyToRun is only recommended for applications that disable [Tiered Compilation](../runtime-config/compilation.md#tiered-compilation) or applications running on Linux that are seeking the best startup time with [self-contained](index.md#publish-as-self-contained) deployment. To enable composite ReadyToRun compilation, specify the `<PublishReadyToRunComposite>` property.
+Normal ReadyToRun compilation produces assemblies that can be serviced and deployed individually. Composite ReadyToRun compiles a set of assemblies together, allowing the compiler to perform additional optimizations and compile more methods ahead of time.
+
+Composite ReadyToRun has the following tradeoffs:
+
+- Compilation takes significantly longer.
+- The application is significantly larger.
+- Only [self-contained](index.md#publish-as-self-contained) deployments are supported.
+- The compiled assemblies must be distributed together.
+
+Composite ReadyToRun is supported in .NET 6 and later. In .NET 7 and later, it's enabled by default for self-contained [single-file](single-file/overview.md) deployments that use ReadyToRun.
+
+To enable composite ReadyToRun explicitly, set `PublishReadyToRunComposite` to `true`:
 
 ```xml
 <PropertyGroup>
@@ -92,7 +103,7 @@ Normal ReadyToRun compilation produces binaries that can be serviced and manipul
 ```
 
 > [!NOTE]
-> In .NET 6, Composite ReadyToRun is only supported for [self-contained](index.md#publish-as-self-contained) deployment.
+> `PublishReadyToRunComposite` is ignored if the deployment is not [self-contained](index.md#publish-as-self-contained). 
 
 ## Cross platform/architecture restrictions
 


### PR DESCRIPTION
including that it was [enabled by default for single file publishes](https://github.com/dotnet/sdk/pull/25963), and that the property is ignored if not non-self-contained.

Confirmed by reading [Microsoft.NET.CrossGen.targets](https://github.com/dotnet/sdk/blob/02d39b6a25a62e5ac313ab8449704c4428fa68f3/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets#L20).

related: https://github.com/dotnet/runtime/issues/90454

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/deploying/ready-to-run.md](https://github.com/dotnet/docs/blob/11d635001c63c455fedd95579e50c87d35571fd7/docs/core/deploying/ready-to-run.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/deploying/ready-to-run?branch=pr-en-us-55899) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202609080332472391-55899/BuildReport?accessString=683c10ae40a050dc3c5c06c9a4dbda76b391cb270bee5d3e415e9a7390d030da)