### PR TITLE
Revert "Fix xref"

### DIFF
--- a/docs/framework/tools/mageui-exe-manifest-generation-and-editing-tool-graphical-client.md
+++ b/docs/framework/tools/mageui-exe-manifest-generation-and-editing-tool-graphical-client.md
@@ -183,7 +183,7 @@ MageUI.exe supports the same functionality as the command-line tool Mage.exe, bu
 
 |UI Element|Description|
 |----------------|-----------------|
-|**This application should check for updates**|Specifies whether ClickOnce should check for application updates. If this check box is not selected, the application will not check for updates unless you update it programmatically by using the APIs in the `System.Deployment.Application` namespace.|
+|**This application should check for updates**|Specifies whether ClickOnce should check for application updates. If this check box is not selected, the application will not check for updates unless you update it programmatically by using the APIs in the <xref:System.Deployment.Application> namespace.|
 |**Choose when the application should check for updates**|Provides two options for update checks:<br /><br /> -   **Before the application starts**. The update check is performed prior to application execution.<br />-   **After the application starts**. The update check begins once the main form of the application has initialized, and will run the next time the application starts.|
 |**Update check frequency**|Determines how often ClickOnce should check for updates:<br /><br /> -   **Check every time the application runs**. ClickOnce will perform an update check every time the user opens the application.<br />-   **Check every**: Select a time interval and a unit (hours, days, or weeks) that must elapse before checking for updates.|
 |**Specify a minimum required version for this application**|Optional. Specifies that a specific version of your application is a required installation, preventing your users from working with an earlier version.|


### PR DESCRIPTION
Reverts dotnet/docs#55765.

The System.Deployment* APIs were inadvertently removed from Learn when a filter was put in place. The filter has now been removed in https://github.com/dotnet/msbuild-api-docs/pull/70.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/framework/tools/mageui-exe-manifest-generation-and-editing-tool-graphical-client.md](https://github.com/dotnet/docs/blob/7b02897e6c09e6fbd3cccbb75d1849e38550367a/docs/framework/tools/mageui-exe-manifest-generation-and-editing-tool-graphical-client.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/framework/tools/mageui-exe-manifest-generation-and-editing-tool-graphical-client?branch=pr-en-us-55934) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202609092156392028-55934/BuildReport?accessString=757276e38c910acd25c12de470004500192b12e305fd686ec18bbdef7e74cd5b)