### PR TITLE
Clarify Azure DevOps report extension features

### DIFF
--- a/docs/core/testing/microsoft-testing-platform-test-reports.md
+++ b/docs/core/testing/microsoft-testing-platform-test-reports.md
@@ -3,7 +3,7 @@ title: Microsoft.Testing.Platform (MTP) test reports
 description: Learn about the MTP extensions that create test report files (TRX, HTML, JUnit, CTRF, Azure DevOps, GitHub Actions).
 author: evangelink
 ms.author: amauryleve
-ms.date: 09/02/2026
+ms.date: 09/12/2026
 ai-usage: ai-assisted
 ---
 
@@ -148,7 +148,9 @@ The terminal summary identifies flaky and retried tests. TRX and JUnit reports k
 
 ## Azure DevOps reports
 
-Azure DevOps report plugin enhances test running for developers that host their code on GitHub, but build on Azure DevOps build agents. It adds additional information to failures to show failure directly in GitHub PR.
+The Azure DevOps report extension integrates MTP test runs with Azure Pipelines. It formats errors and warnings for pipeline logs, adds annotations for failed and skipped tests, creates a Markdown job summary, and can group output by test assembly. The extension can also identify flaky or quarantined failures, upload test artifacts, and stream results to an Azure DevOps test run.
+
+When you host your code on GitHub but run tests on Azure Pipelines agents, failure annotations can appear directly in the GitHub pull request:
 
 ![Error annotation in GitHub PR files view](./media/test-azdoreport-failure.png)
 


### PR DESCRIPTION
## Summary

Clarifies the Azure DevOps report extension introduction by leading with its Azure Pipelines features, including pipeline diagnostics, annotations, job summaries, grouped output, flaky and quarantined test handling, artifact uploads, and live test-result publishing. The GitHub-specific text now introduces only the pull request annotation screenshot.

Fixes: N/A

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [docs/core/testing/microsoft-testing-platform-test-reports.md](https://github.com/dotnet/docs/blob/7fcf22206acf9afe7f55ff473881ea0a9379d972/docs/core/testing/microsoft-testing-platform-test-reports.md) | [Learn preview](https://review.learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-test-reports?branch=pr-en-us-55959) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/a3bda507-3390-de91-8f7f-26f90f4e5fc8/202609120910367504-55959/BuildReport?accessString=e4aa65d0155dcef87fa0c9820cf191d8b74ae52fe45bace48395c5f96e20a643)