### PR TITLE
Fix CLS example: keep private field as UInt16

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.clscompliant/cs/public2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.clscompliant/cs/public2.cs
@@ -5,9 +5,8 @@ using System;
 
 public class Person
 {
-   private Int16 personAge = 0;
+   private UInt16 personAge = 0;
 
-   public Int16 Age
-   { get { return personAge; } }
+   public Int16 Age => (Int16)personAge; 
 }
 // </Snippet2>


### PR DESCRIPTION
The language-independence article explains that only the public `Age` property must use a CLS-compliant type. The C# snippet for the corrected example incorrectly changed the private `personAge` field to `Int16` as well.

This change keeps `personAge` as `UInt16` and casts to `Int16` in the public property getter.

Fixes #49691

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [samples/snippets/csharp/VS_Snippets_CLR/conceptual.clscompliant/cs/public2.cs](https://github.com/dotnet/docs/blob/e0d5fe5b67ba7b0a18f6ac50834fbcab17d270a7/samples/snippets/csharp/VS_Snippets_CLR/conceptual.clscompliant/cs/public2.cs) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/standard/language-independence?branch=pr-en-us-55954) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202609111754450222-55954/BuildReport?accessString=3dd0005ce92a8179a07d7272f74d7fe1e1211b79e4cfa062d7ea54dde9aefe6f)